### PR TITLE
feat: Rust core config loader foundation 추가

### DIFF
--- a/crates/legolas-core/src/config.rs
+++ b/crates/legolas-core/src/config.rs
@@ -1,0 +1,331 @@
+use std::{
+    fmt, fs,
+    path::{Path, PathBuf},
+};
+
+use serde_json::{Map, Value};
+
+use crate::{error::Result, workspace::find_discovered_config_path, LegolasError};
+
+const UNKNOWN_KEY_WARNING: &str = "unknown config key ignored";
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LegolasConfig {
+    pub command_defaults: CommandDefaults,
+    pub budget_rules: Option<BudgetRules>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CommandDefaults {
+    pub scan_path: Option<String>,
+    pub visualize_limit: Option<usize>,
+    pub optimize_top: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BudgetRules {
+    pub potential_kb_saved: Option<BudgetThresholds>,
+    pub duplicate_package_count: Option<BudgetThresholds>,
+    pub dynamic_import_count: Option<BudgetThresholds>,
+}
+
+impl BudgetRules {
+    fn is_empty(&self) -> bool {
+        self.potential_kb_saved.is_none()
+            && self.duplicate_package_count.is_none()
+            && self.dynamic_import_count.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetThresholds {
+    pub warn_at: usize,
+    pub fail_at: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigWarning {
+    pub key_path: String,
+    pub message: String,
+}
+
+impl fmt::Display for ConfigWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.key_path, self.message)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedConfig {
+    pub path: PathBuf,
+    pub config: LegolasConfig,
+    pub warnings: Vec<ConfigWarning>,
+}
+
+pub fn load_discovered_config<P: AsRef<Path>>(input_path: P) -> Result<Option<LoadedConfig>> {
+    let Some(config_path) = find_discovered_config_path(input_path)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(load_config_file(config_path)?))
+}
+
+pub fn load_config_file<P: AsRef<Path>>(config_path: P) -> Result<LoadedConfig> {
+    let config_path = config_path.as_ref();
+    let raw_contents = fs::read_to_string(config_path).map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => {
+            LegolasError::PathNotFound(config_path.display().to_string())
+        }
+        _ => error.into(),
+    })?;
+    let json_value = serde_json::from_str::<Value>(&raw_contents).map_err(|error| {
+        LegolasError::MalformedConfig {
+            path: config_path.display().to_string(),
+            message: error.to_string(),
+        }
+    })?;
+    let root = expect_object(&json_value, config_path, "$")?;
+    let mut warnings = Vec::new();
+
+    let config = parse_root(root, config_path, &mut warnings)?;
+
+    Ok(LoadedConfig {
+        path: config_path.to_path_buf(),
+        config,
+        warnings,
+    })
+}
+
+fn parse_root(
+    root: &Map<String, Value>,
+    config_path: &Path,
+    warnings: &mut Vec<ConfigWarning>,
+) -> Result<LegolasConfig> {
+    warn_unknown_keys(
+        root,
+        &["scan", "visualize", "optimize", "budget"],
+        "",
+        warnings,
+    );
+
+    let mut command_defaults = CommandDefaults::default();
+
+    if let Some(scan) = root.get("scan") {
+        command_defaults.scan_path = parse_scan(scan, config_path, warnings)?;
+    }
+
+    if let Some(visualize) = root.get("visualize") {
+        command_defaults.visualize_limit = parse_visualize(visualize, config_path, warnings)?;
+    }
+
+    if let Some(optimize) = root.get("optimize") {
+        command_defaults.optimize_top = parse_optimize(optimize, config_path, warnings)?;
+    }
+
+    let budget_rules = match root.get("budget") {
+        Some(budget) => parse_budget(budget, config_path, warnings)?,
+        None => None,
+    };
+
+    Ok(LegolasConfig {
+        command_defaults,
+        budget_rules,
+    })
+}
+
+fn parse_scan(
+    value: &Value,
+    config_path: &Path,
+    warnings: &mut Vec<ConfigWarning>,
+) -> Result<Option<String>> {
+    let scan = expect_object(value, config_path, "scan")?;
+    warn_unknown_keys(scan, &["path"], "scan", warnings);
+
+    match scan.get("path") {
+        Some(path) => Ok(Some(
+            expect_string(path, config_path, "scan.path")?.to_string(),
+        )),
+        None => Ok(None),
+    }
+}
+
+fn parse_visualize(
+    value: &Value,
+    config_path: &Path,
+    warnings: &mut Vec<ConfigWarning>,
+) -> Result<Option<usize>> {
+    let visualize = expect_object(value, config_path, "visualize")?;
+    warn_unknown_keys(visualize, &["limit"], "visualize", warnings);
+
+    match visualize.get("limit") {
+        Some(limit) => Ok(Some(expect_positive_usize(
+            limit,
+            config_path,
+            "visualize.limit",
+        )?)),
+        None => Ok(None),
+    }
+}
+
+fn parse_optimize(
+    value: &Value,
+    config_path: &Path,
+    warnings: &mut Vec<ConfigWarning>,
+) -> Result<Option<usize>> {
+    let optimize = expect_object(value, config_path, "optimize")?;
+    warn_unknown_keys(optimize, &["top"], "optimize", warnings);
+
+    match optimize.get("top") {
+        Some(top) => Ok(Some(expect_positive_usize(
+            top,
+            config_path,
+            "optimize.top",
+        )?)),
+        None => Ok(None),
+    }
+}
+
+fn parse_budget(
+    value: &Value,
+    config_path: &Path,
+    warnings: &mut Vec<ConfigWarning>,
+) -> Result<Option<BudgetRules>> {
+    let budget = expect_object(value, config_path, "budget")?;
+    warn_unknown_keys(budget, &["rules"], "budget", warnings);
+
+    let Some(rules_value) = budget.get("rules") else {
+        return Ok(None);
+    };
+
+    let rules_map = expect_object(rules_value, config_path, "budget.rules")?;
+    warn_unknown_keys(
+        rules_map,
+        &[
+            "potentialKbSaved",
+            "duplicatePackageCount",
+            "dynamicImportCount",
+        ],
+        "budget.rules",
+        warnings,
+    );
+
+    let rules = BudgetRules {
+        potential_kb_saved: parse_threshold_rule(
+            rules_map.get("potentialKbSaved"),
+            config_path,
+            warnings,
+            "budget.rules.potentialKbSaved",
+        )?,
+        duplicate_package_count: parse_threshold_rule(
+            rules_map.get("duplicatePackageCount"),
+            config_path,
+            warnings,
+            "budget.rules.duplicatePackageCount",
+        )?,
+        dynamic_import_count: parse_threshold_rule(
+            rules_map.get("dynamicImportCount"),
+            config_path,
+            warnings,
+            "budget.rules.dynamicImportCount",
+        )?,
+    };
+
+    if rules.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(rules))
+}
+
+fn parse_threshold_rule(
+    value: Option<&Value>,
+    config_path: &Path,
+    warnings: &mut Vec<ConfigWarning>,
+    key_path: &str,
+) -> Result<Option<BudgetThresholds>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    let threshold = expect_object(value, config_path, key_path)?;
+    warn_unknown_keys(threshold, &["warnAt", "failAt"], key_path, warnings);
+
+    let warn_at = threshold
+        .get("warnAt")
+        .ok_or_else(|| unsupported_shape(config_path, &format!("{key_path}.warnAt"), "integer"))?;
+    let fail_at = threshold
+        .get("failAt")
+        .ok_or_else(|| unsupported_shape(config_path, &format!("{key_path}.failAt"), "integer"))?;
+
+    Ok(Some(BudgetThresholds {
+        warn_at: expect_usize(warn_at, config_path, &format!("{key_path}.warnAt"))?,
+        fail_at: expect_usize(fail_at, config_path, &format!("{key_path}.failAt"))?,
+    }))
+}
+
+fn expect_object<'a>(
+    value: &'a Value,
+    config_path: &Path,
+    key_path: &str,
+) -> Result<&'a Map<String, Value>> {
+    value
+        .as_object()
+        .ok_or_else(|| unsupported_shape(config_path, key_path, "object"))
+}
+
+fn expect_string<'a>(value: &'a Value, config_path: &Path, key_path: &str) -> Result<&'a str> {
+    value
+        .as_str()
+        .ok_or_else(|| unsupported_shape(config_path, key_path, "string"))
+}
+
+fn expect_positive_usize(value: &Value, config_path: &Path, key_path: &str) -> Result<usize> {
+    let number = expect_usize(value, config_path, key_path)?;
+    if number == 0 {
+        return Err(unsupported_shape(config_path, key_path, "positive integer"));
+    }
+
+    Ok(number)
+}
+
+fn expect_usize(value: &Value, config_path: &Path, key_path: &str) -> Result<usize> {
+    let raw = value
+        .as_u64()
+        .ok_or_else(|| unsupported_shape(config_path, key_path, "integer"))?;
+
+    usize::try_from(raw).map_err(|_| unsupported_shape(config_path, key_path, "integer"))
+}
+
+fn warn_unknown_keys(
+    object: &Map<String, Value>,
+    allowed_keys: &[&str],
+    key_prefix: &str,
+    warnings: &mut Vec<ConfigWarning>,
+) {
+    for key in object.keys() {
+        if allowed_keys.contains(&key.as_str()) {
+            continue;
+        }
+
+        warnings.push(ConfigWarning {
+            key_path: join_key_path(key_prefix, key),
+            message: UNKNOWN_KEY_WARNING.to_string(),
+        });
+    }
+}
+
+fn join_key_path(prefix: &str, key: &str) -> String {
+    if prefix.is_empty() {
+        return key.to_string();
+    }
+
+    format!("{prefix}.{key}")
+}
+
+fn unsupported_shape(config_path: &Path, key_path: &str, expected: &str) -> LegolasError {
+    LegolasError::UnsupportedConfigShape {
+        path: config_path.display().to_string(),
+        key_path: key_path.to_string(),
+        message: format!("expected {expected}"),
+    }
+}

--- a/crates/legolas-core/src/error.rs
+++ b/crates/legolas-core/src/error.rs
@@ -12,6 +12,14 @@ pub enum LegolasError {
     CliUsage(String),
     #[error("unsupported lockfile: {0}")]
     UnsupportedLockfile(String),
+    #[error("malformed config {path}: {message}")]
+    MalformedConfig { path: String, message: String },
+    #[error("unsupported config shape in {path} at {key_path}: {message}")]
+    UnsupportedConfigShape {
+        path: String,
+        key_path: String,
+        message: String,
+    },
     #[error("not implemented: {0}")]
     NotImplemented(&'static str),
     #[error(transparent)]

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod analyze;
+pub mod config;
 pub mod error;
 pub mod impact;
 pub mod import_scanner;

--- a/crates/legolas-core/src/workspace.rs
+++ b/crates/legolas-core/src/workspace.rs
@@ -42,6 +42,17 @@ pub fn find_project_root<P: AsRef<Path>>(input_path: P) -> Result<PathBuf> {
     }
 }
 
+pub fn find_discovered_config_path<P: AsRef<Path>>(input_path: P) -> Result<Option<PathBuf>> {
+    let project_root = find_project_root(input_path)?;
+    let config_path = project_root.join("legolas.config.json");
+
+    match fs::metadata(&config_path) {
+        Ok(_) => Ok(Some(config_path)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
 pub fn read_text_if_exists<P: AsRef<Path>>(file_path: P) -> Result<Option<String>> {
     match fs::read_to_string(file_path.as_ref()) {
         Ok(contents) => Ok(Some(contents)),

--- a/crates/legolas-core/tests/config_loading.rs
+++ b/crates/legolas-core/tests/config_loading.rs
@@ -1,0 +1,222 @@
+#[allow(dead_code)]
+mod support;
+
+use std::fs;
+
+use legolas_core::{
+    config::{
+        load_config_file, load_discovered_config, BudgetRules, BudgetThresholds, CommandDefaults,
+        ConfigWarning, LegolasConfig, LoadedConfig,
+    },
+    workspace::find_discovered_config_path,
+    LegolasError,
+};
+use tempfile::tempdir;
+
+#[test]
+fn load_discovered_config_reads_known_keys_from_project_root() {
+    let project_root = support::fixture_path("tests/fixtures/config/discovered");
+    let package_json = project_root.join("package.json");
+    let config_path = project_root.join("legolas.config.json");
+    let loaded = load_discovered_config(&package_json)
+        .expect("load discovered config")
+        .expect("config should be discovered");
+
+    assert_eq!(
+        find_discovered_config_path(&package_json).expect("find discovered config path"),
+        Some(config_path.clone())
+    );
+    assert_eq!(
+        loaded,
+        LoadedConfig {
+            path: config_path,
+            config: LegolasConfig {
+                command_defaults: CommandDefaults {
+                    scan_path: Some("src".to_string()),
+                    visualize_limit: Some(12),
+                    optimize_top: Some(7),
+                },
+                budget_rules: Some(BudgetRules {
+                    potential_kb_saved: Some(BudgetThresholds {
+                        warn_at: 40,
+                        fail_at: 80,
+                    }),
+                    duplicate_package_count: Some(BudgetThresholds {
+                        warn_at: 2,
+                        fail_at: 4,
+                    }),
+                    dynamic_import_count: Some(BudgetThresholds {
+                        warn_at: 1,
+                        fail_at: 0,
+                    }),
+                }),
+            },
+            warnings: vec![],
+        }
+    );
+    assert_eq!(
+        load_discovered_config(&project_root)
+            .expect("load discovered config from directory")
+            .expect("config should be discovered from directory input"),
+        loaded
+    );
+}
+
+#[test]
+fn load_discovered_config_returns_none_when_config_is_absent() {
+    let project_root = support::fixture_path("tests/fixtures/workspace/vite-project");
+    let package_json = project_root.join("package.json");
+
+    assert_eq!(
+        find_discovered_config_path(&package_json).expect("find discovered config path"),
+        None
+    );
+    assert_eq!(
+        load_discovered_config(&package_json).expect("load missing config"),
+        None
+    );
+}
+
+#[test]
+fn load_config_file_collects_unknown_key_warnings_and_ignores_them() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("legolas.config.json");
+    fs::write(
+        &config_path,
+        r#"{
+  "visualize": { "limit": 9, "theme": "wide" },
+  "budget": {
+    "rules": {
+      "potentialKbSaved": { "warnAt": 40, "failAt": 80, "note": true },
+      "surpriseRule": { "warnAt": 1, "failAt": 2 }
+    }
+  },
+  "extra": true
+}
+"#,
+    )
+    .expect("write config");
+
+    let loaded = load_config_file(&config_path).expect("load config");
+    let mut warnings = loaded
+        .warnings
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    warnings.sort();
+
+    assert_eq!(
+        loaded.config,
+        LegolasConfig {
+            command_defaults: CommandDefaults {
+                scan_path: None,
+                visualize_limit: Some(9),
+                optimize_top: None,
+            },
+            budget_rules: Some(BudgetRules {
+                potential_kb_saved: Some(BudgetThresholds {
+                    warn_at: 40,
+                    fail_at: 80,
+                }),
+                duplicate_package_count: None,
+                dynamic_import_count: None,
+            }),
+        }
+    );
+    assert_eq!(
+        warnings,
+        vec![
+            ConfigWarning {
+                key_path: "budget.rules.potentialKbSaved.note".to_string(),
+                message: "unknown config key ignored".to_string(),
+            }
+            .to_string(),
+            ConfigWarning {
+                key_path: "budget.rules.surpriseRule".to_string(),
+                message: "unknown config key ignored".to_string(),
+            }
+            .to_string(),
+            ConfigWarning {
+                key_path: "extra".to_string(),
+                message: "unknown config key ignored".to_string(),
+            }
+            .to_string(),
+            ConfigWarning {
+                key_path: "visualize.theme".to_string(),
+                message: "unknown config key ignored".to_string(),
+            }
+            .to_string(),
+        ]
+    );
+}
+
+#[test]
+fn load_discovered_config_reports_malformed_json_with_config_path() {
+    let project_root = support::fixture_path("tests/fixtures/config/invalid-json");
+    let config_path = project_root.join("legolas.config.json");
+    let error = load_discovered_config(&project_root).expect_err("malformed config should fail");
+
+    match error {
+        LegolasError::MalformedConfig { path, message } => {
+            assert_eq!(path, config_path.display().to_string());
+            assert!(message.contains("EOF") || message.contains("expected"));
+        }
+        other => panic!("expected malformed config error, got {other:?}"),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn find_discovered_config_path_surfaces_metadata_failures_instead_of_hiding_them() {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+
+    struct PermissionGuard {
+        path: std::path::PathBuf,
+        permissions: fs::Permissions,
+    }
+
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(&self.path, self.permissions.clone());
+        }
+    }
+
+    let project_root = tempdir().expect("create temp project root");
+    let package_json = project_root.path().join("package.json");
+    fs::write(&package_json, "{}").expect("write package.json");
+
+    let sealed_root = tempdir().expect("create sealed root");
+    let sealed_dir = sealed_root.path().join("sealed");
+    fs::create_dir(&sealed_dir).expect("create sealed dir");
+    fs::write(sealed_dir.join("legolas.config.json"), "{}").expect("write config file");
+    symlink(
+        sealed_dir.join("legolas.config.json"),
+        project_root.path().join("legolas.config.json"),
+    )
+    .expect("create config symlink");
+
+    let original_permissions = fs::metadata(&sealed_dir)
+        .expect("read sealed dir metadata")
+        .permissions();
+    let _permission_guard = PermissionGuard {
+        path: sealed_dir.clone(),
+        permissions: original_permissions.clone(),
+    };
+    let mut sealed_permissions = original_permissions;
+    sealed_permissions.set_mode(0o000);
+    fs::set_permissions(&sealed_dir, sealed_permissions).expect("seal directory");
+
+    if fs::metadata(project_root.path().join("legolas.config.json")).is_ok() {
+        return;
+    }
+
+    let error = find_discovered_config_path(&package_json)
+        .expect_err("metadata failure should not be hidden as missing config");
+
+    match error {
+        LegolasError::Io(io_error) => {
+            assert_eq!(io_error.kind(), std::io::ErrorKind::PermissionDenied);
+        }
+        other => panic!("expected permission denied io error, got {other:?}"),
+    }
+}

--- a/tests/fixtures/config/discovered/legolas.config.json
+++ b/tests/fixtures/config/discovered/legolas.config.json
@@ -1,0 +1,27 @@
+{
+  "scan": {
+    "path": "src"
+  },
+  "visualize": {
+    "limit": 12
+  },
+  "optimize": {
+    "top": 7
+  },
+  "budget": {
+    "rules": {
+      "potentialKbSaved": {
+        "warnAt": 40,
+        "failAt": 80
+      },
+      "duplicatePackageCount": {
+        "warnAt": 2,
+        "failAt": 4
+      },
+      "dynamicImportCount": {
+        "warnAt": 1,
+        "failAt": 0
+      }
+    }
+  }
+}

--- a/tests/fixtures/config/discovered/package.json
+++ b/tests/fixtures/config/discovered/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "config-discovered-fixture"
+}

--- a/tests/fixtures/config/invalid-json/legolas.config.json
+++ b/tests/fixtures/config/invalid-json/legolas.config.json
@@ -1,0 +1,12 @@
+{
+  "visualize": {
+    "limit": 10
+  },
+  "budget": {
+    "rules": {
+      "potentialKbSaved": {
+        "warnAt": 40,
+        "failAt": 80
+      }
+    }
+  }

--- a/tests/fixtures/config/invalid-json/package.json
+++ b/tests/fixtures/config/invalid-json/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "config-invalid-json-fixture"
+}


### PR DESCRIPTION
## 요약
- Rust core에 legolas.config.json loader와 discovered config lookup을 추가했습니다.
- malformed config, unsupported config shape를 구분하는 전용 에러를 추가했습니다.
- fixture 기반 core 테스트로 discovery, missing config, unknown key warning, malformed JSON failure를 고정했습니다.

## 검증
- cargo fmt --all
- cargo test -p legolas-core --test config_loading
- cargo test --workspace