### PR TITLE
feat: port rust package intelligence and impact

### DIFF
--- a/crates/legolas-core/src/impact.rs
+++ b/crates/legolas-core/src/impact.rs
@@ -3,10 +3,57 @@ use crate::models::{
 };
 
 pub fn estimate_impact(
-    _heavy_dependencies: &[HeavyDependency],
-    _duplicate_packages: &[DuplicatePackage],
-    _lazy_load_candidates: &[LazyLoadCandidate],
-    _tree_shaking_warnings: &[TreeShakingWarning],
+    heavy_dependencies: &[HeavyDependency],
+    duplicate_packages: &[DuplicatePackage],
+    lazy_load_candidates: &[LazyLoadCandidate],
+    tree_shaking_warnings: &[TreeShakingWarning],
 ) -> Impact {
-    Impact::default()
+    let heavy_kb: f64 = heavy_dependencies
+        .iter()
+        .take(5)
+        .map(|item| item.estimated_kb as f64 * 0.18)
+        .sum();
+    let duplicate_kb: usize = duplicate_packages
+        .iter()
+        .map(|item| item.estimated_extra_kb)
+        .sum();
+    let lazy_kb: usize = lazy_load_candidates
+        .iter()
+        .map(|item| item.estimated_savings_kb)
+        .sum();
+    let shaking_kb: usize = tree_shaking_warnings
+        .iter()
+        .map(|item| item.estimated_kb)
+        .sum();
+
+    let potential_kb_saved =
+        (heavy_kb + duplicate_kb as f64 + lazy_kb as f64 + shaking_kb as f64).round() as usize;
+    let estimated_lcp_improvement_ms = (potential_kb_saved as f64 * 2.1).round() as usize;
+
+    Impact {
+        potential_kb_saved,
+        estimated_lcp_improvement_ms,
+        confidence: if potential_kb_saved > 0 {
+            "directional".to_string()
+        } else {
+            "low".to_string()
+        },
+        summary: summarize_impact(potential_kb_saved).to_string(),
+    }
+}
+
+fn summarize_impact(potential_kb_saved: usize) -> &'static str {
+    if potential_kb_saved >= 300 {
+        return "High impact: the project has clear opportunities to reduce initial payload size.";
+    }
+
+    if potential_kb_saved >= 120 {
+        return "Medium impact: there are several meaningful bundle wins available.";
+    }
+
+    if potential_kb_saved >= 40 {
+        return "Targeted impact: a handful of focused optimizations should pay off.";
+    }
+
+    "Low impact: obvious bundle issues are limited in the current scan."
 }

--- a/crates/legolas-core/src/package_intelligence.rs
+++ b/crates/legolas-core/src/package_intelligence.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PackageIntel {
     pub estimated_kb: usize,
     pub category: &'static str,
@@ -6,6 +6,175 @@ pub struct PackageIntel {
     pub recommendation: &'static str,
 }
 
-pub fn get_package_intel(_name: &str) -> Option<PackageIntel> {
-    None
+static PACKAGE_INTELLIGENCE: [(&str, PackageIntel); 16] = [
+    (
+        "aws-sdk",
+        PackageIntel {
+            estimated_kb: 700,
+            category: "sdk",
+            rationale: "The v2 AWS SDK is broad and frequently lands in client bundles by accident.",
+            recommendation:
+                "Move client-side calls to modular AWS SDK v3 packages or server boundaries.",
+        },
+    ),
+    (
+        "firebase",
+        PackageIntel {
+            estimated_kb: 180,
+            category: "sdk",
+            rationale: "Firebase bundles grow quickly when the compat layer or multiple services are pulled together.",
+            recommendation:
+                "Use modular Firebase imports and lazy load infrequent auth or analytics flows.",
+        },
+    ),
+    (
+        "monaco-editor",
+        PackageIntel {
+            estimated_kb: 320,
+            category: "editor",
+            rationale: "Monaco is powerful but rarely belongs in the critical path.",
+            recommendation:
+                "Load Monaco only on editor routes and defer language workers until needed.",
+        },
+    ),
+    (
+        "three",
+        PackageIntel {
+            estimated_kb: 230,
+            category: "3d",
+            rationale: "Three.js is often one of the heaviest client-side libraries in a web app.",
+            recommendation:
+                "Split 3D experiences behind route boundaries or on-demand interactions.",
+        },
+    ),
+    (
+        "antd",
+        PackageIntel {
+            estimated_kb: 210,
+            category: "ui",
+            rationale: "Large component suites and styling layers can inflate initial chunks.",
+            recommendation:
+                "Prefer route-based splits and avoid importing broad UI modules into shared entry points.",
+        },
+    ),
+    (
+        "chart.js",
+        PackageIntel {
+            estimated_kb: 160,
+            category: "charts",
+            rationale: "Charting code is often only needed on a subset of screens.",
+            recommendation:
+                "Register only the chart primitives you use and lazy load dashboard surfaces.",
+        },
+    ),
+    (
+        "echarts",
+        PackageIntel {
+            estimated_kb: 260,
+            category: "charts",
+            rationale: "ECharts is feature-rich but rarely lightweight.",
+            recommendation:
+                "Split chart-heavy screens and consider lighter renderers for simple charts.",
+        },
+    ),
+    (
+        "react-icons",
+        PackageIntel {
+            estimated_kb: 90,
+            category: "icons",
+            rationale: "Wide icon-pack imports can defeat tree shaking.",
+            recommendation:
+                "Import narrowly from specific icon files or migrate to a more tree-shakable icon set.",
+        },
+    ),
+    (
+        "@mui/icons-material",
+        PackageIntel {
+            estimated_kb: 220,
+            category: "icons",
+            rationale: "Icons often spread across the app and are easy to over-import.",
+            recommendation:
+                "Use direct icon imports and lazy load icon-heavy admin or settings routes.",
+        },
+    ),
+    (
+        "@mui/material",
+        PackageIntel {
+            estimated_kb: 120,
+            category: "ui",
+            rationale: "Barrel imports can keep more UI code in shared chunks than intended.",
+            recommendation:
+                "Audit entry-point imports and keep heavy UI primitives out of global layouts.",
+        },
+    ),
+    (
+        "lodash",
+        PackageIntel {
+            estimated_kb: 72,
+            category: "utility",
+            rationale: "Root lodash imports are a classic source of tree-shaking misses.",
+            recommendation:
+                "Use per-method imports or switch to lodash-es when the toolchain supports it.",
+        },
+    ),
+    (
+        "moment",
+        PackageIntel {
+            estimated_kb: 67,
+            category: "date",
+            rationale: "Moment brings notable weight and locale baggage.",
+            recommendation: "Prefer date-fns, Day.js, or the platform Intl APIs where practical.",
+        },
+    ),
+    (
+        "framer-motion",
+        PackageIntel {
+            estimated_kb: 85,
+            category: "animation",
+            rationale: "Animation libraries can be worth the cost, but not everywhere.",
+            recommendation:
+                "Restrict motion-heavy features to lazy-loaded surfaces and trim rarely used transitions.",
+        },
+    ),
+    (
+        "highlight.js",
+        PackageIntel {
+            estimated_kb: 110,
+            category: "rendering",
+            rationale: "Syntax highlighting usually belongs in secondary reading or editing views.",
+            recommendation:
+                "Load highlight grammars on demand or swap to a smaller highlighter.",
+        },
+    ),
+    (
+        "@react-google-maps/api",
+        PackageIntel {
+            estimated_kb: 130,
+            category: "maps",
+            rationale: "Map SDKs are expensive and usually route-specific.",
+            recommendation:
+                "Keep maps behind dynamic imports and avoid rendering them inside shared shells.",
+        },
+    ),
+    (
+        "@sentry/browser",
+        PackageIntel {
+            estimated_kb: 90,
+            category: "monitoring",
+            rationale: "Instrumentation can bloat entry chunks if initialized too eagerly.",
+            recommendation:
+                "Defer optional integrations and review whether client monitoring needs the full browser SDK.",
+        },
+    ),
+];
+
+pub fn get_package_intel(name: &str) -> Option<PackageIntel> {
+    PACKAGE_INTELLIGENCE
+        .iter()
+        .find(|(key, _)| *key == name)
+        .map(|(_, intel)| *intel)
+}
+
+pub fn package_intelligence_entries() -> &'static [(&'static str, PackageIntel)] {
+    &PACKAGE_INTELLIGENCE
 }

--- a/crates/legolas-core/tests/intelligence_impact.rs
+++ b/crates/legolas-core/tests/intelligence_impact.rs
@@ -1,0 +1,333 @@
+use std::{path::PathBuf, process::Command};
+
+use legolas_core::{
+    impact::estimate_impact,
+    models::{DuplicatePackage, HeavyDependency, Impact, LazyLoadCandidate, TreeShakingWarning},
+    package_intelligence::{get_package_intel, package_intelligence_entries, PackageIntel},
+};
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct JsPackageIntel {
+    estimated_kb: usize,
+    category: String,
+    rationale: String,
+    recommendation: String,
+}
+
+#[test]
+fn get_package_intel_matches_every_js_registry_entry() {
+    let rust_entries = package_intelligence_entries();
+    let rust_keys: Vec<&str> = rust_entries.iter().map(|(key, _)| *key).collect();
+    let js_entries = load_js_package_intelligence();
+    let js_keys: Vec<&str> = js_entries.iter().map(|(key, _)| key.as_str()).collect();
+
+    assert_eq!(rust_keys, js_keys);
+    assert_eq!(js_entries.len(), rust_entries.len());
+
+    for ((rust_key, rust_intel), (js_key, js_intel)) in rust_entries.iter().zip(js_entries) {
+        assert_eq!(*rust_key, js_key);
+        assert_eq!(get_package_intel(rust_key), Some(*rust_intel));
+        assert_eq!(snapshot(*rust_intel), js_intel);
+    }
+}
+
+#[test]
+fn get_package_intel_requires_an_exact_package_key_match() {
+    assert_eq!(get_package_intel("lodash/fp"), None);
+    assert_eq!(get_package_intel("@mui/icons-material/AccessAlarm"), None);
+    assert_eq!(get_package_intel("unknown-package"), None);
+}
+
+#[test]
+fn estimate_impact_matches_the_js_directional_formula() {
+    let heavy_dependencies = vec![
+        heavy_dependency(600),
+        heavy_dependency(500),
+        heavy_dependency(400),
+        heavy_dependency(300),
+        heavy_dependency(200),
+        heavy_dependency(100),
+    ];
+    let duplicate_packages = vec![duplicate_package(15), duplicate_package(5)];
+    let lazy_load_candidates = vec![lazy_load_candidate(30)];
+    let tree_shaking_warnings = vec![tree_shaking_warning(25)];
+
+    let impact = estimate_impact(
+        &heavy_dependencies,
+        &duplicate_packages,
+        &lazy_load_candidates,
+        &tree_shaking_warnings,
+    );
+    let js_impact = load_js_impact(&impact_payload(
+        &[600, 500, 400, 300, 200, 100],
+        &[15, 5],
+        &[30],
+        &[25],
+    ));
+
+    assert_eq!(impact, js_impact);
+    assert_eq!(impact.potential_kb_saved, 435);
+    assert_eq!(impact.estimated_lcp_improvement_ms, 914);
+    assert_eq!(impact.confidence, "directional");
+    assert_eq!(
+        impact.summary,
+        "High impact: the project has clear opportunities to reduce initial payload size."
+    );
+}
+
+#[test]
+fn estimate_impact_matches_js_oracle_for_unsorted_inputs() {
+    let impact = estimate_impact(
+        &[
+            heavy_dependency(100),
+            heavy_dependency(200),
+            heavy_dependency(300),
+            heavy_dependency(400),
+            heavy_dependency(500),
+            heavy_dependency(600),
+        ],
+        &[duplicate_package(15), duplicate_package(5)],
+        &[lazy_load_candidate(30)],
+        &[tree_shaking_warning(25)],
+    );
+    let js_impact = load_js_impact(&impact_payload(
+        &[100, 200, 300, 400, 500, 600],
+        &[15, 5],
+        &[30],
+        &[25],
+    ));
+
+    assert_eq!(impact, js_impact);
+    assert_eq!(impact.potential_kb_saved, 345);
+    assert_eq!(impact.estimated_lcp_improvement_ms, 725);
+}
+
+#[test]
+fn estimate_impact_preserves_fractional_rounding_behavior() {
+    let impact = estimate_impact(&[heavy_dependency(25)], &[], &[], &[]);
+    let js_impact = load_js_impact(&impact_payload(&[25], &[], &[], &[]));
+
+    assert_eq!(impact, js_impact);
+    assert_eq!(impact.potential_kb_saved, 5);
+    assert_eq!(impact.estimated_lcp_improvement_ms, 11);
+    assert_eq!(impact.confidence, "directional");
+    assert_eq!(
+        impact.summary,
+        "Low impact: obvious bundle issues are limited in the current scan."
+    );
+
+    let threshold_impact = estimate_impact(&[heavy_dependency(222)], &[], &[], &[]);
+    let js_threshold_impact = load_js_impact(&impact_payload(&[222], &[], &[], &[]));
+
+    assert_eq!(threshold_impact, js_threshold_impact);
+    assert_eq!(threshold_impact.potential_kb_saved, 40);
+    assert_eq!(threshold_impact.estimated_lcp_improvement_ms, 84);
+    assert_eq!(
+        threshold_impact.summary,
+        "Targeted impact: a handful of focused optimizations should pay off."
+    );
+}
+
+#[test]
+fn estimate_impact_uses_the_js_summary_thresholds() {
+    let cases = [
+        (
+            0,
+            "low",
+            "Low impact: obvious bundle issues are limited in the current scan.",
+        ),
+        (
+            39,
+            "directional",
+            "Low impact: obvious bundle issues are limited in the current scan.",
+        ),
+        (
+            40,
+            "directional",
+            "Targeted impact: a handful of focused optimizations should pay off.",
+        ),
+        (
+            120,
+            "directional",
+            "Medium impact: there are several meaningful bundle wins available.",
+        ),
+        (
+            300,
+            "directional",
+            "High impact: the project has clear opportunities to reduce initial payload size.",
+        ),
+    ];
+
+    for (potential_kb_saved, expected_confidence, expected_summary) in cases {
+        let duplicate_packages = if potential_kb_saved == 0 {
+            Vec::new()
+        } else {
+            vec![duplicate_package(potential_kb_saved)]
+        };
+
+        let impact = estimate_impact(&[], &duplicate_packages, &[], &[]);
+        let js_impact = load_js_impact(&impact_payload(
+            &[],
+            &duplicate_packages
+                .iter()
+                .map(|item| item.estimated_extra_kb)
+                .collect::<Vec<_>>(),
+            &[],
+            &[],
+        ));
+
+        assert_eq!(impact, js_impact);
+        assert_eq!(impact.potential_kb_saved, potential_kb_saved);
+        assert_eq!(impact.confidence, expected_confidence);
+        assert_eq!(impact.summary, expected_summary);
+    }
+}
+
+fn heavy_dependency(estimated_kb: usize) -> HeavyDependency {
+    HeavyDependency {
+        estimated_kb,
+        ..HeavyDependency::default()
+    }
+}
+
+fn duplicate_package(estimated_extra_kb: usize) -> DuplicatePackage {
+    DuplicatePackage {
+        estimated_extra_kb,
+        ..DuplicatePackage::default()
+    }
+}
+
+fn lazy_load_candidate(estimated_savings_kb: usize) -> LazyLoadCandidate {
+    LazyLoadCandidate {
+        estimated_savings_kb,
+        ..LazyLoadCandidate::default()
+    }
+}
+
+fn tree_shaking_warning(estimated_kb: usize) -> TreeShakingWarning {
+    TreeShakingWarning {
+        estimated_kb,
+        ..TreeShakingWarning::default()
+    }
+}
+
+fn snapshot(intel: PackageIntel) -> JsPackageIntel {
+    JsPackageIntel {
+        estimated_kb: intel.estimated_kb,
+        category: intel.category.to_string(),
+        rationale: intel.rationale.to_string(),
+        recommendation: intel.recommendation.to_string(),
+    }
+}
+
+fn load_js_package_intelligence() -> Vec<(String, JsPackageIntel)> {
+    let repo_root = workspace_root();
+    let script = r#"
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+const repoRoot = process.argv[1];
+const sourcePath = path.join(repoRoot, "src/core/package-intelligence.js");
+const source = fs.readFileSync(sourcePath, "utf8").replace(
+  "export function getPackageIntel",
+  "function getPackageIntel"
+);
+const context = {};
+
+vm.runInNewContext(
+  `${source}\nresult = Object.entries(PACKAGE_INTELLIGENCE);`,
+  context
+);
+
+console.log(JSON.stringify(context.result));
+"#;
+
+    let output = Command::new("node")
+        .arg("--input-type=module")
+        .arg("-e")
+        .arg(script)
+        .arg(repo_root.display().to_string())
+        .current_dir(&repo_root)
+        .output()
+        .expect("run node for JS package intelligence");
+
+    assert!(
+        output.status.success(),
+        "node exited unsuccessfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("deserialize JS package intelligence")
+}
+
+fn load_js_impact(payload: &serde_json::Value) -> Impact {
+    let repo_root = workspace_root();
+    let payload_json = serde_json::to_string(payload).expect("serialize JS impact payload");
+    let script = r#"
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = process.argv[1];
+const payload = JSON.parse(process.argv[2]);
+const moduleUrl = pathToFileURL(path.join(repoRoot, "src/core/estimate-impact.js")).href;
+const { estimateImpact } = await import(moduleUrl);
+
+console.log(JSON.stringify(estimateImpact(payload)));
+"#;
+
+    let output = Command::new("node")
+        .arg("--input-type=module")
+        .arg("-e")
+        .arg(script)
+        .arg(repo_root.display().to_string())
+        .arg(payload_json)
+        .current_dir(&repo_root)
+        .output()
+        .expect("run node for JS impact");
+
+    assert!(
+        output.status.success(),
+        "node exited unsuccessfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("deserialize JS impact")
+}
+
+fn impact_payload(
+    heavy_dependencies: &[usize],
+    duplicate_packages: &[usize],
+    lazy_load_candidates: &[usize],
+    tree_shaking_warnings: &[usize],
+) -> serde_json::Value {
+    json!({
+        "heavyDependencies": heavy_dependencies
+            .iter()
+            .map(|estimated_kb| json!({ "estimatedKb": estimated_kb }))
+            .collect::<Vec<_>>(),
+        "duplicatePackages": duplicate_packages
+            .iter()
+            .map(|estimated_extra_kb| json!({ "estimatedExtraKb": estimated_extra_kb }))
+            .collect::<Vec<_>>(),
+        "lazyLoadCandidates": lazy_load_candidates
+            .iter()
+            .map(|estimated_savings_kb| json!({ "estimatedSavingsKb": estimated_savings_kb }))
+            .collect::<Vec<_>>(),
+        "treeShakingWarnings": tree_shaking_warnings
+            .iter()
+            .map(|estimated_kb| json!({ "estimatedKb": estimated_kb }))
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("workspace root")
+        .to_path_buf()
+}


### PR DESCRIPTION
## Summary
- port the JS package intelligence registry into legolas-core as an exact-match Rust table
- port the directional impact formula and summary thresholds with JS-parity rounding behavior
- add Rust parity tests covering full registry comparison against the live JS source, exact-key misses, fractional rounding, and threshold summaries

## Validation
- cargo test -p legolas-core --test intelligence_impact
- cargo test --workspace