### PR TITLE
feat: Rust analyze parity 파이프라인 구현

### DIFF
--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -1,41 +1,301 @@
 use std::{
-    path::{Path, PathBuf},
-    process::Command,
+    fs,
+    path::Path,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use crate::{error::Result, models::Analysis, LegolasError};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde_json::Value;
+
+use crate::{
+    error::Result,
+    impact::estimate_impact,
+    import_scanner::{collect_source_files, scan_imports, SourceAnalysis},
+    lockfiles::parse_duplicate_packages,
+    models::{
+        Analysis, HeavyDependency, LazyLoadCandidate, Metadata, PackageSummary, SourceSummary,
+        TreeShakingWarning, UnusedDependencyCandidate,
+    },
+    package_intelligence::get_package_intel,
+    project_shape::{detect_frameworks, detect_package_manager},
+    workspace::{find_project_root, read_json_if_exists},
+    LegolasError,
+};
+
+static CANDIDATE_FILES_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)(modal|chart|editor|map|viewer|dashboard|settings|admin|page|route|dialog|drawer|popover)")
+        .expect("valid candidate files regex")
+});
+
+const KNOWN_BUNDLE_ARTIFACTS: [&str; 5] = [
+    "stats.json",
+    "dist/stats.json",
+    "build/stats.json",
+    "meta.json",
+    "dist/meta.json",
+];
 
 pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
-    let repo_root = workspace_root();
-    let output = Command::new("node")
-        .arg(repo_root.join("bin/legolas.js"))
-        .arg("scan")
-        .arg(input_path.as_ref())
-        .arg("--json")
-        .current_dir(&repo_root)
-        .output()?;
+    let project_root = find_project_root(input_path)?;
+    let manifest: Value = read_json_if_exists(project_root.join("package.json"))?.ok_or_else(|| {
+        LegolasError::PackageJsonMissing(project_root.display().to_string())
+    })?;
 
-    if !output.status.success() {
-        return Err(LegolasError::CliUsage(extract_error_message(
-            &output.stderr,
-        )));
+    let package_manager = detect_package_manager(&project_root, &manifest)?;
+    let frameworks = detect_frameworks(&project_root, &manifest)?;
+    let source_files = collect_source_files(&project_root)?;
+    let source_analysis = scan_imports(&project_root, &source_files)?;
+    let duplicate_analysis = parse_duplicate_packages(&project_root, &package_manager)?;
+    let heavy_dependencies = build_heavy_dependency_report(&manifest, &source_analysis);
+    let lazy_load_candidates = build_lazy_load_candidates(&source_analysis, &heavy_dependencies);
+    let tree_shaking_warnings = build_tree_shaking_warnings(&source_analysis);
+    let bundle_artifacts = detect_bundle_artifacts(&project_root)?;
+    let impact = estimate_impact(
+        &heavy_dependencies,
+        &duplicate_analysis.duplicates,
+        &lazy_load_candidates,
+        &tree_shaking_warnings,
+    );
+
+    Ok(Analysis {
+        project_root: project_root.to_string_lossy().to_string(),
+        package_manager,
+        frameworks,
+        bundle_artifacts: bundle_artifacts.clone(),
+        package_summary: build_package_summary(&manifest),
+        source_summary: SourceSummary {
+            files_scanned: source_files.len(),
+            imported_packages: source_analysis.imported_packages.len(),
+            dynamic_imports: source_analysis.dynamic_import_count,
+        },
+        heavy_dependencies,
+        duplicate_packages: duplicate_analysis.duplicates,
+        lazy_load_candidates,
+        tree_shaking_warnings,
+        unused_dependency_candidates: build_unused_dependency_candidates(&manifest, &source_analysis),
+        warnings: duplicate_analysis.warnings,
+        impact,
+        metadata: Metadata {
+            mode: if bundle_artifacts.is_empty() {
+                "heuristic".to_string()
+            } else {
+                "artifact-assisted".to_string()
+            },
+            generated_at: generated_at_string(),
+        },
+    })
+}
+
+fn build_package_summary(manifest: &Value) -> PackageSummary {
+    PackageSummary {
+        name: manifest
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown-project")
+            .to_string(),
+        dependency_count: manifest
+            .get("dependencies")
+            .and_then(Value::as_object)
+            .map(|entries| entries.len())
+            .unwrap_or(0),
+        dev_dependency_count: manifest
+            .get("devDependencies")
+            .and_then(Value::as_object)
+            .map(|entries| entries.len())
+            .unwrap_or(0),
+    }
+}
+
+fn build_heavy_dependency_report(
+    manifest: &Value,
+    source_analysis: &SourceAnalysis,
+) -> Vec<HeavyDependency> {
+    let mut heavy_dependencies = Vec::new();
+
+    for (name, version_range) in merged_dependency_entries(manifest) {
+        let Some(intel) = get_package_intel(&name) else {
+            continue;
+        };
+
+        let import_info = source_analysis.by_package.get(&name);
+        heavy_dependencies.push(HeavyDependency {
+            name,
+            version_range,
+            estimated_kb: intel.estimated_kb,
+            category: intel.category.to_string(),
+            rationale: intel.rationale.to_string(),
+            recommendation: intel.recommendation.to_string(),
+            imported_by: import_info.map(|item| item.files.clone()).unwrap_or_default(),
+            dynamic_imported_by: import_info
+                .map(|item| item.dynamic_files.clone())
+                .unwrap_or_default(),
+            import_count: import_info.map(|item| item.files.len()).unwrap_or(0),
+        });
     }
 
-    Ok(serde_json::from_slice(&output.stdout)?)
+    heavy_dependencies.sort_by(|left, right| right.estimated_kb.cmp(&left.estimated_kb));
+    heavy_dependencies
 }
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|path| path.parent())
-        .expect("workspace root")
-        .to_path_buf()
+fn merged_dependency_entries(manifest: &Value) -> Vec<(String, String)> {
+    let mut entries = Vec::new();
+
+    for field in ["dependencies", "optionalDependencies"] {
+        let Some(values) = manifest.get(field).and_then(Value::as_object) else {
+            continue;
+        };
+
+        for (name, version_range) in values {
+            let Some(version_range) = version_range.as_str() else {
+                continue;
+            };
+
+            if let Some((_, existing_range)) =
+                entries.iter_mut().find(|(existing_name, _)| existing_name == name)
+            {
+                *existing_range = version_range.to_string();
+                continue;
+            }
+
+            entries.push((name.clone(), version_range.to_string()));
+        }
+    }
+
+    entries
 }
 
-fn extract_error_message(stderr: &[u8]) -> String {
-    let message = String::from_utf8_lossy(stderr).trim().to_string();
-    message
-        .strip_prefix("legolas: ")
-        .map(ToOwned::to_owned)
-        .unwrap_or(message)
+fn build_lazy_load_candidates(
+    source_analysis: &SourceAnalysis,
+    heavy_dependencies: &[HeavyDependency],
+) -> Vec<LazyLoadCandidate> {
+    let heavy_by_name = heavy_dependencies
+        .iter()
+        .map(|item| (item.name.as_str(), item))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let mut candidates = Vec::new();
+
+    for imported_package in &source_analysis.imported_packages {
+        let Some(heavy) = heavy_by_name.get(imported_package.name.as_str()) else {
+            continue;
+        };
+
+        let split_friendly_files = imported_package
+            .static_files
+            .iter()
+            .filter(|file| CANDIDATE_FILES_PATTERN.is_match(file))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if split_friendly_files.is_empty() || !imported_package.dynamic_files.is_empty() {
+            continue;
+        }
+
+        candidates.push(LazyLoadCandidate {
+            name: imported_package.name.clone(),
+            estimated_savings_kb: (heavy.estimated_kb as f64 * 0.75).round() as usize,
+            recommendation: heavy.recommendation.clone(),
+            files: split_friendly_files,
+            reason: format!(
+                "{} is statically imported in UI surfaces that usually tolerate lazy loading",
+                imported_package.name
+            ),
+        });
+    }
+
+    candidates.sort_by(|left, right| right.estimated_savings_kb.cmp(&left.estimated_savings_kb));
+    candidates
+}
+
+fn build_tree_shaking_warnings(source_analysis: &SourceAnalysis) -> Vec<TreeShakingWarning> {
+    let mut warnings = source_analysis.tree_shaking_warnings.clone();
+    warnings.sort_by(|left, right| right.estimated_kb.cmp(&left.estimated_kb));
+    warnings
+}
+
+fn build_unused_dependency_candidates(
+    manifest: &Value,
+    source_analysis: &SourceAnalysis,
+) -> Vec<UnusedDependencyCandidate> {
+    let used_packages = source_analysis
+        .imported_packages
+        .iter()
+        .map(|item| item.name.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut candidates = Vec::new();
+
+    if let Some(entries) = manifest.get("dependencies").and_then(Value::as_object) {
+        for (name, version_range) in entries {
+            let Some(version_range) = version_range.as_str() else {
+                continue;
+            };
+
+            if used_packages.contains(name.as_str()) {
+                continue;
+            }
+
+            candidates.push(UnusedDependencyCandidate {
+                name: name.clone(),
+                version_range: version_range.to_string(),
+            });
+        }
+    }
+
+    candidates.sort_by(|left, right| left.name.cmp(&right.name));
+    candidates
+}
+
+fn detect_bundle_artifacts(project_root: &Path) -> Result<Vec<String>> {
+    let mut detected = Vec::new();
+
+    for relative_path in KNOWN_BUNDLE_ARTIFACTS {
+        let absolute_path = project_root.join(relative_path);
+        if let Ok(metadata) = fs::metadata(&absolute_path) {
+            if metadata.is_file() {
+                detected.push(relative_path.to_string());
+            }
+        }
+    }
+
+    Ok(detected)
+}
+
+fn generated_at_string() -> String {
+    format_iso8601_utc(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default(),
+    )
+}
+
+fn format_iso8601_utc(duration: Duration) -> String {
+    let total_seconds = duration.as_secs() as i64;
+    let milliseconds = duration.subsec_millis();
+    let days = total_seconds.div_euclid(86_400);
+    let seconds_of_day = total_seconds.rem_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    let hour = seconds_of_day / 3_600;
+    let minute = (seconds_of_day % 3_600) / 60;
+    let second = seconds_of_day % 60;
+
+    format!(
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{milliseconds:03}Z"
+    )
+}
+
+fn civil_from_days(days_since_unix_epoch: i64) -> (i32, u32, u32) {
+    // Convert Unix days to Gregorian UTC using Howard Hinnant's civil date algorithm.
+    let z = days_since_unix_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    let normalized_year = year + if month <= 2 { 1 } else { 0 };
+
+    (normalized_year as i32, month as u32, day as u32)
 }

--- a/crates/legolas-core/tests/analyze_parity.rs
+++ b/crates/legolas-core/tests/analyze_parity.rs
@@ -1,6 +1,10 @@
 mod support;
 
+use std::{fs, path::Path};
+
 use legolas_core::analyze_project;
+use regex::Regex;
+use tempfile::tempdir;
 
 #[test]
 fn analyze_project_matches_the_parity_oracle() {
@@ -10,4 +14,106 @@ fn analyze_project_matches_the_parity_oracle() {
     let expected = support::read_oracle("basic-app/scan.json");
 
     assert_eq!(actual, expected);
+}
+
+#[test]
+fn analyze_project_switches_to_artifact_assisted_mode_only_for_real_files() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "artifact-app",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}"#,
+    );
+    write_file(root, "src/App.ts", "export const App = () => null;\n");
+    write_file(root, "dist/stats.json", "{}\n");
+
+    let analysis = analyze_project(root).expect("analyze project");
+
+    assert_eq!(analysis.metadata.mode, "artifact-assisted");
+    assert_eq!(analysis.bundle_artifacts, vec!["dist/stats.json".to_string()]);
+}
+
+#[test]
+fn analyze_project_unused_dependency_candidates_ignore_dev_dependencies() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "unused-deps-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0"
+  }
+}"#,
+    );
+    write_file(root, "src/App.ts", "import { chunk } from \"lodash\";\n");
+
+    let analysis = analyze_project(root).expect("analyze project");
+
+    assert_eq!(
+        analysis
+            .unused_dependency_candidates
+            .iter()
+            .map(|item| (item.name.as_str(), item.version_range.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("chart.js", "^4.4.1")]
+    );
+}
+
+#[test]
+fn analyze_project_dedupes_dependencies_shadowed_by_optional_dependencies() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "optional-shadow-app",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "optionalDependencies": {
+    "lodash": "^4.17.20"
+  }
+}"#,
+    );
+    write_file(root, "src/App.ts", "import _ from \"lodash\";\n");
+
+    let analysis = analyze_project(root).expect("analyze project");
+
+    assert_eq!(analysis.heavy_dependencies.len(), 1);
+    assert_eq!(analysis.heavy_dependencies[0].name, "lodash");
+    assert_eq!(analysis.heavy_dependencies[0].version_range, "^4.17.20");
+    assert_eq!(analysis.impact.potential_kb_saved, 39);
+}
+
+#[test]
+fn analyze_project_emits_iso_8601_generated_at_metadata() {
+    let analysis = analyze_project(support::fixture_path("tests/fixtures/parity/basic-app"))
+        .expect("analyze parity fixture");
+    let iso8601_utc =
+        Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$").expect("valid regex");
+
+    assert!(iso8601_utc.is_match(&analysis.metadata.generated_at));
+}
+
+fn write_file(root: &Path, relative_path: &str, contents: &str) {
+    let path = root.join(relative_path);
+    let parent = path.parent().expect("fixture file parent");
+    fs::create_dir_all(parent).expect("create fixture directory");
+    fs::write(path, contents).expect("write fixture file");
 }


### PR DESCRIPTION
## 요약
- Node bridge를 제거하고 Rust analyze pipeline을 실제로 조립했습니다.
- `dependencies`와 `optionalDependencies` merge semantics를 JS parity에 맞췄습니다.
- artifact mode, unused dependency, optional shadowing 회귀 테스트를 추가했습니다.

## 검증
- cargo test -p legolas-core --test analyze_parity
- cargo test --workspace