### PR TITLE
Add CI and release automation for Legolas

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,35 @@
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feat'
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Fixes'
+    labels:
+      - 'fix'
+      - 'bug'
+      - 'bugfix'
+      - 'hotfix'
+  - title: '⚡ Performance'
+    labels:
+      - 'perf'
+      - 'performance'
+  - title: '🦾 Refactoring'
+    labels:
+      - 'refactor'
+  - title: '🧪 Tests'
+    labels:
+      - 'test'
+  - title: '📚 Documentation'
+    labels:
+      - 'docs'
+      - 'documentation'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'ci'
+      - 'build'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: legolas-ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: legolas-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-matrix:
+    name: Node ${{ matrix.node-version }} test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["18.17.0", "20", "22", "24"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run tests
+        run: npm test
+
+  smoke-and-package:
+    name: Smoke And Package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "18.17.0"
+
+      - name: Smoke test CLI
+        run: npm run smoke
+
+      - name: Verify package tarball
+        run: npm run pack:check
+
+  pack-check-windows:
+    name: Pack Check Windows
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "18.17.0"
+
+      - name: Verify package tarball
+        run: npm run pack:check

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,30 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Read package version
+        id: meta
+        run: echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-name: release-drafter.yml
+          name: v${{ steps.meta.outputs.version }}
+          tag: v${{ steps.meta.outputs.version }}
+          version: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,168 @@
+name: legolas-release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    if: github.repository == 'JeremyDev87/legolas'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Read package metadata
+        id: meta
+        run: |
+          echo "name=$(node -p 'require(\"./package.json\").name')" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release tag matches package version
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          CLI_VERSION="$(node ./bin/legolas.js --version)"
+          EXPECTED_TAG="v${PACKAGE_VERSION}"
+
+          git fetch origin refs/heads/master:refs/remotes/origin/master
+
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/master"; then
+            echo "Tagged commit ${GITHUB_SHA} is not reachable from origin/master"
+            exit 1
+          fi
+
+          if [ "$TAG_NAME" != "$EXPECTED_TAG" ]; then
+            echo "Expected release tag ${EXPECTED_TAG}, got ${TAG_NAME}"
+            exit 1
+          fi
+
+          if [ "$CLI_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Expected CLI version ${PACKAGE_VERSION}, got ${CLI_VERSION}"
+            exit 1
+          fi
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
+
+      - name: Create GitHub release draft
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Release ${TAG_NAME} already exists"
+          else
+            gh release create "$TAG_NAME" --draft --generate-notes --title "$TAG_NAME" --verify-tag
+          fi
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests
+        run: npm test
+
+      - name: Smoke test CLI
+        run: npm run smoke
+
+      - name: Verify package tarball
+        run: npm run pack:check
+
+      - name: Read package tarball identity
+        id: package_artifact
+        run: |
+          PACK_METADATA="$(mktemp)"
+          npm pack --dry-run --json --cache ./.npm-cache > "$PACK_METADATA"
+
+          node -e '
+            const fs = require("fs");
+            const [result] = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            console.log(`integrity=${result.integrity ?? ""}`);
+            console.log(`shasum=${result.shasum ?? ""}`);
+          ' "$PACK_METADATA" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm
+        run: |
+          PUBLISH_LOG="$(mktemp)"
+
+          if npm publish --access public --provenance >"$PUBLISH_LOG" 2>&1; then
+            cat "$PUBLISH_LOG"
+            exit 0
+          fi
+
+          cat "$PUBLISH_LOG"
+
+          for attempt in 1 2 3 4 5; do
+            PUBLISHED_VERSION="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null || true)"
+            REGISTRY_INTEGRITY="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" dist.integrity 2>/dev/null || true)"
+            REGISTRY_SHASUM="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" dist.shasum 2>/dev/null || true)"
+            MATCHES_INTEGRITY=false
+            MATCHES_SHASUM=false
+
+            if [ -n "$LOCAL_INTEGRITY" ] && [ "$REGISTRY_INTEGRITY" = "$LOCAL_INTEGRITY" ]; then
+              MATCHES_INTEGRITY=true
+            fi
+
+            if [ -n "$LOCAL_SHASUM" ] && [ "$REGISTRY_SHASUM" = "$LOCAL_SHASUM" ]; then
+              MATCHES_SHASUM=true
+            fi
+
+            if [ "$PUBLISHED_VERSION" = "$PACKAGE_VERSION" ] && {
+              [ "$MATCHES_INTEGRITY" = "true" ] || [ "$MATCHES_SHASUM" = "true" ];
+            }; then
+              echo "Confirmed package ${PACKAGE_NAME}@${PACKAGE_VERSION} exists on npm with matching artifact identity; continuing."
+              exit 0
+            fi
+
+            if [ "$PUBLISHED_VERSION" = "$PACKAGE_VERSION" ] && {
+              [ -n "$REGISTRY_INTEGRITY" ] || [ -n "$REGISTRY_SHASUM" ];
+            }; then
+              echo "Package ${PACKAGE_NAME}@${PACKAGE_VERSION} exists on npm, but its artifact identity does not match this checkout."
+              echo "Local integrity: ${LOCAL_INTEGRITY:-<empty>}"
+              echo "Registry integrity: ${REGISTRY_INTEGRITY:-<empty>}"
+              echo "Local shasum: ${LOCAL_SHASUM:-<empty>}"
+              echo "Registry shasum: ${REGISTRY_SHASUM:-<empty>}"
+              exit 1
+            fi
+
+            sleep 5
+          done
+
+          exit 1
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          LOCAL_INTEGRITY: ${{ steps.package_artifact.outputs.integrity }}
+          LOCAL_SHASUM: ${{ steps.package_artifact.outputs.shasum }}
+          PACKAGE_NAME: ${{ steps.meta.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.meta.outputs.version }}
+
+      - name: Publish GitHub release
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          RELEASE_ID="$(gh release view "$TAG_NAME" --json id --jq .id)"
+
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+            -f draft=false \
+            -f make_latest=true \
+            -f name="${TAG_NAME}"
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.npm-cache
 .DS_Store
 coverage
 tmp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,8 @@ Before opening a pull request:
 
 ```bash
 npm test
-node ./bin/legolas.js scan .
-node ./bin/legolas.js visualize .
-node ./bin/legolas.js optimize .
+npm run smoke
+npm run pack:check
 ```
 
 ## Coding Guidelines
@@ -80,5 +79,25 @@ Include:
 - why it changed
 - how it was tested
 - any follow-up work or limitations
+
+## Releases
+
+Legolas release automation uses `package.json` as the version source of truth.
+
+Typical release flow:
+
+1. Update `package.json` to the next version.
+2. Verify the CLI reports the same version with `node ./bin/legolas.js --version`.
+3. Run:
+
+```bash
+npm test
+npm run smoke
+npm run pack:check
+```
+
+4. Merge the version bump to `master`.
+5. Push a matching git tag such as `v0.1.1`.
+6. GitHub Actions validates the tag, publishes to npm, and then publishes the GitHub release.
 
 Thank you for helping make Legolas more useful and more trustworthy.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "url": "https://github.com/sponsors/JeremyDev87"
   },
   "type": "module",
+  "files": [
+    "bin",
+    "src"
+  ],
   "bin": {
     "legolas": "./bin/legolas.js"
   },
@@ -22,6 +26,8 @@
     "scan": "node ./bin/legolas.js scan",
     "visualize": "node ./bin/legolas.js visualize",
     "optimize": "node ./bin/legolas.js optimize",
+    "smoke": "node ./bin/legolas.js --version && node ./bin/legolas.js help && node ./bin/legolas.js scan . && node ./bin/legolas.js visualize . && node ./bin/legolas.js optimize .",
+    "pack:check": "node ./scripts/check-pack.mjs",
     "test": "node --test"
   },
   "engines": {

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -1,0 +1,133 @@
+import { spawn } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+
+const rootAllowlist = new Set(["LICENSE", "package.json"]);
+const rootReadmePattern = /^README(\.[^.]+)?\.md$/i;
+const packageDirs = ["bin", "src"];
+
+const expectedFiles = new Set(await collectExpectedFiles());
+const packedFiles = await collectPackedFiles();
+
+const unexpectedFiles = packedFiles.filter((filePath) => !expectedFiles.has(filePath));
+const missingFiles = [...expectedFiles].filter((filePath) => !packedFiles.includes(filePath));
+
+if (unexpectedFiles.length > 0 || missingFiles.length > 0) {
+  console.error("Package contents validation failed.");
+
+  if (unexpectedFiles.length > 0) {
+    console.error("Unexpected files:");
+    for (const filePath of unexpectedFiles) {
+      console.error(`- ${filePath}`);
+    }
+  }
+
+  if (missingFiles.length > 0) {
+    console.error("Missing files:");
+    for (const filePath of missingFiles) {
+      console.error(`- ${filePath}`);
+    }
+  }
+
+  process.exit(1);
+}
+
+console.log(`Validated ${packedFiles.length} packaged files.`);
+
+async function collectExpectedFiles() {
+  const rootEntries = await readdir(projectRoot, { withFileTypes: true });
+  const expected = new Set();
+
+  for (const entry of rootEntries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (rootAllowlist.has(entry.name) || rootReadmePattern.test(entry.name)) {
+      expected.add(entry.name);
+    }
+  }
+
+  for (const directory of packageDirs) {
+    const absolutePath = path.join(projectRoot, directory);
+    const files = await walkFiles(absolutePath);
+
+    for (const filePath of files) {
+      expected.add(toPosixPath(path.relative(projectRoot, filePath)));
+    }
+  }
+
+  return [...expected].sort();
+}
+
+async function walkFiles(directoryPath) {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directoryPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(absolutePath)));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+async function collectPackedFiles() {
+  const stdout = await runPackCommand();
+
+  const [packResult] = JSON.parse(stdout);
+
+  if (!packResult?.files) {
+    throw new Error("npm pack did not return a file list.");
+  }
+
+  return packResult.files
+    .map((entry) => entry.path)
+    .sort();
+}
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function runPackCommand() {
+  return new Promise((resolve, reject) => {
+    const child = process.platform === "win32"
+      ? spawn("cmd.exe", ["/d", "/s", "/c", "npm pack --dry-run --json --cache ./.npm-cache"], { cwd: projectRoot })
+      : spawn("npm", ["pack", "--dry-run", "--json", "--cache", "./.npm-cache"], { cwd: projectRoot });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+
+      reject(new Error(stderr || stdout || `npm pack exited with code ${code}`));
+    });
+  });
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 import { analyzeProject } from "./core/analyze-project.js";
 import { formatOptimizeReport, formatScanReport, formatVisualizationReport } from "./reporters/text.js";
+import { readJsonIfExists } from "./core/workspace.js";
 
 const HELP_TEXT = `Legolas
 Slim bundles with precision.
@@ -20,7 +21,7 @@ export async function runCli(argv) {
   const { command, targetPath, flags } = parseArgv(argv);
 
   if (flags.version) {
-    console.log("0.1.0");
+    console.log(await readPackageVersion());
     return;
   }
 
@@ -104,4 +105,9 @@ function parseArgv(argv) {
   }
 
   return { command, targetPath, flags };
+}
+
+async function readPackageVersion() {
+  const packageJson = await readJsonIfExists(new URL("../package.json", import.meta.url));
+  return packageJson?.version ?? "0.0.0";
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,12 +11,13 @@ const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "
 const cliPath = path.join(projectRoot, "bin", "legolas.js");
 
 test("cli prints version without requiring a command", async () => {
+  const packageJson = JSON.parse(await readFile(path.join(projectRoot, "package.json"), "utf8"));
   const { stdout, stderr } = await execFile(process.execPath, [cliPath, "--version"], {
     cwd: projectRoot
   });
 
   assert.equal(stderr, "");
-  assert.equal(stdout.trim(), "0.1.0");
+  assert.equal(stdout.trim(), packageJson.version);
 });
 
 test("cli rejects non-numeric visualization and optimize limits", async () => {


### PR DESCRIPTION
# 배경 / Background

Legolas를 오픈소스로 운영하기 위한 기본 CI와 릴리스 자동화가 필요했습니다.
이번 변경은 로컬 검증 흐름과 GitHub Actions 흐름을 맞추고, npm 배포와 GitHub release가 같은 버전 소스를 기준으로 안전하게 동작하도록 정리합니다.

# 변경 사항 / Changes

- `package.json`을 기준으로 CLI `--version` 출력과 릴리스 버전 검증을 연결했습니다.
- `scripts/check-pack.mjs`를 추가해 published tarball 파일 목록을 실제로 검증하도록 했습니다.
- `smoke`, `pack:check` 스크립트를 추가하고 `.npm-cache`를 ignore 처리했습니다.
- PR/push 검증용 `ci.yml`을 추가해 Node 매트릭스 테스트, 최소 지원 버전 smoke/package 검증, Windows package 검증을 구성했습니다.
- `release.yml`을 추가해 태그 기반 npm publish와 GitHub release publish를 자동화했습니다.
- `release-drafter.yml` workflow와 설정 파일을 추가해 릴리스 노트 초안을 자동으로 관리하도록 했습니다.
- `CONTRIBUTING.md`에 현재 검증 명령과 release flow를 문서화했습니다.

# 검증 / Verification

- `npm test`
- `npm run smoke`
- `npm run pack:check`

# 리스크 또는 확인 포인트 / Risks or Follow-ups

- GitHub Actions 자체 실행은 로컬에서 직접 검증할 수 없어서, push 후 실제 runner 결과 확인이 필요합니다.
- npm publish 경로는 동일 버전 재실행 시 registry의 artifact identity까지 확인하도록 했지만, 실제 NPM/GitHub secret 설정은 저장소에서 별도로 점검해야 합니다.
