### PR TITLE
feat: port rust workspace and project-shape primitives

### DIFF
--- a/crates/legolas-core/src/project_shape.rs
+++ b/crates/legolas-core/src/project_shape.rs
@@ -1,13 +1,126 @@
-use std::path::Path;
+use std::{collections::HashSet, path::Path};
 
 use serde_json::Value;
 
-use crate::{error::Result, LegolasError};
+use crate::{error::Result, workspace::exists};
 
-pub fn detect_frameworks(_project_root: &Path, _manifest: &Value) -> Result<Vec<String>> {
-    Err(LegolasError::NotImplemented("detect_frameworks"))
+struct FrameworkMarker {
+    name: &'static str,
+    packages: &'static [&'static str],
+    files: &'static [&'static str],
 }
 
-pub fn detect_package_manager(_project_root: &Path, _manifest: &Value) -> Result<String> {
-    Err(LegolasError::NotImplemented("detect_package_manager"))
+const FRAMEWORK_MARKERS: [FrameworkMarker; 9] = [
+    FrameworkMarker {
+        name: "Next.js",
+        packages: &["next"],
+        files: &["next.config.js", "next.config.mjs", "next.config.ts"],
+    },
+    FrameworkMarker {
+        name: "Vite",
+        packages: &["vite"],
+        files: &["vite.config.js", "vite.config.ts", "vite.config.mjs"],
+    },
+    FrameworkMarker {
+        name: "Webpack",
+        packages: &["webpack"],
+        files: &["webpack.config.js", "webpack.config.ts"],
+    },
+    FrameworkMarker {
+        name: "Rollup",
+        packages: &["rollup"],
+        files: &["rollup.config.js", "rollup.config.mjs", "rollup.config.ts"],
+    },
+    FrameworkMarker {
+        name: "Astro",
+        packages: &["astro"],
+        files: &["astro.config.mjs", "astro.config.ts"],
+    },
+    FrameworkMarker {
+        name: "Nuxt",
+        packages: &["nuxt"],
+        files: &["nuxt.config.ts", "nuxt.config.js"],
+    },
+    FrameworkMarker {
+        name: "React",
+        packages: &["react"],
+        files: &[],
+    },
+    FrameworkMarker {
+        name: "Vue",
+        packages: &["vue"],
+        files: &[],
+    },
+    FrameworkMarker {
+        name: "Svelte",
+        packages: &["svelte", "@sveltejs/kit"],
+        files: &[],
+    },
+];
+
+const PACKAGE_MANAGER_CHECKS: [(&str, &str); 5] = [
+    ("pnpm-lock.yaml", "pnpm"),
+    ("yarn.lock", "yarn"),
+    ("package-lock.json", "npm"),
+    ("bun.lockb", "bun"),
+    ("bun.lock", "bun"),
+];
+
+pub fn detect_frameworks(project_root: &Path, manifest: &Value) -> Result<Vec<String>> {
+    let all_dependencies = dependency_names(manifest);
+    let mut detected = Vec::new();
+
+    for marker in FRAMEWORK_MARKERS {
+        let package_hit = marker
+            .packages
+            .iter()
+            .any(|package| all_dependencies.contains(*package));
+        let file_hit = any_exists(project_root, marker.files)?;
+
+        if package_hit || file_hit {
+            detected.push(marker.name.to_string());
+        }
+    }
+
+    Ok(detected)
+}
+
+pub fn detect_package_manager(project_root: &Path, manifest: &Value) -> Result<String> {
+    if let Some(explicit) = manifest
+        .get("packageManager")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(explicit.to_string());
+    }
+
+    for (file, name) in PACKAGE_MANAGER_CHECKS {
+        if exists(project_root.join(file))? {
+            return Ok(name.to_string());
+        }
+    }
+
+    Ok("unknown".to_string())
+}
+
+fn dependency_names(manifest: &Value) -> HashSet<String> {
+    let mut dependencies = HashSet::new();
+
+    for field in ["dependencies", "devDependencies"] {
+        if let Some(entries) = manifest.get(field).and_then(Value::as_object) {
+            dependencies.extend(entries.keys().cloned());
+        }
+    }
+
+    dependencies
+}
+
+fn any_exists(project_root: &Path, files: &[&str]) -> Result<bool> {
+    for file in files {
+        if exists(project_root.join(file))? {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }

--- a/crates/legolas-core/src/workspace.rs
+++ b/crates/legolas-core/src/workspace.rs
@@ -1,25 +1,112 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    io::ErrorKind,
+    path::{Component, Path, PathBuf},
+};
 
 use serde::de::DeserializeOwned;
 
 use crate::{error::Result, LegolasError};
 
-pub fn find_project_root<P: AsRef<Path>>(_input_path: P) -> Result<PathBuf> {
-    Err(LegolasError::NotImplemented("find_project_root"))
+const ROOT_MARKERS: [&str; 6] = [
+    "package.json",
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "yarn.lock",
+    "bun.lock",
+    "bun.lockb",
+];
+
+pub fn find_project_root<P: AsRef<Path>>(input_path: P) -> Result<PathBuf> {
+    let resolved = resolve_absolute(input_path.as_ref())?;
+    let mut current = normalize_to_directory(&resolved)?;
+    let initial_directory = current.clone();
+
+    loop {
+        for marker in ROOT_MARKERS {
+            if exists(current.join(marker))? {
+                return Ok(current);
+            }
+        }
+
+        let Some(parent) = current.parent() else {
+            return Ok(initial_directory);
+        };
+        let parent = parent.to_path_buf();
+
+        if parent == current {
+            return Ok(initial_directory);
+        }
+
+        current = parent;
+    }
 }
 
-pub fn read_text_if_exists<P: AsRef<Path>>(_file_path: P) -> Result<Option<String>> {
-    Err(LegolasError::NotImplemented("read_text_if_exists"))
+pub fn read_text_if_exists<P: AsRef<Path>>(file_path: P) -> Result<Option<String>> {
+    match fs::read_to_string(file_path.as_ref()) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
 }
 
-pub fn read_json_if_exists<T, P>(_file_path: P) -> Result<Option<T>>
+pub fn read_json_if_exists<T, P>(file_path: P) -> Result<Option<T>>
 where
     T: DeserializeOwned,
     P: AsRef<Path>,
 {
-    Err(LegolasError::NotImplemented("read_json_if_exists"))
+    match read_text_if_exists(file_path)? {
+        Some(contents) if contents.is_empty() => Ok(None),
+        Some(contents) => Ok(Some(serde_json::from_str(&contents)?)),
+        None => Ok(None),
+    }
 }
 
-pub fn exists<P: AsRef<Path>>(_file_path: P) -> Result<bool> {
-    Err(LegolasError::NotImplemented("exists"))
+pub fn exists<P: AsRef<Path>>(file_path: P) -> Result<bool> {
+    match fs::metadata(file_path.as_ref()) {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}
+
+fn normalize_to_directory(target_path: &Path) -> Result<PathBuf> {
+    match fs::metadata(target_path) {
+        Ok(stats) => {
+            if stats.is_dir() {
+                Ok(target_path.to_path_buf())
+            } else {
+                Ok(target_path.parent().unwrap_or(target_path).to_path_buf())
+            }
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => Err(LegolasError::PathNotFound(
+            target_path.display().to_string(),
+        )),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn resolve_absolute(input_path: &Path) -> Result<PathBuf> {
+    let absolute = if input_path.is_absolute() {
+        input_path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(input_path)
+    };
+
+    Ok(normalize_path(&absolute))
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+
+    normalized
 }

--- a/crates/legolas-core/tests/workspace_project_shape.rs
+++ b/crates/legolas-core/tests/workspace_project_shape.rs
@@ -1,0 +1,150 @@
+#[allow(dead_code)]
+mod support;
+
+use std::fs;
+
+use legolas_core::{
+    project_shape::{detect_frameworks, detect_package_manager},
+    workspace::{exists, find_project_root, read_json_if_exists, read_text_if_exists},
+};
+use serde_json::Value;
+use tempfile::tempdir;
+
+#[test]
+fn find_project_root_normalizes_file_inputs_and_ascends_to_nearest_marker() {
+    let file_input = support::fixture_path("tests/fixtures/workspace/file-input/example.ts");
+    let expected_root = support::workspace_root();
+
+    assert_eq!(
+        find_project_root(&file_input).expect("find project root"),
+        expected_root
+    );
+}
+
+#[test]
+fn find_project_root_returns_a_stable_missing_path_error() {
+    let missing = support::fixture_path("tests/fixtures/workspace/file-input/missing.ts");
+    let error = find_project_root(&missing).expect_err("missing path should fail");
+
+    assert_eq!(
+        error.to_string(),
+        format!("path not found: {}", missing.display())
+    );
+}
+
+#[test]
+fn read_helpers_treat_missing_entries_as_optional() {
+    let project_root = support::fixture_path("tests/fixtures/workspace/vite-project");
+    let manifest: Value = read_json_if_exists(project_root.join("package.json"))
+        .expect("read manifest")
+        .expect("package.json should exist");
+
+    assert_eq!(manifest["name"], "workspace-vite-project");
+    assert_eq!(
+        read_text_if_exists(project_root.join("missing.txt")).expect("read missing text"),
+        None
+    );
+    assert!(!exists(project_root.join("missing.txt")).expect("check missing file"));
+    assert!(exists(project_root.join("vite.config.ts")).expect("check config file"));
+}
+
+#[test]
+fn read_json_if_exists_treats_empty_files_as_missing() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let empty_json = temp_dir.path().join("package-lock.json");
+    fs::write(&empty_json, "").expect("write empty json");
+
+    let parsed: Option<Value> = read_json_if_exists(&empty_json).expect("read empty json");
+
+    assert_eq!(parsed, None);
+}
+
+#[cfg(unix)]
+#[test]
+fn exists_swallows_non_not_found_filesystem_errors() {
+    use std::{os::unix::fs::PermissionsExt, path::PathBuf};
+
+    struct PermissionGuard {
+        path: PathBuf,
+        permissions: fs::Permissions,
+    }
+
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(&self.path, self.permissions.clone());
+        }
+    }
+
+    let temp_dir = tempdir().expect("create temp dir");
+    let sealed_dir = temp_dir.path().join("sealed");
+    fs::create_dir(&sealed_dir).expect("create sealed dir");
+    fs::write(sealed_dir.join("package.json"), "{}").expect("write package.json");
+
+    let original_permissions = fs::metadata(&sealed_dir)
+        .expect("read metadata")
+        .permissions();
+    let _permission_guard = PermissionGuard {
+        path: sealed_dir.clone(),
+        permissions: original_permissions.clone(),
+    };
+    let mut sealed_permissions = original_permissions.clone();
+    sealed_permissions.set_mode(0o000);
+    fs::set_permissions(&sealed_dir, sealed_permissions).expect("seal directory");
+
+    if fs::metadata(sealed_dir.join("package.json")).is_ok() {
+        return;
+    }
+
+    let result = exists(sealed_dir.join("package.json")).expect("exists should not fail");
+
+    assert!(!result);
+}
+
+#[test]
+fn detect_frameworks_matches_js_order_and_config_only_hits() {
+    let project_root = support::fixture_path("tests/fixtures/workspace/vite-project");
+    let manifest: Value = read_json_if_exists(project_root.join("package.json"))
+        .expect("read manifest")
+        .expect("package.json should exist");
+
+    assert_eq!(
+        detect_frameworks(&project_root, &manifest).expect("detect frameworks"),
+        vec!["Vite".to_string(), "React".to_string()]
+    );
+}
+
+#[test]
+fn detect_package_manager_prefers_manifest_before_lockfiles() {
+    let project_root = support::fixture_path("tests/fixtures/workspace/multi-lockfiles");
+    let manifest_path = project_root.join("package.json");
+    let mut manifest: Value = read_json_if_exists(&manifest_path)
+        .expect("read manifest")
+        .expect("package.json should exist");
+
+    assert_eq!(
+        detect_package_manager(&project_root, &manifest).expect("detect package manager"),
+        "pnpm@9.0.0"
+    );
+
+    manifest
+        .as_object_mut()
+        .expect("manifest object")
+        .remove("packageManager");
+
+    assert_eq!(
+        detect_package_manager(&project_root, &manifest).expect("detect fallback package manager"),
+        "pnpm"
+    );
+}
+
+#[test]
+fn find_project_root_handles_package_and_lockfile_entry_paths() {
+    let project_root = support::fixture_path("tests/fixtures/workspace/multi-lockfiles");
+
+    for entry in ["package.json", "package-lock.json", "pnpm-lock.yaml"] {
+        assert_eq!(
+            find_project_root(project_root.join(entry)).expect("find project root from file entry"),
+            project_root
+        );
+    }
+}

--- a/tests/fixtures/workspace/file-input/example.ts
+++ b/tests/fixtures/workspace/file-input/example.ts
@@ -1,0 +1,1 @@
+export const example = 1;

--- a/tests/fixtures/workspace/multi-lockfiles/package-lock.json
+++ b/tests/fixtures/workspace/multi-lockfiles/package-lock.json
@@ -1,0 +1,9 @@
+{
+  "name": "workspace-multi-lockfiles",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "workspace-multi-lockfiles"
+    }
+  }
+}

--- a/tests/fixtures/workspace/multi-lockfiles/package.json
+++ b/tests/fixtures/workspace/multi-lockfiles/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "workspace-multi-lockfiles",
+  "packageManager": "pnpm@9.0.0"
+}

--- a/tests/fixtures/workspace/multi-lockfiles/pnpm-lock.yaml
+++ b/tests/fixtures/workspace/multi-lockfiles/pnpm-lock.yaml
@@ -1,0 +1,3 @@
+lockfileVersion: "9.0"
+importers:
+  .: {}

--- a/tests/fixtures/workspace/vite-project/package.json
+++ b/tests/fixtures/workspace/vite-project/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace-vite-project",
+  "dependencies": {
+    "react": "^18.3.0"
+  }
+}

--- a/tests/fixtures/workspace/vite-project/vite.config.ts
+++ b/tests/fixtures/workspace/vite-project/vite.config.ts
@@ -1,0 +1,5 @@
+export default {
+  server: {
+    port: 5173
+  }
+};


### PR DESCRIPTION
## Summary
- port Rust workspace helpers for root discovery, optional file reads, and JS-compatible error handling
- port framework and package manager detection rules from the JS source of truth
- add dedicated workspace fixtures and Rust integration tests for file-input, config-only, empty-file, and permission-error parity cases

## Validation
- cargo test -p legolas-core --test workspace_project_shape
- cargo test --workspace