### PR TITLE
feat: port rust lockfile duplicate parsing

### DIFF
--- a/crates/legolas-core/src/lockfiles.rs
+++ b/crates/legolas-core/src/lockfiles.rs
@@ -1,6 +1,18 @@
-use std::path::Path;
+use std::{
+    cmp::Ordering,
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
-use crate::{error::Result, models::DuplicatePackage, LegolasError};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde_json::{Map, Value};
+
+use crate::{
+    error::Result,
+    models::DuplicatePackage,
+    workspace::{exists, read_json_if_exists, read_text_if_exists},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DuplicateAnalysis {
@@ -8,9 +20,520 @@ pub struct DuplicateAnalysis {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LockfileKind {
+    Npm,
+    Pnpm,
+    Yarn,
+    Bun,
+}
+
+#[derive(Debug, Clone)]
+struct Lockfile {
+    kind: LockfileKind,
+    name: &'static str,
+    file_path: PathBuf,
+}
+
+type VersionsByName = BTreeMap<String, Vec<String>>;
+
+static PNPM_ENTRY_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^ {2,}'?(@?[^:'\s][^:]*?)'?:\s*$").expect("valid pnpm entry regex"));
+static DESCRIPTOR_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(@[^/]+/[^@]+|[^@]+)@(.+)$").expect("valid descriptor regex"));
+static YARN_ALIAS_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"@npm:(@[^/]+/[^@]+|[^@]+)@").expect("valid yarn alias regex"));
+static YARN_VERSION_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"^ {2}version "(.*)"$"#).expect("valid yarn version regex"));
+static YARN_BERRY_VERSION_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"^ {2}version:\s+"?([^"]+)"?$"#).expect("valid yarn berry version regex")
+});
+static SPLIT_HEADER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r",\s*").expect("valid yarn header split regex"));
+
 pub fn parse_duplicate_packages<P: AsRef<Path>>(
-    _project_root: P,
-    _package_manager: &str,
+    project_root: P,
+    package_manager: &str,
 ) -> Result<DuplicateAnalysis> {
-    Err(LegolasError::NotImplemented("parse_duplicate_packages"))
+    let project_root = project_root.as_ref();
+    let preferred_lockfile = normalize_package_manager(package_manager);
+    let ordered_lockfiles = prioritize_lockfiles(lockfiles(project_root), preferred_lockfile);
+    let mut existing_lockfiles = Vec::new();
+
+    for lockfile in ordered_lockfiles {
+        if exists(&lockfile.file_path)? {
+            existing_lockfiles.push(lockfile);
+        }
+    }
+
+    if existing_lockfiles.is_empty() {
+        return Ok(DuplicateAnalysis::default());
+    }
+
+    let selected_lockfile = existing_lockfiles.remove(0);
+    let duplicates = read_lockfile(&selected_lockfile)?;
+    let warnings =
+        build_lockfile_warnings(&selected_lockfile, &existing_lockfiles, package_manager);
+
+    Ok(DuplicateAnalysis {
+        duplicates,
+        warnings,
+    })
+}
+
+fn lockfiles(project_root: &Path) -> Vec<Lockfile> {
+    vec![
+        Lockfile {
+            kind: LockfileKind::Npm,
+            name: "npm",
+            file_path: project_root.join("package-lock.json"),
+        },
+        Lockfile {
+            kind: LockfileKind::Pnpm,
+            name: "pnpm",
+            file_path: project_root.join("pnpm-lock.yaml"),
+        },
+        Lockfile {
+            kind: LockfileKind::Yarn,
+            name: "yarn",
+            file_path: project_root.join("yarn.lock"),
+        },
+        Lockfile {
+            kind: LockfileKind::Bun,
+            name: "bun",
+            file_path: project_root.join("bun.lock"),
+        },
+        Lockfile {
+            kind: LockfileKind::Bun,
+            name: "bun",
+            file_path: project_root.join("bun.lockb"),
+        },
+    ]
+}
+
+fn prioritize_lockfiles(
+    lockfiles: Vec<Lockfile>,
+    preferred_lockfile: Option<&'static str>,
+) -> Vec<Lockfile> {
+    let Some(preferred_lockfile) = preferred_lockfile else {
+        return lockfiles;
+    };
+
+    let (preferred, remaining): (Vec<_>, Vec<_>) = lockfiles
+        .into_iter()
+        .partition(|lockfile| lockfile.name == preferred_lockfile);
+
+    preferred.into_iter().chain(remaining).collect()
+}
+
+fn read_lockfile(lockfile: &Lockfile) -> Result<Vec<DuplicatePackage>> {
+    match lockfile.kind {
+        LockfileKind::Npm => {
+            let package_lock: Option<Value> = read_json_if_exists(&lockfile.file_path)?;
+            Ok(summarize_duplicates(collect_from_package_lock(
+                package_lock,
+            )))
+        }
+        LockfileKind::Pnpm => {
+            let content = read_text_if_exists(&lockfile.file_path)?.unwrap_or_default();
+            Ok(summarize_duplicates(collect_from_pnpm_lock(&content)))
+        }
+        LockfileKind::Yarn => {
+            let content = read_text_if_exists(&lockfile.file_path)?.unwrap_or_default();
+            Ok(summarize_duplicates(collect_from_yarn_lock(&content)))
+        }
+        LockfileKind::Bun => Ok(Vec::new()),
+    }
+}
+
+fn collect_from_package_lock(package_lock: Option<Value>) -> VersionsByName {
+    let mut versions_by_name = BTreeMap::new();
+    let Some(package_lock) = package_lock else {
+        return versions_by_name;
+    };
+
+    let Some(package_lock_object) = package_lock.as_object() else {
+        return versions_by_name;
+    };
+
+    if let Some(packages) = package_lock_object.get("packages").and_then(Value::as_object) {
+        if !packages.is_empty() {
+            for (package_path, metadata) in packages {
+                let Some(version) = metadata
+                    .get("version")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                else {
+                    continue;
+                };
+
+                let Some(start_index) = package_path.rfind("node_modules/") else {
+                    continue;
+                };
+                let package_name = &package_path[start_index + "node_modules/".len()..];
+                add_version(&mut versions_by_name, package_name, version);
+            }
+
+            return versions_by_name;
+        }
+    }
+
+    if let Some(dependencies) = package_lock_object
+        .get("dependencies")
+        .and_then(Value::as_object)
+    {
+        collect_from_package_lock_dependencies(dependencies, &mut versions_by_name);
+    }
+
+    versions_by_name
+}
+
+fn collect_from_package_lock_dependencies(
+    dependencies: &Map<String, Value>,
+    versions_by_name: &mut VersionsByName,
+) {
+    for (name, metadata) in dependencies {
+        if let Some(version) = metadata
+            .get("version")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        {
+            add_version(versions_by_name, name, version);
+        }
+
+        if let Some(child_dependencies) = metadata.get("dependencies").and_then(Value::as_object) {
+            collect_from_package_lock_dependencies(child_dependencies, versions_by_name);
+        }
+    }
+}
+
+fn collect_from_pnpm_lock(content: &str) -> VersionsByName {
+    let mut versions_by_name = BTreeMap::new();
+    let mut inside_packages = false;
+
+    for raw_line in content.split('\n') {
+        let line = raw_line.trim_end_matches('\r');
+
+        if line == "packages:" || line == "snapshots:" {
+            inside_packages = true;
+            continue;
+        }
+
+        if inside_packages && starts_with_ascii_alpha(line) {
+            inside_packages = false;
+        }
+
+        if !inside_packages {
+            continue;
+        }
+
+        let Some(captures) = PNPM_ENTRY_RE.captures(line) else {
+            continue;
+        };
+        let mut descriptor = captures[1].to_string();
+        if let Some(stripped) = descriptor.strip_prefix('/') {
+            descriptor = stripped.to_string();
+        }
+
+        let Some((name, version)) = split_descriptor(&descriptor) else {
+            continue;
+        };
+        add_version(&mut versions_by_name, &name, &version);
+    }
+
+    versions_by_name
+}
+
+fn collect_from_yarn_lock(content: &str) -> VersionsByName {
+    let mut versions_by_name = BTreeMap::new();
+    let mut current_package_names: Vec<String> = Vec::new();
+    let mut current_version: Option<String> = None;
+
+    for raw_line in content.split('\n') {
+        let line = raw_line.trim_end_matches('\r');
+
+        if line.trim().is_empty() {
+            flush_current_yarn_entry(
+                &mut versions_by_name,
+                &current_package_names,
+                current_version.as_deref(),
+            );
+            current_package_names.clear();
+            current_version = None;
+            continue;
+        }
+
+        if !line.starts_with(' ') {
+            flush_current_yarn_entry(
+                &mut versions_by_name,
+                &current_package_names,
+                current_version.as_deref(),
+            );
+            current_package_names = parse_yarn_header(line);
+            current_version = None;
+            continue;
+        }
+
+        if let Some(captures) = YARN_VERSION_RE.captures(line) {
+            current_version = Some(captures[1].to_string());
+            continue;
+        }
+
+        if let Some(captures) = YARN_BERRY_VERSION_RE.captures(line) {
+            current_version = Some(captures[1].to_string());
+        }
+    }
+
+    flush_current_yarn_entry(
+        &mut versions_by_name,
+        &current_package_names,
+        current_version.as_deref(),
+    );
+    versions_by_name
+}
+
+fn parse_yarn_header(line: &str) -> Vec<String> {
+    let trimmed = line.strip_suffix(':').unwrap_or(line);
+
+    SPLIT_HEADER_RE
+        .split(trimmed)
+        .map(str::trim)
+        .map(strip_wrapping_quotes)
+        .filter_map(extract_yarn_package_name)
+        .collect()
+}
+
+fn flush_current_yarn_entry(
+    versions_by_name: &mut VersionsByName,
+    package_names: &[String],
+    version: Option<&str>,
+) {
+    let Some(version) = version else {
+        return;
+    };
+    if package_names.is_empty() {
+        return;
+    }
+
+    for package_name in package_names {
+        add_version(versions_by_name, package_name, version);
+    }
+}
+
+fn split_descriptor(descriptor: &str) -> Option<(String, String)> {
+    let clean = descriptor.strip_prefix("npm:").unwrap_or(descriptor);
+    let captures = DESCRIPTOR_RE.captures(clean)?;
+
+    Some((
+        captures[1].to_string(),
+        captures[2]
+            .split('(')
+            .next()
+            .unwrap_or_default()
+            .to_string(),
+    ))
+}
+
+fn extract_yarn_package_name(descriptor: &str) -> Option<String> {
+    if let Some(captures) = YARN_ALIAS_RE.captures(descriptor) {
+        return Some(captures[1].to_string());
+    }
+
+    split_descriptor(descriptor).map(|(name, _)| name)
+}
+
+fn summarize_duplicates(versions_by_name: VersionsByName) -> Vec<DuplicatePackage> {
+    let mut results = Vec::new();
+
+    for (name, mut versions) in versions_by_name {
+        if versions.len() < 2 {
+            continue;
+        }
+
+        versions.sort_by(|left, right| compare_versions(left, right));
+        let estimated_extra_kb = usize::max((versions.len().saturating_sub(1)) * 18, 18);
+
+        results.push(DuplicatePackage {
+            name,
+            count: versions.len(),
+            versions,
+            estimated_extra_kb,
+        });
+    }
+
+    results.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    results
+}
+
+fn add_version(versions_by_name: &mut VersionsByName, name: &str, version: &str) {
+    let versions = versions_by_name.entry(name.to_string()).or_default();
+    if !versions.iter().any(|existing| existing == version) {
+        versions.push(version.to_string());
+    }
+}
+
+fn compare_versions(left: &str, right: &str) -> Ordering {
+    let mut left_index = 0;
+    let mut right_index = 0;
+
+    loop {
+        match (
+            next_natural_part(left, left_index),
+            next_natural_part(right, right_index),
+        ) {
+            (Some((left_part, true, next_left)), Some((right_part, true, next_right))) => {
+                left_index = next_left;
+                right_index = next_right;
+                let ordering = compare_digit_parts(left_part, right_part);
+                if ordering != Ordering::Equal {
+                    return ordering;
+                }
+            }
+            (Some((left_part, false, next_left)), Some((right_part, false, next_right))) => {
+                left_index = next_left;
+                right_index = next_right;
+                let ordering = left_part
+                    .to_ascii_lowercase()
+                    .cmp(&right_part.to_ascii_lowercase());
+                if ordering != Ordering::Equal {
+                    return ordering;
+                }
+            }
+            (Some((_, true, _)), Some((_, false, _))) => return Ordering::Less,
+            (Some((_, false, _)), Some((_, true, _))) => return Ordering::Greater,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (None, None) => return Ordering::Equal,
+        }
+    }
+}
+
+fn next_natural_part(value: &str, start: usize) -> Option<(&str, bool, usize)> {
+    if start >= value.len() {
+        return None;
+    }
+
+    let bytes = value.as_bytes();
+    let is_digit = bytes[start].is_ascii_digit();
+    let mut end = start + 1;
+
+    while end < bytes.len() && bytes[end].is_ascii_digit() == is_digit {
+        end += 1;
+    }
+
+    Some((&value[start..end], is_digit, end))
+}
+
+fn compare_digit_parts(left: &str, right: &str) -> Ordering {
+    let left_trimmed = left.trim_start_matches('0');
+    let right_trimmed = right.trim_start_matches('0');
+    let left_normalized = if left_trimmed.is_empty() {
+        "0"
+    } else {
+        left_trimmed
+    };
+    let right_normalized = if right_trimmed.is_empty() {
+        "0"
+    } else {
+        right_trimmed
+    };
+
+    left_normalized
+        .len()
+        .cmp(&right_normalized.len())
+        .then_with(|| left_normalized.cmp(right_normalized))
+}
+
+fn normalize_package_manager(package_manager: &str) -> Option<&'static str> {
+    let normalized = package_manager.to_ascii_lowercase();
+
+    if normalized.starts_with("bun") {
+        return Some("bun");
+    }
+
+    if normalized.starts_with("pnpm") {
+        return Some("pnpm");
+    }
+
+    if normalized.starts_with("yarn") {
+        return Some("yarn");
+    }
+
+    if normalized.starts_with("npm") {
+        return Some("npm");
+    }
+
+    None
+}
+
+fn build_lockfile_warnings(
+    selected_lockfile: &Lockfile,
+    ignored_lockfiles: &[Lockfile],
+    package_manager: &str,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    if ignored_lockfiles.is_empty() {
+        if selected_lockfile.kind == LockfileKind::Bun {
+            warnings.push(unsupported_bun_lockfile_warning(selected_lockfile));
+        }
+        return warnings;
+    }
+
+    let selected_name = basename(&selected_lockfile.file_path);
+    let ignored_names = ignored_lockfiles
+        .iter()
+        .map(|lockfile| basename(&lockfile.file_path))
+        .collect::<Vec<_>>();
+    let package_manager_text = if !package_manager.is_empty() && package_manager != "unknown" {
+        format!(r#" based on package manager "{package_manager}""#)
+    } else {
+        String::new()
+    };
+
+    warnings.push(format!(
+        "Multiple lockfiles detected. Duplicate analysis used {selected_name}{package_manager_text} and ignored {}.",
+        ignored_names.join(", ")
+    ));
+
+    if selected_lockfile.kind == LockfileKind::Bun {
+        warnings.push(unsupported_bun_lockfile_warning(selected_lockfile));
+    }
+
+    warnings
+}
+
+fn basename(file_path: &Path) -> String {
+    file_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn starts_with_ascii_alpha(value: &str) -> bool {
+    value
+        .chars()
+        .next()
+        .map(|character| character.is_ascii_alphabetic())
+        .unwrap_or(false)
+}
+
+fn strip_wrapping_quotes(value: &str) -> &str {
+    let trimmed_prefix = value.strip_prefix('"').unwrap_or(value);
+    trimmed_prefix
+        .strip_suffix('"')
+        .unwrap_or(trimmed_prefix)
+}
+
+fn unsupported_bun_lockfile_warning(lockfile: &Lockfile) -> String {
+    format!(
+        "Detected {}, but duplicate analysis does not yet parse Bun lockfiles, so results may be incomplete.",
+        basename(&lockfile.file_path)
+    )
 }

--- a/crates/legolas-core/tests/lockfiles.rs
+++ b/crates/legolas-core/tests/lockfiles.rs
@@ -1,0 +1,396 @@
+mod support;
+
+use std::{fs, process::Command};
+
+use legolas_core::{
+    lockfiles::{parse_duplicate_packages, DuplicateAnalysis},
+    DuplicatePackage,
+};
+use serde_json::json;
+use tempfile::tempdir;
+
+#[test]
+fn parses_npm_v3_duplicates_from_the_packages_section() {
+    let fixture = support::fixture_path("tests/fixtures/lockfiles/npm-v3");
+
+    let analysis = parse_duplicate_packages(&fixture, "npm").expect("parse npm v3 lockfile");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![
+                duplicate("@scope/pkg", &["1.0.0", "1.2.0"]),
+                duplicate("lodash", &["4.17.20", "4.17.21"]),
+            ],
+            warnings: vec![],
+        }
+    );
+}
+
+#[test]
+fn parses_npm_v1_duplicates_from_dependency_trees_and_sorts_versions_naturally() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let package_lock_path = temp_dir.path().join("package-lock.json");
+
+    fs::write(
+        &package_lock_path,
+        r#"{
+  "name": "npm-v1-fixture",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "alpha": {
+      "version": "1.0.0",
+      "dependencies": {
+        "shared": {
+          "version": "1.2.10"
+        },
+        "left-pad": {
+          "version": "1.0.1"
+        }
+      }
+    },
+    "beta": {
+      "version": "2.0.0",
+      "dependencies": {
+        "shared": {
+          "version": "1.2.2"
+        }
+      }
+    },
+    "shared": {
+      "version": "1.2.0"
+    },
+    "left-pad": {
+      "version": "1.0.0"
+    }
+  }
+}"#,
+    )
+    .expect("write npm v1 fixture");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "unknown").expect("parse npm v1");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![
+                DuplicatePackage {
+                    name: "shared".to_string(),
+                    versions: vec![
+                        "1.2.0".to_string(),
+                        "1.2.2".to_string(),
+                        "1.2.10".to_string(),
+                    ],
+                    count: 3,
+                    estimated_extra_kb: 36,
+                },
+                duplicate("left-pad", &["1.0.0", "1.0.1"]),
+            ],
+            warnings: vec![],
+        }
+    );
+}
+
+#[test]
+fn parses_pnpm_duplicates_from_packages_and_snapshots_sections() {
+    let fixture = support::fixture_path("tests/fixtures/lockfiles/pnpm-basic");
+
+    let analysis = parse_duplicate_packages(&fixture, "pnpm@9.0.0").expect("parse pnpm lockfile");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![duplicate("lodash", &["4.17.20", "4.17.21"])],
+            warnings: vec![],
+        }
+    );
+}
+
+#[test]
+fn parses_yarn_berry_entries_with_version_colons() {
+    let fixture = support::fixture_path("tests/fixtures/lockfiles/yarn-berry");
+
+    let analysis = parse_duplicate_packages(&fixture, "yarn@4.1.1").expect("parse yarn berry");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![duplicate("lodash", &["4.17.20", "4.17.21"])],
+            warnings: vec![],
+        }
+    );
+}
+
+#[test]
+fn parses_yarn_aliases_as_the_underlying_package_name() {
+    let fixture = support::fixture_path("tests/fixtures/lockfiles/yarn-alias");
+
+    let analysis = parse_duplicate_packages(&fixture, "yarn").expect("parse yarn alias lockfile");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![duplicate("react", &["18.2.0", "18.3.1"])],
+            warnings: vec![],
+        }
+    );
+}
+
+#[test]
+fn parses_yarn_entries_with_one_sided_quotes_like_the_js_parser() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let yarn_lock_path = temp_dir.path().join("yarn.lock");
+
+    fs::write(
+        &yarn_lock_path,
+        r#""lodash@npm:^4.17.20:
+  version "4.17.20"
+
+lodash@npm:^4.17.21:
+  version "4.17.21"
+"#,
+    )
+    .expect("write yarn lockfile");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "yarn").expect("parse yarn lockfile");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![duplicate("lodash", &["4.17.20", "4.17.21"])],
+            warnings: vec![],
+        }
+    );
+}
+
+#[test]
+fn warns_when_bun_lockfile_is_selected_because_parsing_is_not_supported() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let bun_lockb_path = temp_dir.path().join("bun.lockb");
+
+    fs::write(&bun_lockb_path, [0_u8, 255, 42]).expect("write bun lockb fixture");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "bun@1.1.8").expect("parse bun lockfile");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![],
+            warnings: vec![
+                "Detected bun.lockb, but duplicate analysis does not yet parse Bun lockfiles, so results may be incomplete.".to_string(),
+            ],
+        }
+    );
+}
+
+#[test]
+fn prefers_text_bun_lock_when_both_bun_lockfiles_exist() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let bun_lock_path = temp_dir.path().join("bun.lock");
+    let bun_lockb_path = temp_dir.path().join("bun.lockb");
+
+    fs::write(&bun_lock_path, "placeholder bun text lock").expect("write bun lock fixture");
+    fs::write(&bun_lockb_path, [0_u8, 255, 42]).expect("write bun lockb fixture");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "bun@1.2.0").expect("parse bun lockfiles");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![],
+            warnings: vec![
+                "Multiple lockfiles detected. Duplicate analysis used bun.lock based on package manager \"bun@1.2.0\" and ignored bun.lockb.".to_string(),
+                "Detected bun.lock, but duplicate analysis does not yet parse Bun lockfiles, so results may be incomplete.".to_string(),
+            ],
+        }
+    );
+}
+
+#[test]
+fn skips_empty_versions_in_package_lock_v3_entries() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let package_lock_path = temp_dir.path().join("package-lock.json");
+
+    fs::write(
+        &package_lock_path,
+        r#"{
+  "name": "npm-v3-empty-version",
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/lodash": {
+      "version": ""
+    },
+    "node_modules/example/node_modules/lodash": {
+      "version": "4.17.21"
+    }
+  }
+}"#,
+    )
+    .expect("write package lockfile");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "npm").expect("parse npm v3");
+
+    assert_eq!(analysis, DuplicateAnalysis::default());
+}
+
+#[test]
+fn skips_empty_versions_in_package_lock_v1_dependencies() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let package_lock_path = temp_dir.path().join("package-lock.json");
+
+    fs::write(
+        &package_lock_path,
+        r#"{
+  "name": "npm-v1-empty-version",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "lodash": {
+      "version": ""
+    },
+    "example": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21"
+        }
+      }
+    }
+  }
+}"#,
+    )
+    .expect("write package lockfile");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "npm").expect("parse npm v1");
+
+    assert_eq!(analysis, DuplicateAnalysis::default());
+}
+
+#[test]
+fn sorts_versions_like_js_locale_compare_numeric() {
+    let input_versions = vec![
+        "1",
+        "01",
+        "1.0.0",
+        "1.0.00",
+        "1.2.0",
+        "1.02.0",
+        "1.2.2",
+        "1.2.10",
+        "a1",
+        "A1",
+    ];
+    let temp_dir = tempdir().expect("create temp dir");
+    let package_lock_path = temp_dir.path().join("package-lock.json");
+    let packages = input_versions
+        .iter()
+        .enumerate()
+        .map(|(index, version)| {
+            (
+                format!("node_modules/pkg-{index}/node_modules/shared"),
+                json!({ "version": version }),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
+
+    fs::write(
+        &package_lock_path,
+        serde_json::to_string_pretty(&json!({
+            "name": "npm-v3-version-sort",
+            "lockfileVersion": 3,
+            "packages": packages,
+        }))
+        .expect("serialize package lockfile"),
+    )
+    .expect("write package lockfile");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "npm").expect("parse npm v3");
+    let expected_versions = load_js_sorted_versions(&input_versions);
+
+    assert_eq!(
+        analysis.duplicates,
+        vec![DuplicatePackage {
+            name: "shared".to_string(),
+            versions: expected_versions,
+            count: input_versions.len(),
+            estimated_extra_kb: 162,
+        }]
+    );
+}
+
+#[test]
+fn prefers_the_package_manager_lockfile_and_warns_about_the_rest() {
+    let fixture = support::fixture_path("tests/fixtures/lockfiles/multi-lockfiles");
+
+    let analysis =
+        parse_duplicate_packages(&fixture, "pnpm@9.0.0").expect("parse preferred lockfile");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![duplicate("kleur", &["4.1.4", "4.1.5"])],
+            warnings: vec![
+                "Multiple lockfiles detected. Duplicate analysis used pnpm-lock.yaml based on package manager \"pnpm@9.0.0\" and ignored package-lock.json.".to_string(),
+            ],
+        }
+    );
+}
+
+#[test]
+fn falls_back_to_default_lockfile_priority_when_package_manager_is_unknown() {
+    let fixture = support::fixture_path("tests/fixtures/lockfiles/multi-lockfiles");
+
+    let analysis = parse_duplicate_packages(&fixture, "unknown").expect("parse default lockfile");
+
+    assert_eq!(
+        analysis,
+        DuplicateAnalysis {
+            duplicates: vec![duplicate("left-pad", &["1.0.0", "1.1.0"])],
+            warnings: vec![
+                "Multiple lockfiles detected. Duplicate analysis used package-lock.json and ignored pnpm-lock.yaml.".to_string(),
+            ],
+        }
+    );
+}
+
+#[test]
+fn returns_empty_results_when_no_supported_lockfile_exists() {
+    let temp_dir = tempdir().expect("create temp dir");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "unknown").expect("parse empty dir");
+
+    assert_eq!(analysis, DuplicateAnalysis::default());
+}
+
+fn duplicate(name: &str, versions: &[&str]) -> DuplicatePackage {
+    DuplicatePackage {
+        name: name.to_string(),
+        versions: versions.iter().map(|value| (*value).to_string()).collect(),
+        count: versions.len(),
+        estimated_extra_kb: usize::max((versions.len().saturating_sub(1)) * 18, 18),
+    }
+}
+
+fn load_js_sorted_versions(input_versions: &[&str]) -> Vec<String> {
+    let payload = serde_json::to_string(input_versions).expect("serialize version payload");
+    let script = format!(
+        r#"
+const versions = {payload};
+versions.sort((left, right) => left.localeCompare(right, undefined, {{ numeric: true, sensitivity: "base" }}));
+console.log(JSON.stringify(versions));
+"#
+    );
+
+    let output = Command::new("node")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .expect("run node for JS version sort");
+
+    assert!(
+        output.status.success(),
+        "node version sort exited unsuccessfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("parse JS-sorted versions")
+}

--- a/tests/fixtures/lockfiles/multi-lockfiles/package-lock.json
+++ b/tests/fixtures/lockfiles/multi-lockfiles/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "multi-lockfiles-fixture",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "multi-lockfiles-fixture",
+      "version": "1.0.0"
+    },
+    "node_modules/left-pad": {
+      "version": "1.0.0"
+    },
+    "node_modules/tooling/node_modules/left-pad": {
+      "version": "1.1.0"
+    }
+  }
+}

--- a/tests/fixtures/lockfiles/multi-lockfiles/package.json
+++ b/tests/fixtures/lockfiles/multi-lockfiles/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "multi-lockfiles-fixture",
+  "packageManager": "pnpm@9.0.0"
+}

--- a/tests/fixtures/lockfiles/multi-lockfiles/pnpm-lock.yaml
+++ b/tests/fixtures/lockfiles/multi-lockfiles/pnpm-lock.yaml
@@ -1,0 +1,7 @@
+lockfileVersion: '9.0'
+
+packages:
+  /kleur@4.1.4:
+    resolution: {integrity: sha512-a}
+  /kleur@4.1.5:
+    resolution: {integrity: sha512-b}

--- a/tests/fixtures/lockfiles/npm-v3/package-lock.json
+++ b/tests/fixtures/lockfiles/npm-v3/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "npm-v3-fixture",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "npm-v3-fixture",
+      "version": "1.0.0"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.20"
+    },
+    "node_modules/react": {
+      "version": "18.2.0"
+    },
+    "node_modules/foo/node_modules/lodash": {
+      "version": "4.17.21"
+    },
+    "node_modules/@scope/pkg": {
+      "version": "1.0.0"
+    },
+    "node_modules/bar/node_modules/@scope/pkg": {
+      "version": "1.2.0"
+    },
+    "node_modules/left-pad": {
+      "resolved": "https://example.test/left-pad.tgz"
+    }
+  }
+}

--- a/tests/fixtures/lockfiles/pnpm-basic/package.json
+++ b/tests/fixtures/lockfiles/pnpm-basic/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-basic-fixture",
+  "packageManager": "pnpm@9.0.0"
+}

--- a/tests/fixtures/lockfiles/pnpm-basic/pnpm-lock.yaml
+++ b/tests/fixtures/lockfiles/pnpm-basic/pnpm-lock.yaml
@@ -1,0 +1,20 @@
+lockfileVersion: '9.0'
+
+packages:
+  '/lodash@4.17.20':
+    resolution: {integrity: sha512-a}
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-b}
+  /react-dom@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-c}
+
+snapshots:
+  /kleur@4.1.4:
+    dependencies: {}
+  /lodash@4.17.21:
+    dependencies: {}
+
+importers:
+  .:
+    dependencies:
+      lodash: 4.17.21

--- a/tests/fixtures/lockfiles/yarn-alias/package.json
+++ b/tests/fixtures/lockfiles/yarn-alias/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "yarn-alias-fixture",
+  "packageManager": "yarn@4.1.1"
+}

--- a/tests/fixtures/lockfiles/yarn-alias/yarn.lock
+++ b/tests/fixtures/lockfiles/yarn-alias/yarn.lock
@@ -1,0 +1,11 @@
+"app-react@npm:react@18.2.0":
+  version: "18.2.0"
+  resolution: "react@npm:18.2.0"
+
+"app-react@npm:react@18.3.1":
+  version: "18.3.1"
+  resolution: "react@npm:18.3.1"
+
+"chalk@npm:^5.0.0":
+  version "5.3.0"
+  resolution "chalk@npm:5.3.0"

--- a/tests/fixtures/lockfiles/yarn-berry/package.json
+++ b/tests/fixtures/lockfiles/yarn-berry/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "yarn-berry-fixture",
+  "packageManager": "yarn@4.1.1"
+}

--- a/tests/fixtures/lockfiles/yarn-berry/yarn.lock
+++ b/tests/fixtures/lockfiles/yarn-berry/yarn.lock
@@ -1,0 +1,15 @@
+__metadata:
+  version: 8
+  cacheKey: 10
+
+"lodash@npm:^4.17.20":
+  version: "4.17.20"
+  resolution: "lodash@npm:4.17.20"
+
+"lodash@npm:^4.17.21":
+  version: "4.17.21"
+  resolution: "lodash@npm:4.17.21"
+
+"react@npm:^18.2.0":
+  version: "18.2.0"
+  resolution: "react@npm:18.2.0"


### PR DESCRIPTION
## Summary
- port duplicate lockfile parsing for npm, pnpm, and Yarn into Rust
- add fixture-backed integration coverage for parser behavior and warning selection
- validate the Rust workspace with cargo tests

## Validation
- cargo test -p legolas-core --test lockfiles
- cargo test --workspace