### PR TITLE
test: Rust CLI contract 회귀 검증 강화

### DIFF
--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -4,34 +4,38 @@ use assert_cmd::Command;
 
 #[test]
 fn prints_version_without_a_command() {
-    let output = Command::cargo_bin("legolas-cli")
-        .expect("build binary")
-        .arg("--version")
-        .output()
-        .expect("run --version");
+    for args in [vec!["--version"], vec!["-v"]] {
+        let output = Command::cargo_bin("legolas-cli")
+            .expect("build binary")
+            .args(args)
+            .output()
+            .expect("run version");
 
-    assert!(output.status.success());
-    assert_eq!(
-        support::normalize_cli_output(&String::from_utf8(output.stdout).expect("stdout")),
-        support::read_oracle("cli/version.txt")
-    );
-    assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
+        assert!(output.status.success());
+        assert_eq!(
+            support::normalize_cli_output(&String::from_utf8(output.stdout).expect("stdout")),
+            support::read_oracle("cli/version.txt")
+        );
+        assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
+    }
 }
 
 #[test]
-fn prints_help_when_requested() {
-    let output = Command::cargo_bin("legolas-cli")
-        .expect("build binary")
-        .arg("help")
-        .output()
-        .expect("run help");
+fn prints_help_for_empty_command_and_help_variants() {
+    for args in [Vec::<&str>::new(), vec!["help"], vec!["--help"], vec!["-h"]] {
+        let output = Command::cargo_bin("legolas-cli")
+            .expect("build binary")
+            .args(args)
+            .output()
+            .expect("run help");
 
-    assert!(output.status.success());
-    assert_eq!(
-        support::normalize_cli_output(&String::from_utf8(output.stdout).expect("stdout")),
-        support::read_oracle("cli/help.txt")
-    );
-    assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
+        assert!(output.status.success());
+        assert_eq!(
+            support::normalize_cli_output(&String::from_utf8(output.stdout).expect("stdout")),
+            support::read_oracle("cli/help.txt")
+        );
+        assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
+    }
 }
 
 #[test]
@@ -69,6 +73,23 @@ fn matches_scan_visualize_and_optimize_oracles() {
 }
 
 #[test]
+fn matches_scan_json_oracle() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run scan --json");
+
+    assert!(output.status.success());
+    assert_eq!(
+        support::normalize_analysis_json_output(&String::from_utf8(output.stdout).expect("stdout")),
+        support::normalize_analysis_json_output(&support::read_oracle("basic-app/scan.json"))
+    );
+    assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
+}
+
+#[test]
 fn matches_validation_error_oracles() {
     let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
     let cases = [
@@ -100,10 +121,54 @@ fn matches_validation_error_oracles() {
             .expect("run command");
 
         assert!(!output.status.success(), "expected failure for {oracle}");
+        assert_eq!(output.status.code(), Some(1), "expected exit code 1 for {oracle}");
         assert_eq!(String::from_utf8(output.stdout).expect("stdout"), "");
         assert_eq!(
             support::normalize_cli_output(&String::from_utf8(output.stderr).expect("stderr")),
             support::read_oracle(oracle)
+        );
+    }
+}
+
+#[test]
+fn matches_missing_number_and_unknown_flag_contracts() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let cases = [
+        (
+            vec![
+                "visualize".to_string(),
+                fixture.display().to_string(),
+                "--limit".to_string(),
+            ],
+            "legolas: --limit expects a number\n",
+        ),
+        (
+            vec![
+                "optimize".to_string(),
+                fixture.display().to_string(),
+                "--top".to_string(),
+            ],
+            "legolas: --top expects a number\n",
+        ),
+        (
+            vec!["--bogus".to_string()],
+            "legolas: unknown flag \"--bogus\"\n",
+        ),
+    ];
+
+    for (args, expected_stderr) in cases {
+        let output = Command::cargo_bin("legolas-cli")
+            .expect("build binary")
+            .args(args)
+            .output()
+            .expect("run invalid command");
+
+        assert!(!output.status.success());
+        assert_eq!(output.status.code(), Some(1));
+        assert_eq!(String::from_utf8(output.stdout).expect("stdout"), "");
+        assert_eq!(
+            String::from_utf8(output.stderr).expect("stderr"),
+            expected_stderr
         );
     }
 }

--- a/crates/legolas-cli/tests/support/mod.rs
+++ b/crates/legolas-cli/tests/support/mod.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use serde_json::Value;
 
 pub fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -26,6 +27,73 @@ pub fn normalize_cli_output(output: &str) -> String {
         ),
         "<PROJECT_ROOT>",
     )
+}
+
+pub fn normalize_analysis_json_output(output: &str) -> Value {
+    let mut analysis = serde_json::from_str::<Value>(output).expect("parse analysis json");
+    normalize_analysis_value(&mut analysis);
+    analysis
+}
+
+fn normalize_analysis_value(analysis: &mut Value) {
+    replace_string_field(analysis, &["projectRoot"], "<PROJECT_ROOT>");
+    replace_string_field(analysis, &["metadata", "generatedAt"], "<GENERATED_AT>");
+    normalize_string_array(analysis, &["bundleArtifacts"]);
+    normalize_string_array(analysis, &["warnings"]);
+    normalize_object_array_string_field(analysis, &["heavyDependencies"], "importedBy");
+    normalize_object_array_string_field(analysis, &["heavyDependencies"], "dynamicImportedBy");
+    normalize_object_array_string_field(analysis, &["lazyLoadCandidates"], "files");
+    normalize_object_array_string_field(analysis, &["treeShakingWarnings"], "files");
+}
+
+fn replace_string_field(root: &mut Value, path: &[&str], replacement: &str) {
+    let Some(value) = get_path_mut(root, path) else {
+        return;
+    };
+
+    if value.is_string() {
+        *value = Value::String(replacement.to_string());
+    }
+}
+
+fn normalize_string_array(root: &mut Value, path: &[&str]) {
+    let Some(Value::Array(items)) = get_path_mut(root, path) else {
+        return;
+    };
+
+    for item in items {
+        if let Some(value) = item.as_str() {
+            *item = Value::String(to_posix(value.to_string()));
+        }
+    }
+}
+
+fn normalize_object_array_string_field(root: &mut Value, path: &[&str], field: &str) {
+    let Some(Value::Array(items)) = get_path_mut(root, path) else {
+        return;
+    };
+
+    for item in items {
+        let Some(array) = item.get_mut(field).and_then(Value::as_array_mut) else {
+            continue;
+        };
+
+        for entry in array {
+            if let Some(value) = entry.as_str() {
+                *entry = Value::String(to_posix(value.to_string()));
+            }
+        }
+    }
+}
+
+fn get_path_mut<'a>(value: &'a mut Value, path: &[&str]) -> Option<&'a mut Value> {
+    let mut current = value;
+
+    for segment in path {
+        current = current.get_mut(*segment)?;
+    }
+
+    Some(current)
 }
 
 fn to_posix(value: String) -> String {


### PR DESCRIPTION
## 요약
- Rust CLI contract 테스트에 help/version alias와 no-command help 경계를 추가했습니다.
- `scan --json` 출력은 raw `serde_json::Value` 기반 normalized oracle 비교로 고정해 unknown field drift를 놓치지 않게 했습니다.
- invalid argv 케이스에 exit code `1` 검증과 `--top` missing-value 회귀 테스트를 추가했습니다.

## 검증
- cargo test -p legolas-cli --test cli_contract
- cargo test --workspace