### PR TITLE
ci: Rust release pipeline과 vendor staging 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,14 @@ jobs:
 
       - name: Setup Rust toolchain
         run: |
-          rustup toolchain install 1.95.0 --profile minimal
+          rustup toolchain install 1.95.0 --profile minimal --component clippy --component rustfmt
           rustup default 1.95.0
+
+      - name: Check Rust formatting
+        run: cargo fmt --check
+
+      - name: Lint Rust workspace
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Run Rust workspace tests
         run: cargo test --workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,14 @@ permissions:
   id-token: write
 
 jobs:
-  publish:
+  prepare-release:
     if: github.repository == 'JeremyDev87/legolas'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      package_name: ${{ steps.meta.outputs.name }}
+      package_version: ${{ steps.meta.outputs.version }}
+      tag_name: ${{ steps.meta.outputs.tag_name }}
 
     steps:
       - name: Checkout code
@@ -32,6 +36,7 @@ jobs:
         run: |
           echo "name=$(node -p 'require(\"./package.json\").name')" >> "$GITHUB_OUTPUT"
           echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Verify release tag matches package version
         run: |
@@ -72,6 +77,90 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  rust-release-binaries:
+    if: github.repository == 'JeremyDev87/legolas'
+    needs: prepare-release
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_name: legolas
+            asset_name: legolas-x86_64-unknown-linux-gnu
+          - runs-on: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary_name: legolas.exe
+            asset_name: legolas-x86_64-pc-windows-msvc.exe
+          - runs-on: macos-13
+            target: x86_64-apple-darwin
+            binary_name: legolas
+            asset_name: legolas-x86_64-apple-darwin
+          - runs-on: macos-14
+            target: aarch64-apple-darwin
+            binary_name: legolas
+            asset_name: legolas-aarch64-apple-darwin
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "22"
+
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Build Rust release binary
+        run: cargo build --release -p legolas-cli
+
+      - name: Stage vendor layout
+        run: node ./scripts/stage-local-vendor-binary.mjs
+
+      - name: Verify vendor layout
+        run: node ./scripts/verify-vendor-layout.mjs ${{ matrix.target }}
+
+      - name: Copy release asset
+        shell: bash
+        run: |
+          mkdir -p release-assets
+          cp "vendor/${{ matrix.target }}/${{ matrix.binary_name }}" "release-assets/${{ matrix.asset_name }}"
+
+      - name: Upload binary asset to release draft
+        run: gh release upload "${{ needs.prepare-release.outputs.tag_name }}" "release-assets/${{ matrix.asset_name }}" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    if: github.repository == 'JeremyDev87/legolas'
+    needs: [prepare-release, rust-release-binaries]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Read package metadata
+        id: meta
+        run: |
+          echo "name=$(node -p 'require(\"./package.json\").name')" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
 
       - name: Run tests
         run: npm test
@@ -152,7 +241,7 @@ jobs:
 
       - name: Publish GitHub release
         run: |
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          TAG_NAME="${{ needs.prepare-release.outputs.tag_name }}"
           RELEASE_ID="$(gh release view "$TAG_NAME" --json id --jq .id)"
 
           gh api \
@@ -163,6 +252,5 @@ jobs:
             -f make_latest=true \
             -f name="${TAG_NAME}"
         env:
-          GITHUB_REF: ${{ github.ref }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -121,7 +121,11 @@ fn matches_validation_error_oracles() {
             .expect("run command");
 
         assert!(!output.status.success(), "expected failure for {oracle}");
-        assert_eq!(output.status.code(), Some(1), "expected exit code 1 for {oracle}");
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "expected exit code 1 for {oracle}"
+        );
         assert_eq!(String::from_utf8(output.stdout).expect("stdout"), "");
         assert_eq!(
             support::normalize_cli_output(&String::from_utf8(output.stderr).expect("stderr")),

--- a/crates/legolas-cli/tests/support/mod.rs
+++ b/crates/legolas-cli/tests/support/mod.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
 use serde_json::Value;
+use std::path::PathBuf;
 
+#[allow(dead_code)]
 pub fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -9,15 +10,18 @@ pub fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
+#[allow(dead_code)]
 pub fn fixture_path(relative_path: &str) -> PathBuf {
     workspace_root().join(relative_path)
 }
 
+#[allow(dead_code)]
 pub fn read_oracle(relative_path: &str) -> String {
     std::fs::read_to_string(workspace_root().join("tests/oracles").join(relative_path))
         .expect("read oracle")
 }
 
+#[allow(dead_code)]
 pub fn normalize_cli_output(output: &str) -> String {
     to_posix(output.to_string()).replace(
         &to_posix(
@@ -29,12 +33,14 @@ pub fn normalize_cli_output(output: &str) -> String {
     )
 }
 
+#[allow(dead_code)]
 pub fn normalize_analysis_json_output(output: &str) -> Value {
     let mut analysis = serde_json::from_str::<Value>(output).expect("parse analysis json");
     normalize_analysis_value(&mut analysis);
     analysis
 }
 
+#[allow(dead_code)]
 fn normalize_analysis_value(analysis: &mut Value) {
     replace_string_field(analysis, &["projectRoot"], "<PROJECT_ROOT>");
     replace_string_field(analysis, &["metadata", "generatedAt"], "<GENERATED_AT>");
@@ -46,6 +52,7 @@ fn normalize_analysis_value(analysis: &mut Value) {
     normalize_object_array_string_field(analysis, &["treeShakingWarnings"], "files");
 }
 
+#[allow(dead_code)]
 fn replace_string_field(root: &mut Value, path: &[&str], replacement: &str) {
     let Some(value) = get_path_mut(root, path) else {
         return;
@@ -56,6 +63,7 @@ fn replace_string_field(root: &mut Value, path: &[&str], replacement: &str) {
     }
 }
 
+#[allow(dead_code)]
 fn normalize_string_array(root: &mut Value, path: &[&str]) {
     let Some(Value::Array(items)) = get_path_mut(root, path) else {
         return;
@@ -68,6 +76,7 @@ fn normalize_string_array(root: &mut Value, path: &[&str]) {
     }
 }
 
+#[allow(dead_code)]
 fn normalize_object_array_string_field(root: &mut Value, path: &[&str], field: &str) {
     let Some(Value::Array(items)) = get_path_mut(root, path) else {
         return;
@@ -86,6 +95,7 @@ fn normalize_object_array_string_field(root: &mut Value, path: &[&str], field: &
     }
 }
 
+#[allow(dead_code)]
 fn get_path_mut<'a>(value: &'a mut Value, path: &[&str]) -> Option<&'a mut Value> {
     let mut current = value;
 
@@ -96,6 +106,7 @@ fn get_path_mut<'a>(value: &'a mut Value, path: &[&str]) -> Option<&'a mut Value
     Some(current)
 }
 
+#[allow(dead_code)]
 fn to_posix(value: String) -> String {
     value.replace('\\', "/")
 }

--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -25,7 +25,10 @@ fn matches_scan_visualize_and_optimize_oracles() {
         format_visualization_report(&analysis, 10),
         "basic-app/visualize.txt",
     );
-    assert_report_matches_oracle(format_optimize_report(&analysis, 5), "basic-app/optimize.txt");
+    assert_report_matches_oracle(
+        format_optimize_report(&analysis, 5),
+        "basic-app/optimize.txt",
+    );
 }
 
 #[test]
@@ -97,8 +100,7 @@ fn optimize_and_visualize_reports_clamp_zero_limits_and_cover_lazy_load_fallback
         potential_kb_saved: 42,
         estimated_lcp_improvement_ms: 88,
         confidence: "directional".to_string(),
-        summary: "Targeted impact: a handful of focused optimizations should pay off."
-            .to_string(),
+        summary: "Targeted impact: a handful of focused optimizations should pay off.".to_string(),
     };
     optimize_analysis.lazy_load_candidates = vec![LazyLoadCandidate {
         name: "chart.js".to_string(),

--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Reverse,
     fs,
     path::Path,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -38,9 +39,8 @@ const KNOWN_BUNDLE_ARTIFACTS: [&str; 5] = [
 
 pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
     let project_root = find_project_root(input_path)?;
-    let manifest: Value = read_json_if_exists(project_root.join("package.json"))?.ok_or_else(|| {
-        LegolasError::PackageJsonMissing(project_root.display().to_string())
-    })?;
+    let manifest: Value = read_json_if_exists(project_root.join("package.json"))?
+        .ok_or_else(|| LegolasError::PackageJsonMissing(project_root.display().to_string()))?;
 
     let package_manager = detect_package_manager(&project_root, &manifest)?;
     let frameworks = detect_frameworks(&project_root, &manifest)?;
@@ -73,7 +73,10 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
         duplicate_packages: duplicate_analysis.duplicates,
         lazy_load_candidates,
         tree_shaking_warnings,
-        unused_dependency_candidates: build_unused_dependency_candidates(&manifest, &source_analysis),
+        unused_dependency_candidates: build_unused_dependency_candidates(
+            &manifest,
+            &source_analysis,
+        ),
         warnings: duplicate_analysis.warnings,
         impact,
         metadata: Metadata {
@@ -126,7 +129,9 @@ fn build_heavy_dependency_report(
             category: intel.category.to_string(),
             rationale: intel.rationale.to_string(),
             recommendation: intel.recommendation.to_string(),
-            imported_by: import_info.map(|item| item.files.clone()).unwrap_or_default(),
+            imported_by: import_info
+                .map(|item| item.files.clone())
+                .unwrap_or_default(),
             dynamic_imported_by: import_info
                 .map(|item| item.dynamic_files.clone())
                 .unwrap_or_default(),
@@ -134,7 +139,7 @@ fn build_heavy_dependency_report(
         });
     }
 
-    heavy_dependencies.sort_by(|left, right| right.estimated_kb.cmp(&left.estimated_kb));
+    heavy_dependencies.sort_by_key(|item| Reverse(item.estimated_kb));
     heavy_dependencies
 }
 
@@ -151,8 +156,9 @@ fn merged_dependency_entries(manifest: &Value) -> Vec<(String, String)> {
                 continue;
             };
 
-            if let Some((_, existing_range)) =
-                entries.iter_mut().find(|(existing_name, _)| existing_name == name)
+            if let Some((_, existing_range)) = entries
+                .iter_mut()
+                .find(|(existing_name, _)| existing_name == name)
             {
                 *existing_range = version_range.to_string();
                 continue;
@@ -203,13 +209,13 @@ fn build_lazy_load_candidates(
         });
     }
 
-    candidates.sort_by(|left, right| right.estimated_savings_kb.cmp(&left.estimated_savings_kb));
+    candidates.sort_by_key(|item| Reverse(item.estimated_savings_kb));
     candidates
 }
 
 fn build_tree_shaking_warnings(source_analysis: &SourceAnalysis) -> Vec<TreeShakingWarning> {
     let mut warnings = source_analysis.tree_shaking_warnings.clone();
-    warnings.sort_by(|left, right| right.estimated_kb.cmp(&left.estimated_kb));
+    warnings.sort_by_key(|item| Reverse(item.estimated_kb));
     warnings
 }
 
@@ -278,9 +284,7 @@ fn format_iso8601_utc(duration: Duration) -> String {
     let minute = (seconds_of_day % 3_600) / 60;
     let second = seconds_of_day % 60;
 
-    format!(
-        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{milliseconds:03}Z"
-    )
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{milliseconds:03}Z")
 }
 
 fn civil_from_days(days_since_unix_epoch: i64) -> (i32, u32, u32) {

--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -202,7 +202,7 @@ fn ensure_directory_exists(path: &Path) -> Result<()> {
 
 fn walk(current_path: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
     let mut entries = fs::read_dir(current_path)?.collect::<std::io::Result<Vec<_>>>()?;
-    entries.sort_by(|left, right| left.file_name().cmp(&right.file_name()));
+    entries.sort_by_key(|entry| entry.file_name());
 
     for entry in entries {
         let absolute_path = entry.path();

--- a/crates/legolas-core/src/lockfiles.rs
+++ b/crates/legolas-core/src/lockfiles.rs
@@ -156,7 +156,10 @@ fn collect_from_package_lock(package_lock: Option<Value>) -> VersionsByName {
         return versions_by_name;
     };
 
-    if let Some(packages) = package_lock_object.get("packages").and_then(Value::as_object) {
+    if let Some(packages) = package_lock_object
+        .get("packages")
+        .and_then(Value::as_object)
+    {
         if !packages.is_empty() {
             for (package_path, metadata) in packages {
                 let Some(version) = metadata
@@ -526,9 +529,7 @@ fn starts_with_ascii_alpha(value: &str) -> bool {
 
 fn strip_wrapping_quotes(value: &str) -> &str {
     let trimmed_prefix = value.strip_prefix('"').unwrap_or(value);
-    trimmed_prefix
-        .strip_suffix('"')
-        .unwrap_or(trimmed_prefix)
+    trimmed_prefix.strip_suffix('"').unwrap_or(trimmed_prefix)
 }
 
 fn unsupported_bun_lockfile_warning(lockfile: &Lockfile) -> String {

--- a/crates/legolas-core/tests/analyze_parity.rs
+++ b/crates/legolas-core/tests/analyze_parity.rs
@@ -37,7 +37,10 @@ fn analyze_project_switches_to_artifact_assisted_mode_only_for_real_files() {
     let analysis = analyze_project(root).expect("analyze project");
 
     assert_eq!(analysis.metadata.mode, "artifact-assisted");
-    assert_eq!(analysis.bundle_artifacts, vec!["dist/stats.json".to_string()]);
+    assert_eq!(
+        analysis.bundle_artifacts,
+        vec!["dist/stats.json".to_string()]
+    );
 }
 
 #[test]

--- a/crates/legolas-core/tests/lockfiles.rs
+++ b/crates/legolas-core/tests/lockfiles.rs
@@ -170,7 +170,8 @@ fn warns_when_bun_lockfile_is_selected_because_parsing_is_not_supported() {
 
     fs::write(&bun_lockb_path, [0_u8, 255, 42]).expect("write bun lockb fixture");
 
-    let analysis = parse_duplicate_packages(temp_dir.path(), "bun@1.1.8").expect("parse bun lockfile");
+    let analysis =
+        parse_duplicate_packages(temp_dir.path(), "bun@1.1.8").expect("parse bun lockfile");
 
     assert_eq!(
         analysis,
@@ -192,7 +193,8 @@ fn prefers_text_bun_lock_when_both_bun_lockfiles_exist() {
     fs::write(&bun_lock_path, "placeholder bun text lock").expect("write bun lock fixture");
     fs::write(&bun_lockb_path, [0_u8, 255, 42]).expect("write bun lockb fixture");
 
-    let analysis = parse_duplicate_packages(temp_dir.path(), "bun@1.2.0").expect("parse bun lockfiles");
+    let analysis =
+        parse_duplicate_packages(temp_dir.path(), "bun@1.2.0").expect("parse bun lockfiles");
 
     assert_eq!(
         analysis,
@@ -268,16 +270,7 @@ fn skips_empty_versions_in_package_lock_v1_dependencies() {
 #[test]
 fn sorts_versions_like_js_locale_compare_numeric() {
     let input_versions = vec![
-        "1",
-        "01",
-        "1.0.0",
-        "1.0.00",
-        "1.2.0",
-        "1.02.0",
-        "1.2.2",
-        "1.2.10",
-        "a1",
-        "A1",
+        "1", "01", "1.0.0", "1.0.00", "1.2.0", "1.02.0", "1.2.2", "1.2.10", "a1", "A1",
     ];
     let temp_dir = tempdir().expect("create temp dir");
     let package_lock_path = temp_dir.path().join("package-lock.json");

--- a/crates/legolas-core/tests/support/mod.rs
+++ b/crates/legolas-core/tests/support/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use legolas_core::Analysis;
 
+#[allow(dead_code)]
 pub fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -10,15 +11,18 @@ pub fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
+#[allow(dead_code)]
 pub fn fixture_path(relative_path: &str) -> PathBuf {
     workspace_root().join(relative_path)
 }
 
+#[allow(dead_code)]
 pub fn read_oracle(relative_path: &str) -> String {
     std::fs::read_to_string(workspace_root().join("tests/oracles").join(relative_path))
         .expect("read oracle")
 }
 
+#[allow(dead_code)]
 pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
     let mut normalized = analysis.clone();
 
@@ -62,6 +66,7 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
     )
 }
 
+#[allow(dead_code)]
 fn to_posix(value: String) -> String {
     value.replace('\\', "/")
 }

--- a/scripts/stage-local-vendor-binary.mjs
+++ b/scripts/stage-local-vendor-binary.mjs
@@ -1,0 +1,104 @@
+import { chmod, copyFile, mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+const { options } = parseArgs(process.argv.slice(2));
+const vendorRoot = path.resolve(
+  options.vendorDir ?? process.env.LEGOLAS_VENDOR_DIR ?? path.join(projectRoot, "vendor"),
+);
+const hostTriple = readRustHostTriple();
+const stagedBinaryName = stagedBinaryNameForTriple(hostTriple);
+const sourceBinary = path.resolve(
+  options.sourceBinary ??
+    process.env.LEGOLAS_SOURCE_BINARY ??
+    path.join(projectRoot, "target", "release", sourceBinaryNameForTriple(hostTriple)),
+);
+const stagedBinary = path.join(vendorRoot, hostTriple, stagedBinaryName);
+
+await assertFileExists(sourceBinary, `Built binary not found at ${sourceBinary}`);
+await mkdir(path.dirname(stagedBinary), { recursive: true });
+await copyFile(sourceBinary, stagedBinary);
+
+if (!hostTriple.includes("windows")) {
+  await chmod(stagedBinary, 0o755);
+}
+
+console.log(`Staged ${sourceBinary} -> ${stagedBinary}`);
+
+function readRustHostTriple() {
+  const result = spawnSync("rustc", ["-vV"], {
+    cwd: projectRoot,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || "Failed to read rustc host triple.");
+  }
+
+  const hostLine = result.stdout
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("host: "));
+
+  if (!hostLine) {
+    throw new Error("rustc -vV did not include a host triple.");
+  }
+
+  return hostLine.replace(/^host:\s*/, "").trim();
+}
+
+function sourceBinaryNameForTriple(targetTriple) {
+  return targetTriple.includes("windows") ? "legolas-cli.exe" : "legolas-cli";
+}
+
+function stagedBinaryNameForTriple(targetTriple) {
+  return targetTriple.includes("windows") ? "legolas.exe" : "legolas";
+}
+
+async function assertFileExists(filePath, message) {
+  const fileStat = await stat(filePath).catch(() => null);
+
+  if (!fileStat?.isFile()) {
+    throw new Error(message);
+  }
+}
+
+function parseArgs(argv) {
+  const options = {};
+  const positionals = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === "--vendor-dir" || token === "--source-binary") {
+      const next = argv[index + 1];
+      if (!next) {
+        throw new Error(`${token} expects a value.`);
+      }
+
+      if (token === "--vendor-dir") {
+        options.vendorDir = next;
+      } else {
+        options.sourceBinary = next;
+      }
+
+      index += 1;
+      continue;
+    }
+
+    if (token.startsWith("--vendor-dir=")) {
+      options.vendorDir = token.slice("--vendor-dir=".length);
+      continue;
+    }
+
+    if (token.startsWith("--source-binary=")) {
+      options.sourceBinary = token.slice("--source-binary=".length);
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { options, positionals };
+}

--- a/scripts/verify-vendor-layout.mjs
+++ b/scripts/verify-vendor-layout.mjs
@@ -1,0 +1,87 @@
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+const { options, positionals } = parseArgs(process.argv.slice(2));
+const vendorRoot = path.resolve(
+  options.vendorDir ?? process.env.LEGOLAS_VENDOR_DIR ?? path.join(projectRoot, "vendor"),
+);
+
+const vendorEntries = await readdir(vendorRoot, { withFileTypes: true }).catch((error) => {
+  throw new Error(`Unable to read vendor root ${vendorRoot}: ${error.message}`);
+});
+const tripleDirectories = vendorEntries
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+const expectedTriples = positionals.length > 0 ? [...positionals].sort() : tripleDirectories;
+
+if (expectedTriples.length === 0) {
+  throw new Error(`No staged vendor binaries found under ${vendorRoot}.`);
+}
+
+for (const expectedTriple of expectedTriples) {
+  if (!tripleDirectories.includes(expectedTriple)) {
+    throw new Error(`Expected vendor triple ${expectedTriple} under ${vendorRoot}.`);
+  }
+
+  const tripleRoot = path.join(vendorRoot, expectedTriple);
+  const expectedBinary = binaryNameForTriple(expectedTriple);
+  const entries = await readdir(tripleRoot, { withFileTypes: true });
+  const files = entries.filter((entry) => entry.isFile()).map((entry) => entry.name).sort();
+  const nestedDirectories = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+
+  if (nestedDirectories.length > 0) {
+    throw new Error(
+      `Vendor triple ${expectedTriple} should not contain nested directories: ${nestedDirectories.join(", ")}`,
+    );
+  }
+
+  if (files.length !== 1 || files[0] !== expectedBinary) {
+    throw new Error(
+      `Vendor triple ${expectedTriple} must contain exactly ${expectedBinary}, found: ${files.join(", ") || "<empty>"}`,
+    );
+  }
+
+  const binaryPath = path.join(tripleRoot, expectedBinary);
+  const binaryStat = await stat(binaryPath);
+  if (!binaryStat.isFile()) {
+    throw new Error(`Expected staged binary at ${binaryPath}.`);
+  }
+}
+
+console.log(`Validated ${expectedTriples.length} staged vendor ${expectedTriples.length === 1 ? "binary" : "binaries"}.`);
+
+function binaryNameForTriple(targetTriple) {
+  return targetTriple.includes("windows") ? "legolas.exe" : "legolas";
+}
+
+function parseArgs(argv) {
+  const options = {};
+  const positionals = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === "--vendor-dir") {
+      const next = argv[index + 1];
+      if (!next) {
+        throw new Error(`${token} expects a value.`);
+      }
+
+      options.vendorDir = next;
+      index += 1;
+      continue;
+    }
+
+    if (token.startsWith("--vendor-dir=")) {
+      options.vendorDir = token.slice("--vendor-dir=".length);
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { options, positionals };
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,22 @@
+# Vendor Layout
+
+Rust release binaries are staged under `vendor/<triple>/legolas[.exe]`.
+
+Examples:
+
+- `vendor/x86_64-unknown-linux-gnu/legolas`
+- `vendor/x86_64-pc-windows-msvc/legolas.exe`
+- `vendor/x86_64-apple-darwin/legolas`
+- `vendor/aarch64-apple-darwin/legolas`
+
+This directory is intentionally kept empty in git except for this README.
+Release workflows populate it transiently before uploading release assets, and
+the npm cutover later uses the same layout.
+
+Local staging flow:
+
+```bash
+cargo build --release -p legolas-cli
+node ./scripts/stage-local-vendor-binary.mjs --vendor-dir /tmp/legolas-vendor
+node ./scripts/verify-vendor-layout.mjs --vendor-dir /tmp/legolas-vendor
+```


### PR DESCRIPTION
## 요약
- CI에 `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` quality gate를 추가했습니다.
- release workflow를 확장해 플랫폼별 Rust binary를 build하고 `vendor/<triple>/legolas[.exe]` layout으로 stage/verify 후 draft release asset으로 업로드하도록 구성했습니다.
- 로컬 재현용 `stage-local-vendor-binary.mjs`, `verify-vendor-layout.mjs`, `vendor/README.md`를 추가했습니다.
- quality gate를 실제로 켤 수 있도록 기존 Rust 코드의 clippy/fmt baseline도 함께 정리했습니다.

## 검증
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build --release -p legolas-cli
- node ./scripts/stage-local-vendor-binary.mjs --vendor-dir /tmp/legolas-vendor.biFahz
- node ./scripts/verify-vendor-layout.mjs --vendor-dir /tmp/legolas-vendor.biFahz aarch64-apple-darwin