### PR TITLE
feat: npm launcher를 Rust binary로 전환

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-matrix:
-    name: Node ${{ matrix.node-version }} test
+  node-launcher-matrix:
+    name: Node ${{ matrix.node-version }} launcher
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -32,8 +32,27 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Run tests
-        run: npm test
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Build Rust release binary
+        run: cargo build --release -p legolas-cli
+
+      - name: Stage vendor layout
+        run: node ./scripts/stage-local-vendor-binary.mjs
+
+      - name: Verify vendor layout
+        run: node ./scripts/verify-vendor-layout.mjs
+
+      - name: Run launcher platform contract tests
+        run: node --test test/launcher-platform.test.js
+
+      - name: Smoke test packaged launcher
+        run: |
+          node ./bin/legolas.js --version
+          node ./bin/legolas.js help
 
   rust-workspace:
     name: Rust Workspace
@@ -77,8 +96,34 @@ jobs:
         with:
           node-version: "18.17.0"
 
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Build Rust release binary
+        run: cargo build --release -p legolas-cli
+
+      - name: Stage vendor layout
+        run: node ./scripts/stage-local-vendor-binary.mjs
+
+      - name: Verify vendor layout
+        run: node ./scripts/verify-vendor-layout.mjs
+
+      - name: Run Rust workspace tests
+        run: npm test
+
+      - name: Run launcher platform contract tests
+        run: node --test test/launcher-platform.test.js
+
       - name: Smoke test CLI
         run: npm run smoke
+
+      - name: Smoke test packaged launcher
+        run: |
+          node ./bin/legolas.js --version
+          node ./bin/legolas.js help
+          node ./bin/legolas.js scan tests/fixtures/parity/basic-app
 
       - name: Verify package tarball
         run: npm run pack:check
@@ -96,6 +141,20 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "18.17.0"
+
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Build Rust release binary
+        run: cargo build --release -p legolas-cli
+
+      - name: Stage vendor layout
+        run: node ./scripts/stage-local-vendor-binary.mjs
+
+      - name: Verify vendor layout
+        run: node ./scripts/verify-vendor-layout.mjs
 
       - name: Verify package tarball
         run: npm run pack:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
       - name: Read package metadata
         id: meta
         run: |
@@ -42,7 +47,7 @@ jobs:
         run: |
           TAG_NAME="${GITHUB_REF#refs/tags/}"
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          CLI_VERSION="$(node ./bin/legolas.js --version)"
+          CLI_VERSION="$(cargo run -q -p legolas-cli -- --version)"
           EXPECTED_TAG="v${PACKAGE_VERSION}"
 
           git fetch origin refs/heads/master:refs/remotes/origin/master
@@ -127,6 +132,15 @@ jobs:
       - name: Verify vendor layout
         run: node ./scripts/verify-vendor-layout.mjs ${{ matrix.target }}
 
+      - name: Run launcher platform contract tests
+        run: node --test test/launcher-platform.test.js
+
+      - name: Smoke test packaged launcher on runner host
+        run: |
+          node ./bin/legolas.js --version
+          node ./bin/legolas.js help
+          node ./bin/legolas.js scan tests/fixtures/parity/basic-app
+
       - name: Copy release asset
         shell: bash
         run: |
@@ -156,6 +170,44 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Download staged release binaries
+        shell: bash
+        run: |
+          mkdir -p release-assets
+
+          gh release download "${{ needs.prepare-release.outputs.tag_name }}" \
+            --pattern "legolas-*" \
+            --dir release-assets
+
+          mkdir -p vendor/x86_64-unknown-linux-gnu
+          mkdir -p vendor/x86_64-pc-windows-msvc
+          mkdir -p vendor/x86_64-apple-darwin
+          mkdir -p vendor/aarch64-apple-darwin
+
+          cp release-assets/legolas-x86_64-unknown-linux-gnu vendor/x86_64-unknown-linux-gnu/legolas
+          cp release-assets/legolas-x86_64-pc-windows-msvc.exe vendor/x86_64-pc-windows-msvc/legolas.exe
+          cp release-assets/legolas-x86_64-apple-darwin vendor/x86_64-apple-darwin/legolas
+          cp release-assets/legolas-aarch64-apple-darwin vendor/aarch64-apple-darwin/legolas
+
+          chmod 755 vendor/x86_64-unknown-linux-gnu/legolas
+          chmod 755 vendor/x86_64-apple-darwin/legolas
+          chmod 755 vendor/aarch64-apple-darwin/legolas
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify vendor layout
+        run: |
+          node ./scripts/verify-vendor-layout.mjs \
+            x86_64-unknown-linux-gnu \
+            x86_64-pc-windows-msvc \
+            x86_64-apple-darwin \
+            aarch64-apple-darwin
+
       - name: Read package metadata
         id: meta
         run: |
@@ -167,6 +219,12 @@ jobs:
 
       - name: Smoke test CLI
         run: npm run smoke
+
+      - name: Smoke test packaged launcher
+        run: |
+          node ./bin/legolas.js --version
+          node ./bin/legolas.js help
+          node ./bin/legolas.js scan tests/fixtures/parity/basic-app
 
       - name: Verify package tarball
         run: npm run pack:check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,26 +13,32 @@ Thank you for your interest in contributing to Legolas.
 ### Prerequisites
 
 - Node.js 18.17 or newer
+- Rust 1.95.0 with `cargo`
+
+Prebuilt npm binaries currently target macOS `x64/arm64`, Linux `x64` glibc,
+and Windows `x64`.
 
 ### Setup
 
 ```bash
 git clone https://github.com/JeremyDev87/legolas.git
 cd legolas
-npm test
-node ./bin/legolas.js help
+cargo test --workspace
+cargo run -p legolas-cli -- help
 ```
 
 ## Project Shape
 
-Legolas is currently a small zero-dependency Node CLI.
+Legolas is now a Rust CLI workspace, with a thin npm launcher and packaging
+helpers kept in JavaScript.
 
 ```text
 legolas/
-├── bin/           # CLI entrypoint
-├── src/core/      # analysis engine
-├── src/reporters/ # text output
-└── test/          # node:test coverage
+├── crates/        # Rust CLI and core analysis crates
+├── bin/           # npm launcher
+├── scripts/       # packaging and vendor helpers
+├── tests/         # parity fixtures and oracles
+└── src/           # legacy JS implementation retained until cutover cleanup
 ```
 
 ## How To Contribute
@@ -49,7 +55,11 @@ Before opening a pull request:
 
 ```bash
 npm test
+node --test test/launcher-platform.test.js
 npm run smoke
+cargo build --release -p legolas-cli
+node ./scripts/stage-local-vendor-binary.mjs
+node ./scripts/verify-vendor-layout.mjs
 npm run pack:check
 ```
 
@@ -87,12 +97,17 @@ Legolas release automation uses `package.json` as the version source of truth.
 Typical release flow:
 
 1. Update `package.json` to the next version.
-2. Verify the CLI reports the same version with `node ./bin/legolas.js --version`.
+2. Verify the Rust CLI reports the same version with `cargo run -q -p legolas-cli -- --version`.
 3. Run:
 
 ```bash
 npm test
+node --test test/launcher-platform.test.js
 npm run smoke
+cargo build --release -p legolas-cli
+node ./scripts/stage-local-vendor-binary.mjs
+node ./scripts/verify-vendor-layout.mjs
+node ./bin/legolas.js --version
 npm run pack:check
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@
 
 Slim bundles with precision.
 
-Legolas is a zero-dependency CLI that inspects modern web projects for bundle weight, duplicate packages, tree-shaking misses, and lazy-loading opportunities.
+Legolas is a Rust-powered CLI, shipped through npm with native binaries, that inspects modern web projects for bundle weight, duplicate packages, tree-shaking misses, and lazy-loading opportunities.
 
 ## Why Legolas
 
@@ -34,9 +34,9 @@ npx legolas optimize
 You can also point Legolas at a specific project path:
 
 ```bash
-node ./bin/legolas.js scan ./apps/storefront
-node ./bin/legolas.js visualize . --limit 12
-node ./bin/legolas.js optimize . --top 7
+cargo run -p legolas-cli -- scan ./apps/storefront
+cargo run -p legolas-cli -- visualize . --limit 12
+cargo run -p legolas-cli -- optimize . --top 7
 ```
 
 ## What The Current MVP Does
@@ -66,8 +66,8 @@ Medium impact: there are several meaningful bundle wins available.
 ## Development
 
 ```bash
-npm test
-node ./bin/legolas.js help
+cargo test --workspace
+cargo run -p legolas-cli -- help
 ```
 
 ## Open Source
@@ -81,4 +81,5 @@ node ./bin/legolas.js help
 ## Notes
 
 - The current release is heuristic-first. If bundle artifacts such as `stats.json` or `meta.json` exist, Legolas detects them, but full artifact-native analysis is still the next natural step.
-- The CLI intentionally avoids external runtime dependencies so contributors can clone and run it immediately.
+- The current npm package ships prebuilt binaries for macOS `x64/arm64`, Linux `x64` glibc, and Windows `x64`.
+- The npm package ships platform-specific Rust binaries under `vendor/<triple>/legolas[.exe]`, while contributor workflows use `cargo run -p legolas-cli -- ...` as the source of truth.

--- a/README.es.md
+++ b/README.es.md
@@ -10,7 +10,7 @@
 
 Slim bundles with precision.
 
-Legolas es una CLI sin dependencias de runtime que inspecciona proyectos web modernos para detectar peso de bundle, paquetes duplicados, fallos de tree-shaking y oportunidades de lazy loading.
+Legolas es una CLI impulsada por Rust, distribuida por npm con binarios nativos, que inspecciona proyectos web modernos para detectar peso de bundle, paquetes duplicados, fallos de tree-shaking y oportunidades de lazy loading.
 
 ## Por Qué Legolas
 
@@ -34,9 +34,9 @@ npx legolas optimize
 También puedes analizar una ruta de proyecto específica:
 
 ```bash
-node ./bin/legolas.js scan ./apps/storefront
-node ./bin/legolas.js visualize . --limit 12
-node ./bin/legolas.js optimize . --top 7
+cargo run -p legolas-cli -- scan ./apps/storefront
+cargo run -p legolas-cli -- visualize . --limit 12
+cargo run -p legolas-cli -- optimize . --top 7
 ```
 
 ## Qué Hace El MVP Actual
@@ -66,8 +66,8 @@ Medium impact: there are several meaningful bundle wins available.
 ## Desarrollo
 
 ```bash
-npm test
-node ./bin/legolas.js help
+cargo test --workspace
+cargo run -p legolas-cli -- help
 ```
 
 ## Código Abierto
@@ -81,4 +81,5 @@ node ./bin/legolas.js help
 ## Notas
 
 - La versión actual es principalmente heurística. Si existen artefactos de bundle como `stats.json` o `meta.json`, Legolas los detecta, pero el análisis completo basado en artifacts sigue siendo el siguiente paso natural.
-- La CLI evita a propósito dependencias externas de runtime para que cualquier colaborador pueda clonar y ejecutarla de inmediato.
+- El paquete npm actual distribuye binarios precompilados para macOS `x64/arm64`, Linux `x64` con glibc y Windows `x64`.
+- El paquete npm distribuye binarios Rust por plataforma bajo `vendor/<triple>/legolas[.exe]`, mientras que la ruta de contribución del repositorio usa `cargo run -p legolas-cli -- ...` como referencia.

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,7 +10,7 @@
 
 Slim bundles with precision.
 
-Legolas は、モダンな Web プロジェクトのバンドルサイズ、重複パッケージ、tree-shaking の取りこぼし、lazy loading の余地を点検する zero-dependency CLI です。
+Legolas は、npm パッケージ内に native Rust binary を同梱して配布する CLI で、モダンな Web プロジェクトのバンドルサイズ、重複パッケージ、tree-shaking の取りこぼし、lazy loading の余地を点検します。
 
 ## なぜ Legolas か
 
@@ -34,9 +34,9 @@ npx legolas optimize
 特定のプロジェクトパスを直接指定して解析することもできます。
 
 ```bash
-node ./bin/legolas.js scan ./apps/storefront
-node ./bin/legolas.js visualize . --limit 12
-node ./bin/legolas.js optimize . --top 7
+cargo run -p legolas-cli -- scan ./apps/storefront
+cargo run -p legolas-cli -- visualize . --limit 12
+cargo run -p legolas-cli -- optimize . --top 7
 ```
 
 ## 現在の MVP でできること
@@ -66,8 +66,8 @@ Medium impact: there are several meaningful bundle wins available.
 ## 開発
 
 ```bash
-npm test
-node ./bin/legolas.js help
+cargo test --workspace
+cargo run -p legolas-cli -- help
 ```
 
 ## オープンソース
@@ -81,4 +81,5 @@ node ./bin/legolas.js help
 ## 補足
 
 - 現在のリリースは heuristic-first な方針です。`stats.json` や `meta.json` のようなバンドル成果物があれば存在は検出しますが、artifact-native の本格解析は次の自然な拡張です。
-- この CLI は、コントリビューターが clone してすぐ実行できるように、ランタイム外部依存を意図的に避けています。
+- 現在の npm 配布物の prebuilt binary は macOS `x64/arm64`、Linux `x64` glibc、Windows `x64` をサポートします。
+- npm 配布物は `vendor/<triple>/legolas[.exe]` layout で platform ごとの Rust binary を含み、repository 側の contributor path は `cargo run -p legolas-cli -- ...` を基準にします。

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Slim bundles with precision.
 
-> Quick Overview (EN): Legolas is a zero-dependency CLI for analyzing bundle weight, duplicate packages, tree-shaking misses, and lazy-loading opportunities in modern web projects.
+> Quick Overview (EN): Legolas is a Rust-powered CLI, shipped through npm with native binaries, for analyzing bundle weight, duplicate packages, tree-shaking misses, and lazy-loading opportunities in modern web projects.
 >
 > Quick Start:
 > ```bash
@@ -19,7 +19,7 @@ Slim bundles with precision.
 > npx legolas optimize
 > ```
 
-Legolas는 최신 웹 프로젝트의 번들 크기, 중복 패키지, tree-shaking 누수, lazy loading 기회를 점검하는 zero-dependency CLI입니다.
+Legolas는 npm package 안에 native Rust binary를 담아 배포하는 CLI로, 최신 웹 프로젝트의 번들 크기, 중복 패키지, tree-shaking 누수, lazy loading 기회를 점검합니다.
 
 ## 왜 Legolas인가
 
@@ -43,9 +43,9 @@ npx legolas optimize
 특정 프로젝트 경로를 직접 넘겨서 분석할 수도 있습니다.
 
 ```bash
-node ./bin/legolas.js scan ./apps/storefront
-node ./bin/legolas.js visualize . --limit 12
-node ./bin/legolas.js optimize . --top 7
+cargo run -p legolas-cli -- scan ./apps/storefront
+cargo run -p legolas-cli -- visualize . --limit 12
+cargo run -p legolas-cli -- optimize . --top 7
 ```
 
 ## 현재 MVP가 하는 일
@@ -75,8 +75,8 @@ Medium impact: there are several meaningful bundle wins available.
 ## 개발
 
 ```bash
-npm test
-node ./bin/legolas.js help
+cargo test --workspace
+cargo run -p legolas-cli -- help
 ```
 
 ## 오픈소스
@@ -90,4 +90,5 @@ node ./bin/legolas.js help
 ## 참고
 
 - 현재 릴리스는 heuristic-first 접근입니다. `stats.json`, `meta.json` 같은 번들 산출물이 있으면 존재는 감지하지만, artifact-native 정밀 분석은 다음 단계의 자연스러운 확장입니다.
-- 이 CLI는 기여자가 바로 clone 해서 실행할 수 있도록 런타임 외부 의존성을 두지 않는 방향을 유지합니다.
+- 현재 npm 배포본의 prebuilt binary는 macOS `x64/arm64`, Linux `x64` glibc, Windows `x64`만 지원합니다.
+- npm 배포본은 `vendor/<triple>/legolas[.exe]` layout으로 platform별 Rust binary를 싣고, repository contributor path는 `cargo run -p legolas-cli -- ...`를 기준으로 유지합니다.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 Slim bundles with precision.
 
-Legolas 是一个零运行时依赖的 CLI，用来检查现代 Web 项目的打包体积、重复依赖、tree-shaking 漏损以及 lazy loading 优化机会。
+Legolas 是一个由 Rust 驱动、通过 npm 分发原生二进制的 CLI，用来检查现代 Web 项目的打包体积、重复依赖、tree-shaking 漏损以及 lazy loading 优化机会。
 
 ## 为什么选择 Legolas
 
@@ -34,9 +34,9 @@ npx legolas optimize
 也可以直接指定某个项目路径进行分析：
 
 ```bash
-node ./bin/legolas.js scan ./apps/storefront
-node ./bin/legolas.js visualize . --limit 12
-node ./bin/legolas.js optimize . --top 7
+cargo run -p legolas-cli -- scan ./apps/storefront
+cargo run -p legolas-cli -- visualize . --limit 12
+cargo run -p legolas-cli -- optimize . --top 7
 ```
 
 ## 当前 MVP 的能力
@@ -66,8 +66,8 @@ Medium impact: there are several meaningful bundle wins available.
 ## 开发
 
 ```bash
-npm test
-node ./bin/legolas.js help
+cargo test --workspace
+cargo run -p legolas-cli -- help
 ```
 
 ## 开源信息
@@ -81,4 +81,5 @@ node ./bin/legolas.js help
 ## 说明
 
 - 当前版本以启发式分析为主。如果项目中存在 `stats.json`、`meta.json` 之类的打包产物，Legolas 会识别到它们，但完整的 artifact-native 精确分析仍是下一阶段的自然扩展。
-- 这个 CLI 有意避免引入运行时外部依赖，方便贡献者 clone 后立即运行。
+- 当前 npm 发布物提供 macOS `x64/arm64`、Linux `x64` glibc、Windows `x64` 的预构建二进制。
+- npm 发布物会把各平台 Rust 二进制放在 `vendor/<triple>/legolas[.exe]` 下，而仓库贡献路径则以 `cargo run -p legolas-cli -- ...` 为准。

--- a/bin/legolas.js
+++ b/bin/legolas.js
@@ -1,9 +1,44 @@
 #!/usr/bin/env node
 
-import { runCli } from "../src/cli.js";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { missingBinaryMessage, resolveCurrentHostSupport } from "./platform-support.js";
 
-runCli(process.argv.slice(2)).catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`legolas: ${message}`);
-  process.exitCode = 1;
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const hostSupport = resolveCurrentHostSupport();
+
+if (!hostSupport.supported) {
+  exitMissingBinary(hostSupport.hostKey);
+}
+
+const binaryPath = path.join(projectRoot, "vendor", hostSupport.targetTriple, hostSupport.binaryName);
+
+if (!existsSync(binaryPath)) {
+  exitMissingBinary(hostSupport.hostKey);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: "inherit"
 });
+
+if (result.error) {
+  console.error(`legolas: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (typeof result.status === "number") {
+  process.exit(result.status);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(1);
+
+function exitMissingBinary(hostKey) {
+  console.error(missingBinaryMessage(hostKey));
+  process.exit(1);
+}

--- a/bin/platform-support.js
+++ b/bin/platform-support.js
@@ -1,0 +1,58 @@
+export function resolveCurrentHostSupport() {
+  return resolveHostSupport(process.platform, process.arch, {
+    linuxGlibc: hasLinuxGlibcRuntime()
+  });
+}
+
+export function resolveHostSupport(platform, arch, options = {}) {
+  const hostKey = `${platform}/${arch}`;
+
+  switch (hostKey) {
+    case "darwin/arm64":
+      return supportedHost(hostKey, "aarch64-apple-darwin");
+    case "darwin/x64":
+      return supportedHost(hostKey, "x86_64-apple-darwin");
+    case "linux/x64":
+      if (options.linuxGlibc === false) {
+        return unsupportedHost(hostKey);
+      }
+      return supportedHost(hostKey, "x86_64-unknown-linux-gnu");
+    case "win32/x64":
+      return supportedHost(hostKey, "x86_64-pc-windows-msvc");
+    default:
+      return unsupportedHost(hostKey);
+  }
+}
+
+export function missingBinaryMessage(hostKey) {
+  return `legolas: no packaged Rust binary for ${hostKey}`;
+}
+
+function supportedHost(hostKey, targetTriple) {
+  return {
+    supported: true,
+    hostKey,
+    targetTriple,
+    binaryName: targetTriple.includes("windows") ? "legolas.exe" : "legolas"
+  };
+}
+
+function unsupportedHost(hostKey) {
+  return {
+    supported: false,
+    hostKey,
+    targetTriple: null,
+    binaryName: null
+  };
+}
+
+function hasLinuxGlibcRuntime() {
+  if (process.platform !== "linux") {
+    return true;
+  }
+
+  const runtimeReport = process.report?.getReport?.();
+  const runtimeHeader = runtimeReport?.header;
+
+  return Boolean(runtimeHeader?.glibcVersionRuntime || runtimeHeader?.glibcVersionCompiler);
+}

--- a/bin/preinstall-check.js
+++ b/bin/preinstall-check.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { missingBinaryMessage, resolveCurrentHostSupport } from "./platform-support.js";
+
+const hostSupport = resolveCurrentHostSupport();
+
+if (!hostSupport.supported) {
+  console.error(missingBinaryMessage(hostSupport.hostKey));
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -17,18 +17,28 @@
   "type": "module",
   "files": [
     "bin",
-    "src"
+    "vendor"
+  ],
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
   ],
   "bin": {
     "legolas": "./bin/legolas.js"
   },
   "scripts": {
-    "scan": "node ./bin/legolas.js scan",
-    "visualize": "node ./bin/legolas.js visualize",
-    "optimize": "node ./bin/legolas.js optimize",
-    "smoke": "node ./bin/legolas.js --version && node ./bin/legolas.js help && node ./bin/legolas.js scan . && node ./bin/legolas.js visualize . && node ./bin/legolas.js optimize .",
+    "preinstall": "node ./bin/preinstall-check.js",
+    "scan": "cargo run -p legolas-cli -- scan",
+    "visualize": "cargo run -p legolas-cli -- visualize",
+    "optimize": "cargo run -p legolas-cli -- optimize",
+    "smoke": "cargo run -p legolas-cli -- --version && cargo run -p legolas-cli -- help && cargo run -p legolas-cli -- scan . && cargo run -p legolas-cli -- visualize . && cargo run -p legolas-cli -- optimize .",
     "pack:check": "node ./scripts/check-pack.mjs",
-    "test": "node --test"
+    "test": "cargo test --workspace"
   },
   "engines": {
     "node": ">=18.17"

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -6,15 +6,24 @@ const projectRoot = fileURLToPath(new URL("..", import.meta.url));
 
 const rootAllowlist = new Set(["LICENSE", "package.json"]);
 const rootReadmePattern = /^README(\.[^.]+)?\.md$/i;
-const packageDirs = ["bin", "src"];
+const packageDirs = ["bin", "vendor"];
+const vendorReadmePath = "vendor/README.md";
+const vendorBinaryPattern = /^vendor\/[^/]+\/legolas(?:\.exe)?$/;
 
 const expectedFiles = new Set(await collectExpectedFiles());
 const packedFiles = await collectPackedFiles();
+const invalidVendorFiles = packedFiles.filter(isInvalidVendorFile);
+const stagedVendorBinaries = packedFiles.filter((filePath) => vendorBinaryPattern.test(filePath));
 
 const unexpectedFiles = packedFiles.filter((filePath) => !expectedFiles.has(filePath));
 const missingFiles = [...expectedFiles].filter((filePath) => !packedFiles.includes(filePath));
 
-if (unexpectedFiles.length > 0 || missingFiles.length > 0) {
+if (
+  unexpectedFiles.length > 0 ||
+  missingFiles.length > 0 ||
+  invalidVendorFiles.length > 0 ||
+  stagedVendorBinaries.length === 0
+) {
   console.error("Package contents validation failed.");
 
   if (unexpectedFiles.length > 0) {
@@ -29,6 +38,17 @@ if (unexpectedFiles.length > 0 || missingFiles.length > 0) {
     for (const filePath of missingFiles) {
       console.error(`- ${filePath}`);
     }
+  }
+
+  if (invalidVendorFiles.length > 0) {
+    console.error("Invalid vendor layout files:");
+    for (const filePath of invalidVendorFiles) {
+      console.error(`- ${filePath}`);
+    }
+  }
+
+  if (stagedVendorBinaries.length === 0) {
+    console.error("Missing staged vendor binary under vendor/<triple>/legolas[.exe].");
   }
 
   process.exit(1);
@@ -98,6 +118,10 @@ async function collectPackedFiles() {
 
 function toPosixPath(filePath) {
   return filePath.split(path.sep).join("/");
+}
+
+function isInvalidVendorFile(filePath) {
+  return filePath.startsWith("vendor/") && filePath !== vendorReadmePath && !vendorBinaryPattern.test(filePath);
 }
 
 function runPackCommand() {

--- a/test/launcher-platform.test.js
+++ b/test/launcher-platform.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { missingBinaryMessage, resolveHostSupport } from "../bin/platform-support.js";
+
+test("resolveHostSupport accepts each packaged native target", () => {
+  assert.deepEqual(resolveHostSupport("darwin", "arm64"), {
+    supported: true,
+    hostKey: "darwin/arm64",
+    targetTriple: "aarch64-apple-darwin",
+    binaryName: "legolas"
+  });
+  assert.deepEqual(resolveHostSupport("darwin", "x64"), {
+    supported: true,
+    hostKey: "darwin/x64",
+    targetTriple: "x86_64-apple-darwin",
+    binaryName: "legolas"
+  });
+  assert.deepEqual(resolveHostSupport("linux", "x64", { linuxGlibc: true }), {
+    supported: true,
+    hostKey: "linux/x64",
+    targetTriple: "x86_64-unknown-linux-gnu",
+    binaryName: "legolas"
+  });
+  assert.deepEqual(resolveHostSupport("win32", "x64"), {
+    supported: true,
+    hostKey: "win32/x64",
+    targetTriple: "x86_64-pc-windows-msvc",
+    binaryName: "legolas.exe"
+  });
+});
+
+test("resolveHostSupport rejects unsupported host combinations", () => {
+  assert.deepEqual(resolveHostSupport("linux", "arm64", { linuxGlibc: true }), {
+    supported: false,
+    hostKey: "linux/arm64",
+    targetTriple: null,
+    binaryName: null
+  });
+  assert.deepEqual(resolveHostSupport("win32", "arm64"), {
+    supported: false,
+    hostKey: "win32/arm64",
+    targetTriple: null,
+    binaryName: null
+  });
+  assert.deepEqual(resolveHostSupport("freebsd", "x64"), {
+    supported: false,
+    hostKey: "freebsd/x64",
+    targetTriple: null,
+    binaryName: null
+  });
+  assert.deepEqual(resolveHostSupport("linux", "x64", { linuxGlibc: false }), {
+    supported: false,
+    hostKey: "linux/x64",
+    targetTriple: null,
+    binaryName: null
+  });
+});
+
+test("missingBinaryMessage preserves the launcher contract", () => {
+  assert.equal(
+    missingBinaryMessage("linux/arm64"),
+    "legolas: no packaged Rust binary for linux/arm64"
+  );
+});

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -11,7 +11,7 @@ Examples:
 
 This directory is intentionally kept empty in git except for this README.
 Release workflows populate it transiently before uploading release assets, and
-the npm cutover later uses the same layout.
+the npm launcher uses the same layout when packaging platform binaries.
 
 Local staging flow:
 


### PR DESCRIPTION
## 요약
- npm launcher를 JS business logic 대신 `vendor/<triple>/legolas[.exe]` 를 실행하는 thin launcher로 전환했습니다.
- `package.json`, `scripts/check-pack.mjs`, CI/release workflow를 Rust vendor 배포 모델에 맞게 정리했습니다.
- README/CONTRIBUTING 문서를 `npx` 사용자 경로와 `cargo` 기반 contributor 경로로 분리해 현재 배포 방식과 맞췄습니다.

## 검증
- `cargo test --workspace`
- `npm test`
- `npm run smoke`
- `node ./scripts/stage-local-vendor-binary.mjs`
- `node ./scripts/verify-vendor-layout.mjs`
- `node ./bin/legolas.js --version`
- `node ./bin/legolas.js help`
- `node ./bin/legolas.js scan tests/fixtures/parity/basic-app`
- `npm run pack:check`
- `npm pack --dry-run --json --cache ./.npm-cache`

## 메모
- missing vendor binary 경로도 로컬에서 확인했고, `legolas: no packaged Rust binary for <platform>/<arch>` 로 실패하도록 고정했습니다.
- 로컬 smoke를 위해 생성한 host vendor binary는 커밋하지 않았습니다.