### PR TITLE
feat: Rust budget evaluator core 추가

### DIFF
--- a/crates/legolas-core/src/budget.rs
+++ b/crates/legolas-core/src/budget.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::{BudgetRules, BudgetThresholds},
+    models::Analysis,
+};
+
+const POTENTIAL_KB_SAVED_KEY: &str = "potentialKbSaved";
+const DUPLICATE_PACKAGE_COUNT_KEY: &str = "duplicatePackageCount";
+const DYNAMIC_IMPORT_COUNT_KEY: &str = "dynamicImportCount";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+pub enum BudgetStatus {
+    #[default]
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetRuleResult {
+    pub key: String,
+    pub actual: usize,
+    pub warn_at: usize,
+    pub fail_at: usize,
+    pub status: BudgetStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetEvaluation {
+    pub overall_status: BudgetStatus,
+    pub rules: Vec<BudgetRuleResult>,
+}
+
+impl BudgetEvaluation {
+    pub fn has_failures(&self) -> bool {
+        self.overall_status == BudgetStatus::Fail
+    }
+}
+
+pub fn evaluate_budget(analysis: &Analysis, overrides: Option<&BudgetRules>) -> BudgetEvaluation {
+    let rules = resolved_rules(overrides);
+    let results = vec![
+        evaluate_max_rule(
+            POTENTIAL_KB_SAVED_KEY,
+            analysis.impact.potential_kb_saved,
+            rules
+                .potential_kb_saved
+                .as_ref()
+                .expect("starter rule exists"),
+        ),
+        evaluate_max_rule(
+            DUPLICATE_PACKAGE_COUNT_KEY,
+            analysis.duplicate_packages.len(),
+            rules
+                .duplicate_package_count
+                .as_ref()
+                .expect("starter rule exists"),
+        ),
+        evaluate_min_rule(
+            DYNAMIC_IMPORT_COUNT_KEY,
+            analysis.source_summary.dynamic_imports,
+            rules
+                .dynamic_import_count
+                .as_ref()
+                .expect("starter rule exists"),
+        ),
+    ];
+    let overall_status = results
+        .iter()
+        .map(|item| item.status)
+        .max()
+        .unwrap_or_default();
+
+    BudgetEvaluation {
+        overall_status,
+        rules: results,
+    }
+}
+
+fn resolved_rules(overrides: Option<&BudgetRules>) -> BudgetRules {
+    overrides
+        .map(BudgetRules::merged_with_starter_defaults)
+        .unwrap_or_else(BudgetRules::starter_defaults)
+}
+
+fn evaluate_max_rule(key: &str, actual: usize, thresholds: &BudgetThresholds) -> BudgetRuleResult {
+    BudgetRuleResult {
+        key: key.to_string(),
+        actual,
+        warn_at: thresholds.warn_at,
+        fail_at: thresholds.fail_at,
+        status: evaluate_max_status(actual, thresholds),
+    }
+}
+
+fn evaluate_min_rule(key: &str, actual: usize, thresholds: &BudgetThresholds) -> BudgetRuleResult {
+    BudgetRuleResult {
+        key: key.to_string(),
+        actual,
+        warn_at: thresholds.warn_at,
+        fail_at: thresholds.fail_at,
+        status: evaluate_min_status(actual, thresholds),
+    }
+}
+
+fn evaluate_max_status(actual: usize, thresholds: &BudgetThresholds) -> BudgetStatus {
+    if actual >= thresholds.fail_at {
+        return BudgetStatus::Fail;
+    }
+
+    if actual >= thresholds.warn_at {
+        return BudgetStatus::Warn;
+    }
+
+    BudgetStatus::Pass
+}
+
+fn evaluate_min_status(actual: usize, thresholds: &BudgetThresholds) -> BudgetStatus {
+    if actual <= thresholds.fail_at {
+        return BudgetStatus::Fail;
+    }
+
+    if actual <= thresholds.warn_at {
+        return BudgetStatus::Warn;
+    }
+
+    BudgetStatus::Pass
+}

--- a/crates/legolas-core/src/config.rs
+++ b/crates/legolas-core/src/config.rs
@@ -9,6 +9,12 @@ use crate::{error::Result, workspace::find_discovered_config_path, LegolasError}
 
 const UNKNOWN_KEY_WARNING: &str = "unknown config key ignored";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ThresholdDirection {
+    Max,
+    Min,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct LegolasConfig {
     pub command_defaults: CommandDefaults,
@@ -30,6 +36,42 @@ pub struct BudgetRules {
 }
 
 impl BudgetRules {
+    pub fn starter_defaults() -> Self {
+        Self {
+            potential_kb_saved: Some(BudgetThresholds {
+                warn_at: 40,
+                fail_at: 80,
+            }),
+            duplicate_package_count: Some(BudgetThresholds {
+                warn_at: 2,
+                fail_at: 4,
+            }),
+            dynamic_import_count: Some(BudgetThresholds {
+                warn_at: 1,
+                fail_at: 0,
+            }),
+        }
+    }
+
+    pub fn merged_with_starter_defaults(&self) -> Self {
+        let defaults = Self::starter_defaults();
+
+        Self {
+            potential_kb_saved: self
+                .potential_kb_saved
+                .clone()
+                .or(defaults.potential_kb_saved),
+            duplicate_package_count: self
+                .duplicate_package_count
+                .clone()
+                .or(defaults.duplicate_package_count),
+            dynamic_import_count: self
+                .dynamic_import_count
+                .clone()
+                .or(defaults.dynamic_import_count),
+        }
+    }
+
     fn is_empty(&self) -> bool {
         self.potential_kb_saved.is_none()
             && self.duplicate_package_count.is_none()
@@ -215,18 +257,21 @@ fn parse_budget(
             config_path,
             warnings,
             "budget.rules.potentialKbSaved",
+            ThresholdDirection::Max,
         )?,
         duplicate_package_count: parse_threshold_rule(
             rules_map.get("duplicatePackageCount"),
             config_path,
             warnings,
             "budget.rules.duplicatePackageCount",
+            ThresholdDirection::Max,
         )?,
         dynamic_import_count: parse_threshold_rule(
             rules_map.get("dynamicImportCount"),
             config_path,
             warnings,
             "budget.rules.dynamicImportCount",
+            ThresholdDirection::Min,
         )?,
     };
 
@@ -242,6 +287,7 @@ fn parse_threshold_rule(
     config_path: &Path,
     warnings: &mut Vec<ConfigWarning>,
     key_path: &str,
+    direction: ThresholdDirection,
 ) -> Result<Option<BudgetThresholds>> {
     let Some(value) = value else {
         return Ok(None);
@@ -257,10 +303,12 @@ fn parse_threshold_rule(
         .get("failAt")
         .ok_or_else(|| unsupported_shape(config_path, &format!("{key_path}.failAt"), "integer"))?;
 
-    Ok(Some(BudgetThresholds {
-        warn_at: expect_usize(warn_at, config_path, &format!("{key_path}.warnAt"))?,
-        fail_at: expect_usize(fail_at, config_path, &format!("{key_path}.failAt"))?,
-    }))
+    let warn_at = expect_usize(warn_at, config_path, &format!("{key_path}.warnAt"))?;
+    let fail_at = expect_usize(fail_at, config_path, &format!("{key_path}.failAt"))?;
+
+    validate_threshold_ordering(config_path, key_path, direction, warn_at, fail_at)?;
+
+    Ok(Some(BudgetThresholds { warn_at, fail_at }))
 }
 
 fn expect_object<'a>(
@@ -294,6 +342,28 @@ fn expect_usize(value: &Value, config_path: &Path, key_path: &str) -> Result<usi
         .ok_or_else(|| unsupported_shape(config_path, key_path, "integer"))?;
 
     usize::try_from(raw).map_err(|_| unsupported_shape(config_path, key_path, "integer"))
+}
+
+fn validate_threshold_ordering(
+    config_path: &Path,
+    key_path: &str,
+    direction: ThresholdDirection,
+    warn_at: usize,
+    fail_at: usize,
+) -> Result<()> {
+    match direction {
+        ThresholdDirection::Max if warn_at > fail_at => Err(unsupported_shape(
+            config_path,
+            key_path,
+            "warnAt must be less than or equal to failAt for max rule",
+        )),
+        ThresholdDirection::Min if warn_at < fail_at => Err(unsupported_shape(
+            config_path,
+            key_path,
+            "warnAt must be greater than or equal to failAt for min rule",
+        )),
+        _ => Ok(()),
+    }
 }
 
 fn warn_unknown_keys(

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod analyze;
+pub mod budget;
 pub mod config;
 pub mod error;
 pub mod impact;

--- a/crates/legolas-core/tests/budget_evaluator.rs
+++ b/crates/legolas-core/tests/budget_evaluator.rs
@@ -1,0 +1,149 @@
+use legolas_core::{
+    budget::{evaluate_budget, BudgetStatus},
+    config::{BudgetRules, BudgetThresholds},
+    Analysis, DuplicatePackage,
+};
+
+#[test]
+fn evaluate_budget_uses_starter_thresholds_when_no_override_is_present() {
+    let evaluation = evaluate_budget(&analysis_with_metrics(39, 1, 2), None);
+
+    assert_eq!(evaluation.overall_status, BudgetStatus::Pass);
+    assert_eq!(
+        rule_snapshot(&evaluation),
+        vec![
+            (
+                "potentialKbSaved".to_string(),
+                39,
+                40,
+                80,
+                BudgetStatus::Pass,
+            ),
+            (
+                "duplicatePackageCount".to_string(),
+                1,
+                2,
+                4,
+                BudgetStatus::Pass,
+            ),
+            (
+                "dynamicImportCount".to_string(),
+                2,
+                1,
+                0,
+                BudgetStatus::Pass,
+            ),
+        ]
+    );
+    assert!(!evaluation.has_failures());
+}
+
+#[test]
+fn evaluate_budget_merges_partial_overrides_with_starter_defaults() {
+    let overrides = BudgetRules {
+        potential_kb_saved: None,
+        duplicate_package_count: Some(BudgetThresholds {
+            warn_at: 1,
+            fail_at: 2,
+        }),
+        dynamic_import_count: Some(BudgetThresholds {
+            warn_at: 3,
+            fail_at: 1,
+        }),
+    };
+    let evaluation = evaluate_budget(&analysis_with_metrics(39, 2, 2), Some(&overrides));
+
+    assert_eq!(evaluation.overall_status, BudgetStatus::Fail);
+    assert_eq!(
+        rule_snapshot(&evaluation),
+        vec![
+            (
+                "potentialKbSaved".to_string(),
+                39,
+                40,
+                80,
+                BudgetStatus::Pass,
+            ),
+            (
+                "duplicatePackageCount".to_string(),
+                2,
+                1,
+                2,
+                BudgetStatus::Fail,
+            ),
+            (
+                "dynamicImportCount".to_string(),
+                2,
+                3,
+                1,
+                BudgetStatus::Warn,
+            ),
+        ]
+    );
+    assert!(evaluation.has_failures());
+}
+
+#[test]
+fn evaluate_budget_locks_warn_and_fail_boundaries_for_each_rule() {
+    let warn = evaluate_budget(&analysis_with_metrics(40, 2, 1), None);
+    let fail = evaluate_budget(&analysis_with_metrics(80, 4, 0), None);
+
+    assert_eq!(warn.overall_status, BudgetStatus::Warn);
+    assert_eq!(
+        rule_statuses(&warn),
+        vec![BudgetStatus::Warn, BudgetStatus::Warn, BudgetStatus::Warn]
+    );
+
+    assert_eq!(fail.overall_status, BudgetStatus::Fail);
+    assert_eq!(
+        rule_statuses(&fail),
+        vec![BudgetStatus::Fail, BudgetStatus::Fail, BudgetStatus::Fail]
+    );
+}
+
+fn analysis_with_metrics(
+    potential_kb_saved: usize,
+    duplicate_package_count: usize,
+    dynamic_import_count: usize,
+) -> Analysis {
+    Analysis {
+        impact: legolas_core::Impact {
+            potential_kb_saved,
+            ..legolas_core::Impact::default()
+        },
+        duplicate_packages: (0..duplicate_package_count)
+            .map(|index| DuplicatePackage {
+                name: format!("pkg-{index}"),
+                count: 2,
+                ..DuplicatePackage::default()
+            })
+            .collect(),
+        source_summary: legolas_core::SourceSummary {
+            dynamic_imports: dynamic_import_count,
+            ..legolas_core::SourceSummary::default()
+        },
+        ..Analysis::default()
+    }
+}
+
+fn rule_snapshot(
+    evaluation: &legolas_core::budget::BudgetEvaluation,
+) -> Vec<(String, usize, usize, usize, BudgetStatus)> {
+    evaluation
+        .rules
+        .iter()
+        .map(|item| {
+            (
+                item.key.clone(),
+                item.actual,
+                item.warn_at,
+                item.fail_at,
+                item.status,
+            )
+        })
+        .collect()
+}
+
+fn rule_statuses(evaluation: &legolas_core::budget::BudgetEvaluation) -> Vec<BudgetStatus> {
+    evaluation.rules.iter().map(|item| item.status).collect()
+}

--- a/crates/legolas-core/tests/config_loading.rs
+++ b/crates/legolas-core/tests/config_loading.rs
@@ -165,6 +165,78 @@ fn load_discovered_config_reports_malformed_json_with_config_path() {
     }
 }
 
+#[test]
+fn load_config_file_rejects_invalid_max_threshold_ordering() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("legolas.config.json");
+    fs::write(
+        &config_path,
+        r#"{
+  "budget": {
+    "rules": {
+      "potentialKbSaved": { "warnAt": 80, "failAt": 40 }
+    }
+  }
+}
+"#,
+    )
+    .expect("write config");
+
+    let error = load_config_file(&config_path).expect_err("invalid max threshold should fail");
+
+    match error {
+        LegolasError::UnsupportedConfigShape {
+            path,
+            key_path,
+            message,
+        } => {
+            assert_eq!(path, config_path.display().to_string());
+            assert_eq!(key_path, "budget.rules.potentialKbSaved");
+            assert_eq!(
+                message,
+                "expected warnAt must be less than or equal to failAt for max rule"
+            );
+        }
+        other => panic!("expected unsupported config shape error, got {other:?}"),
+    }
+}
+
+#[test]
+fn load_config_file_rejects_invalid_min_threshold_ordering() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("legolas.config.json");
+    fs::write(
+        &config_path,
+        r#"{
+  "budget": {
+    "rules": {
+      "dynamicImportCount": { "warnAt": 0, "failAt": 1 }
+    }
+  }
+}
+"#,
+    )
+    .expect("write config");
+
+    let error = load_config_file(&config_path).expect_err("invalid min threshold should fail");
+
+    match error {
+        LegolasError::UnsupportedConfigShape {
+            path,
+            key_path,
+            message,
+        } => {
+            assert_eq!(path, config_path.display().to_string());
+            assert_eq!(key_path, "budget.rules.dynamicImportCount");
+            assert_eq!(
+                message,
+                "expected warnAt must be greater than or equal to failAt for min rule"
+            );
+        }
+        other => panic!("expected unsupported config shape error, got {other:?}"),
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn find_discovered_config_path_surfaces_metadata_failures_instead_of_hiding_them() {


### PR DESCRIPTION
배경
`budget` command와 이후 `ci` command가 같은 evaluator를 재사용할 수 있도록, core 레벨에서 reusable budget evaluation foundation을 먼저 고정했습니다.

변경 사항
- `crates/legolas-core/src/budget.rs`에 `BudgetStatus`, `BudgetRuleResult`, `BudgetEvaluation`, `evaluate_budget()`를 추가했습니다.
- `crates/legolas-core/src/config.rs`에 starter threshold와 partial override merge helper를 추가했습니다.
- `crates/legolas-core/tests/budget_evaluator.rs`에서 built-in default, partial override, warn/fail 경계값을 고정했습니다.
- 이 PR은 core evaluator만 다루며 CLI `budget`/`ci` command wiring은 포함하지 않습니다.

검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Devil's Advocate review loop Round 1: meaningful finding 없음

브랜치 / 워크트리
- 대상 브랜치: `master`
- 작업 브랜치: `codex/cli-006a-budget-evaluator-core`
- 작업 워크트리: `/Users/pjw/workspace/legolas`

이슈 연결
- 없음