### PR TITLE
feat: Rust CLI config 채택과 --config 플래그 추가

### DIFF
--- a/crates/legolas-cli/src/argv.rs
+++ b/crates/legolas-cli/src/argv.rs
@@ -11,29 +11,16 @@ pub enum Command {
     Unknown(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CliArgs {
     pub command: Option<Command>,
-    pub target_path: PathBuf,
+    pub target_path: Option<PathBuf>,
+    pub config_path: Option<PathBuf>,
     pub json: bool,
     pub limit: Option<usize>,
     pub top: Option<usize>,
     pub help: bool,
     pub version: bool,
-}
-
-impl Default for CliArgs {
-    fn default() -> Self {
-        Self {
-            command: None,
-            target_path: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-            json: false,
-            limit: None,
-            top: None,
-            help: false,
-            version: false,
-        }
-    }
 }
 
 pub fn parse_argv<I, S>(args: I) -> Result<CliArgs>
@@ -55,7 +42,7 @@ where
         }
 
         if !token.starts_with('-') {
-            parsed.target_path = resolve_target_path(token)?;
+            parsed.target_path = Some(resolve_path_token(token)?);
             index += 1;
             continue;
         }
@@ -69,6 +56,20 @@ where
             }
             "--json" => {
                 parsed.json = true;
+            }
+            "--config" => {
+                let next = tokens
+                    .get(index + 1)
+                    .ok_or_else(|| LegolasError::CliUsage("--config expects a path".to_string()))?;
+
+                if next.starts_with('-') {
+                    return Err(LegolasError::CliUsage(
+                        "--config expects a path".to_string(),
+                    ));
+                }
+
+                parsed.config_path = Some(resolve_path_token(next)?);
+                index += 1;
             }
             "--limit" | "--top" => {
                 let next = tokens
@@ -118,7 +119,7 @@ fn parse_command(token: &str) -> Command {
     }
 }
 
-fn resolve_target_path(token: &str) -> Result<PathBuf> {
+fn resolve_path_token(token: &str) -> Result<PathBuf> {
     let path = PathBuf::from(token);
     if path.is_absolute() {
         return Ok(path);

--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -4,19 +4,24 @@ use legolas_cli::{
     argv::{self, Command},
     reporters::text::{format_optimize_report, format_scan_report, format_visualization_report},
 };
-use legolas_core::{analyze_project, LegolasError, Result};
+use legolas_core::{
+    analyze_project,
+    config::{load_config_file, load_discovered_config, LoadedConfig},
+    LegolasError, Result,
+};
 
 const HELP_TEXT: &str = r#"Legolas
 Slim bundles with precision.
 
 Usage:
-  legolas scan [path] [--json]
-  legolas visualize [path] [--limit 10]
-  legolas optimize [path] [--top 5]
+  legolas scan [path] [--config file] [--json]
+  legolas visualize [path] [--config file] [--limit 10]
+  legolas optimize [path] [--config file] [--top 5]
   legolas help
 
 Examples:
   legolas scan .
+  legolas scan --config ./legolas.config.json
   legolas visualize ./apps/storefront --limit 12
   legolas optimize --top 7
 "#;
@@ -37,18 +42,21 @@ fn run() -> Result<()> {
     }
 
     if parsed.help || parsed.command.is_none() || matches!(parsed.command, Some(Command::Help)) {
-        println!("{HELP_TEXT}");
+        print!("{HELP_TEXT}");
         return Ok(());
     }
 
-    let command = parsed.command.expect("command already checked");
+    let command = parsed.command.clone().expect("command already checked");
     if let Command::Unknown(command) = command {
         return Err(LegolasError::CliUsage(format!(
             "unknown command \"{command}\""
         )));
     }
 
-    let analysis = analyze_project(&parsed.target_path)?;
+    let loaded_config = resolve_loaded_config(&parsed)?;
+    emit_config_warnings(loaded_config.as_ref(), parsed.json);
+    let target_path = resolve_target_path(&parsed, loaded_config.as_ref())?;
+    let analysis = analyze_project(&target_path)?;
 
     if parsed.json {
         println!("{}", serde_json::to_string_pretty(&analysis)?);
@@ -57,8 +65,14 @@ fn run() -> Result<()> {
 
     let output = match command {
         Command::Scan => format_scan_report(&analysis),
-        Command::Visualize => format_visualization_report(&analysis, parsed.limit.unwrap_or(10)),
-        Command::Optimize => format_optimize_report(&analysis, parsed.top.unwrap_or(5)),
+        Command::Visualize => format_visualization_report(
+            &analysis,
+            resolve_visualize_limit(&parsed, loaded_config.as_ref()),
+        ),
+        Command::Optimize => format_optimize_report(
+            &analysis,
+            resolve_optimize_top(&parsed, loaded_config.as_ref()),
+        ),
         Command::Help | Command::Unknown(_) => unreachable!("handled above"),
     };
 
@@ -83,4 +97,76 @@ fn workspace_root() -> PathBuf {
         .and_then(|path| path.parent())
         .expect("workspace root")
         .to_path_buf()
+}
+
+fn resolve_loaded_config(parsed: &argv::CliArgs) -> Result<Option<LoadedConfig>> {
+    if let Some(config_path) = &parsed.config_path {
+        return Ok(Some(load_config_file(config_path)?));
+    }
+
+    let discovery_input = parsed
+        .target_path
+        .clone()
+        .unwrap_or(std::env::current_dir()?);
+    load_discovered_config(discovery_input)
+}
+
+fn emit_config_warnings(config: Option<&LoadedConfig>, json_mode: bool) {
+    if json_mode {
+        return;
+    }
+
+    let Some(config) = config else {
+        return;
+    };
+
+    for warning in &config.warnings {
+        eprintln!(
+            "legolas: config warning: {}: {}",
+            config.path.display(),
+            warning
+        );
+    }
+}
+
+fn resolve_target_path(parsed: &argv::CliArgs, config: Option<&LoadedConfig>) -> Result<PathBuf> {
+    if let Some(target_path) = &parsed.target_path {
+        return Ok(target_path.clone());
+    }
+
+    if let Some(default_path) = config
+        .and_then(|item| item.config.command_defaults.scan_path.as_deref())
+        .map(|value| resolve_config_relative_path(config.expect("config exists"), value))
+    {
+        return Ok(default_path);
+    }
+
+    std::env::current_dir().map_err(Into::into)
+}
+
+fn resolve_visualize_limit(parsed: &argv::CliArgs, config: Option<&LoadedConfig>) -> usize {
+    parsed
+        .limit
+        .or_else(|| config.and_then(|item| item.config.command_defaults.visualize_limit))
+        .unwrap_or(10)
+}
+
+fn resolve_optimize_top(parsed: &argv::CliArgs, config: Option<&LoadedConfig>) -> usize {
+    parsed
+        .top
+        .or_else(|| config.and_then(|item| item.config.command_defaults.optimize_top))
+        .unwrap_or(5)
+}
+
+fn resolve_config_relative_path(config: &LoadedConfig, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        return path;
+    }
+
+    config
+        .path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join(path)
 }

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -158,6 +158,10 @@ fn matches_missing_number_and_unknown_flag_contracts() {
             vec!["--bogus".to_string()],
             "legolas: unknown flag \"--bogus\"\n",
         ),
+        (
+            vec!["scan".to_string(), "--config".to_string()],
+            "legolas: --config expects a path\n",
+        ),
     ];
 
     for (args, expected_stderr) in cases {

--- a/crates/legolas-cli/tests/config_contract.rs
+++ b/crates/legolas-cli/tests/config_contract.rs
@@ -1,0 +1,216 @@
+mod support;
+
+use std::{fs, path::Path};
+
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(args)
+        .output()
+        .expect("run command")
+}
+
+fn run_cli_in_dir(current_dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .current_dir(current_dir)
+        .args(args)
+        .output()
+        .expect("run command in directory")
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout")
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr")
+}
+
+fn normalize(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
+#[test]
+fn explicit_config_path_applies_relative_scan_path_and_command_defaults() {
+    let config_path =
+        support::fixture_path("tests/fixtures/config/explicit-path/custom.config.json");
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+
+    let visualize_output = run_cli(&["visualize", "--config", &config_path.display().to_string()]);
+    let visualize_expected = run_cli(&[
+        "visualize",
+        &basic_app.display().to_string(),
+        "--limit",
+        "2",
+    ]);
+
+    assert!(visualize_output.status.success());
+    assert_eq!(stdout(&visualize_output), stdout(&visualize_expected));
+    assert_eq!(stderr(&visualize_output), "");
+
+    let optimize_output = run_cli(&["optimize", "--config", &config_path.display().to_string()]);
+    let optimize_expected = run_cli(&["optimize", &basic_app.display().to_string(), "--top", "2"]);
+
+    assert!(optimize_output.status.success());
+    assert_eq!(stdout(&optimize_output), stdout(&optimize_expected));
+    assert_eq!(stderr(&optimize_output), "");
+}
+
+#[test]
+fn discovered_config_applies_defaults_from_current_project_root() {
+    let project_root = support::fixture_path("tests/fixtures/config/cli-override");
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+
+    let visualize_output = run_cli_in_dir(&project_root, &["visualize"]);
+    let visualize_expected = run_cli(&[
+        "visualize",
+        &basic_app.display().to_string(),
+        "--limit",
+        "2",
+    ]);
+
+    assert!(visualize_output.status.success());
+    assert_eq!(stdout(&visualize_output), stdout(&visualize_expected));
+    assert_eq!(stderr(&visualize_output), "");
+
+    let optimize_output = run_cli_in_dir(&project_root, &["optimize"]);
+    let optimize_expected = run_cli(&["optimize", &basic_app.display().to_string(), "--top", "2"]);
+
+    assert!(optimize_output.status.success());
+    assert_eq!(stdout(&optimize_output), stdout(&optimize_expected));
+    assert_eq!(stderr(&optimize_output), "");
+}
+
+#[test]
+fn cli_flags_override_config_defaults() {
+    let project_root = support::fixture_path("tests/fixtures/config/cli-override");
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+
+    let visualize_output = run_cli_in_dir(&project_root, &["visualize", "--limit", "1"]);
+    let visualize_expected = run_cli(&[
+        "visualize",
+        &basic_app.display().to_string(),
+        "--limit",
+        "1",
+    ]);
+
+    assert!(visualize_output.status.success());
+    assert_eq!(stdout(&visualize_output), stdout(&visualize_expected));
+    assert_eq!(stderr(&visualize_output), "");
+
+    let optimize_output = run_cli_in_dir(&project_root, &["optimize", "--top", "1"]);
+    let optimize_expected = run_cli(&["optimize", &basic_app.display().to_string(), "--top", "1"]);
+
+    assert!(optimize_output.status.success());
+    assert_eq!(stdout(&optimize_output), stdout(&optimize_expected));
+    assert_eq!(stderr(&optimize_output), "");
+}
+
+#[test]
+fn malformed_discovered_config_fails_with_dedicated_error() {
+    let fixture = support::fixture_path("tests/fixtures/config/invalid-json");
+    let output = run_cli(&["visualize", &fixture.display().to_string()]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout(&output), "");
+    assert!(normalize(&stderr(&output)).starts_with(&format!(
+        "legolas: malformed config {}/tests/fixtures/config/invalid-json/legolas.config.json:",
+        normalize(&support::workspace_root().display().to_string())
+    )));
+}
+
+#[test]
+fn help_and_version_do_not_touch_invalid_discovered_config() {
+    let invalid_root = support::fixture_path("tests/fixtures/config/invalid-json");
+
+    let help_output = run_cli_in_dir(&invalid_root, &[]);
+    assert!(help_output.status.success());
+    assert_eq!(
+        support::normalize_cli_output(&stdout(&help_output)),
+        support::read_oracle("cli/help.txt")
+    );
+    assert_eq!(stderr(&help_output), "");
+
+    let version_output = run_cli_in_dir(&invalid_root, &["--version"]);
+    assert!(version_output.status.success());
+    assert_eq!(
+        support::normalize_cli_output(&stdout(&version_output)),
+        support::read_oracle("cli/version.txt")
+    );
+    assert_eq!(stderr(&version_output), "");
+}
+
+#[test]
+fn config_warning_uses_stderr_without_failing_the_command() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("legolas.config.json");
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    fs::write(
+        &config_path,
+        format!(
+            r#"{{
+  "scan": {{ "path": "{}" }},
+  "visualize": {{ "limit": 2, "theme": "wide" }},
+  "extra": true
+}}
+"#,
+            normalize(&basic_app.display().to_string())
+        ),
+    )
+    .expect("write config");
+
+    let output = run_cli(&["visualize", "--config", &config_path.display().to_string()]);
+    let expected = run_cli(&[
+        "visualize",
+        &basic_app.display().to_string(),
+        "--limit",
+        "2",
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stdout(&output), stdout(&expected));
+    let normalized_stderr = normalize(&stderr(&output));
+    assert!(normalized_stderr.contains("legolas: config warning:"));
+    assert!(normalized_stderr.contains("visualize.theme: unknown config key ignored"));
+    assert!(normalized_stderr.contains("extra: unknown config key ignored"));
+}
+
+#[test]
+fn json_mode_suppresses_config_warnings_to_keep_machine_output_clean() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("legolas.config.json");
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    fs::write(
+        &config_path,
+        format!(
+            r#"{{
+  "scan": {{ "path": "{}" }},
+  "visualize": {{ "limit": 2, "theme": "wide" }},
+  "extra": true
+}}
+"#,
+            normalize(&basic_app.display().to_string())
+        ),
+    )
+    .expect("write config");
+
+    let output = run_cli(&[
+        "scan",
+        "--config",
+        &config_path.display().to_string(),
+        "--json",
+    ]);
+    let expected = run_cli(&["scan", &basic_app.display().to_string(), "--json"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        support::normalize_analysis_json_output(&stdout(&output)),
+        support::normalize_analysis_json_output(&stdout(&expected))
+    );
+    assert_eq!(stderr(&output), "");
+}

--- a/tests/fixtures/config/cli-override/legolas.config.json
+++ b/tests/fixtures/config/cli-override/legolas.config.json
@@ -1,0 +1,11 @@
+{
+  "scan": {
+    "path": "../../parity/basic-app"
+  },
+  "visualize": {
+    "limit": 2
+  },
+  "optimize": {
+    "top": 2
+  }
+}

--- a/tests/fixtures/config/cli-override/package.json
+++ b/tests/fixtures/config/cli-override/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "config-cli-override-fixture"
+}

--- a/tests/fixtures/config/explicit-path/custom.config.json
+++ b/tests/fixtures/config/explicit-path/custom.config.json
@@ -1,0 +1,11 @@
+{
+  "scan": {
+    "path": "../../parity/basic-app"
+  },
+  "visualize": {
+    "limit": 2
+  },
+  "optimize": {
+    "top": 2
+  }
+}

--- a/tests/fixtures/config/explicit-path/package.json
+++ b/tests/fixtures/config/explicit-path/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "config-explicit-path-fixture"
+}

--- a/tests/oracles/cli/help.txt
+++ b/tests/oracles/cli/help.txt
@@ -2,13 +2,13 @@ Legolas
 Slim bundles with precision.
 
 Usage:
-  legolas scan [path] [--json]
-  legolas visualize [path] [--limit 10]
-  legolas optimize [path] [--top 5]
+  legolas scan [path] [--config file] [--json]
+  legolas visualize [path] [--config file] [--limit 10]
+  legolas optimize [path] [--config file] [--top 5]
   legolas help
 
 Examples:
   legolas scan .
+  legolas scan --config ./legolas.config.json
   legolas visualize ./apps/storefront --limit 12
   legolas optimize --top 7
-


### PR DESCRIPTION
배경
Rust 기반 CLI에 config discovery와 explicit `--config` 경로를 실제로 연결해 다음 budget/ci 기능이 같은 contract를 재사용할 수 있도록 준비했습니다.

변경 사항
- `--config <path>` 파싱과 help oracle 갱신을 추가했습니다.
- precedence를 `CLI 인자 > explicit config > discovered config > built-in default`로 맞췄습니다.
- `scan.path`를 config 파일 위치 기준 상대경로로 해석하도록 연결했습니다.
- `visualize.limit`, `optimize.top` config adoption과 malformed config / warning stderr contract를 Rust CLI에서 검증했습니다.
- JSON 모드에서는 config warning을 suppress해서 machine-consumable stdout contract를 지키도록 보강했습니다.

검증
- `cargo fmt --all --check`
- `cargo test -p legolas-cli --test cli_contract`
- `cargo test -p legolas-cli --test config_contract`
- `cargo test --workspace`
- Devil's Advocate review loop Round 1 finding 1건 반영 후 재검증 완료

브랜치 / 워크트리
- 대상 브랜치: `master`
- 작업 브랜치: `codex/dx-002b-cli-config-adoption`
- 작업 워크트리: `/Users/pjw/workspace/legolas`

이슈 연결
- 없음