### PR TITLE
feat: Rust budget 커맨드와 출력 계약 추가

### DIFF
--- a/crates/legolas-cli/src/argv.rs
+++ b/crates/legolas-cli/src/argv.rs
@@ -7,6 +7,7 @@ pub enum Command {
     Scan,
     Visualize,
     Optimize,
+    Budget,
     Help,
     Unknown(String),
 }
@@ -23,6 +24,13 @@ pub struct CliArgs {
     pub version: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PendingNumericValue {
+    MissingOrFlag,
+    MissingOrFlagBeforeCommand,
+    Raw(String),
+}
+
 pub fn parse_argv<I, S>(args: I) -> Result<CliArgs>
 where
     I: IntoIterator<Item = S>,
@@ -30,6 +38,8 @@ where
 {
     let tokens = args.into_iter().map(Into::into).collect::<Vec<_>>();
     let mut parsed = CliArgs::default();
+    let mut pending_limit = None;
+    let mut pending_top = None;
     let mut index = 0;
 
     while index < tokens.len() {
@@ -72,31 +82,28 @@ where
                 index += 1;
             }
             "--limit" | "--top" => {
-                let next = tokens
-                    .get(index + 1)
-                    .ok_or_else(|| LegolasError::CliUsage(format!("{token} expects a number")))?;
-
-                if next.starts_with('-') {
-                    return Err(LegolasError::CliUsage(format!("{token} expects a number")));
-                }
-
-                let parsed_value = next.parse::<usize>().map_err(|_| {
-                    LegolasError::CliUsage(format!("{token} expects a positive integer"))
-                })?;
-
-                if parsed_value < 1 {
-                    return Err(LegolasError::CliUsage(format!(
-                        "{token} expects a positive integer"
-                    )));
-                }
+                let command_known = parsed.command.is_some();
+                let pending_value = match tokens.get(index + 1) {
+                    Some(next) if !next.starts_with('-') => {
+                        index += 1;
+                        PendingNumericValue::Raw(next.clone())
+                    }
+                    Some(next) if command_known && looks_like_signed_integer_token(next) => {
+                        index += 1;
+                        PendingNumericValue::Raw(next.clone())
+                    }
+                    Some(next) if !command_known && next.starts_with('-') => {
+                        index += 1;
+                        PendingNumericValue::MissingOrFlagBeforeCommand
+                    }
+                    _ => PendingNumericValue::MissingOrFlag,
+                };
 
                 match token.as_str() {
-                    "--limit" => parsed.limit = Some(parsed_value),
-                    "--top" => parsed.top = Some(parsed_value),
-                    _ => {}
+                    "--limit" => pending_limit = Some(pending_value),
+                    "--top" => pending_top = Some(pending_value),
+                    _ => unreachable!("validated numeric flag"),
                 }
-
-                index += 1;
             }
             _ => {
                 return Err(LegolasError::CliUsage(format!("unknown flag \"{token}\"")));
@@ -106,6 +113,9 @@ where
         index += 1;
     }
 
+    parsed.limit = finalize_numeric_flag(parsed.command.as_ref(), pending_limit, "--limit")?;
+    parsed.top = finalize_numeric_flag(parsed.command.as_ref(), pending_top, "--top")?;
+
     Ok(parsed)
 }
 
@@ -114,6 +124,7 @@ fn parse_command(token: &str) -> Command {
         "scan" => Command::Scan,
         "visualize" => Command::Visualize,
         "optimize" => Command::Optimize,
+        "budget" => Command::Budget,
         "help" => Command::Help,
         other => Command::Unknown(other.to_string()),
     }
@@ -126,4 +137,43 @@ fn resolve_path_token(token: &str) -> Result<PathBuf> {
     }
 
     Ok(std::env::current_dir()?.join(path))
+}
+
+fn finalize_numeric_flag(
+    command: Option<&Command>,
+    pending_value: Option<PendingNumericValue>,
+    token: &str,
+) -> Result<Option<usize>> {
+    let Some(pending_value) = pending_value else {
+        return Ok(None);
+    };
+
+    if matches!(command, Some(Command::Budget)) {
+        return Err(LegolasError::CliUsage(format!("unknown flag \"{token}\"")));
+    }
+
+    match pending_value {
+        PendingNumericValue::MissingOrFlag | PendingNumericValue::MissingOrFlagBeforeCommand => {
+            Err(LegolasError::CliUsage(format!("{token} expects a number")))
+        }
+        PendingNumericValue::Raw(raw) => {
+            let parsed_value = raw.parse::<usize>().map_err(|_| {
+                LegolasError::CliUsage(format!("{token} expects a positive integer"))
+            })?;
+
+            if parsed_value < 1 {
+                return Err(LegolasError::CliUsage(format!(
+                    "{token} expects a positive integer"
+                )));
+            }
+
+            Ok(Some(parsed_value))
+        }
+    }
+}
+
+fn looks_like_signed_integer_token(token: &str) -> bool {
+    token
+        .strip_prefix('-')
+        .is_some_and(|rest| !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_digit()))
 }

--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -2,10 +2,14 @@ use std::{fs, path::PathBuf};
 
 use legolas_cli::{
     argv::{self, Command},
-    reporters::text::{format_optimize_report, format_scan_report, format_visualization_report},
+    reporters::text::{
+        format_budget_report, format_optimize_report, format_scan_report,
+        format_visualization_report,
+    },
 };
 use legolas_core::{
     analyze_project,
+    budget::evaluate_budget,
     config::{load_config_file, load_discovered_config, LoadedConfig},
     LegolasError, Result,
 };
@@ -17,6 +21,7 @@ Usage:
   legolas scan [path] [--config file] [--json]
   legolas visualize [path] [--config file] [--limit 10]
   legolas optimize [path] [--config file] [--top 5]
+  legolas budget [path] [--config file] [--json]
   legolas help
 
 Examples:
@@ -24,6 +29,7 @@ Examples:
   legolas scan --config ./legolas.config.json
   legolas visualize ./apps/storefront --limit 12
   legolas optimize --top 7
+  legolas budget ./apps/storefront --json
 "#;
 
 fn main() {
@@ -52,14 +58,33 @@ fn run() -> Result<()> {
             "unknown command \"{command}\""
         )));
     }
+    validate_command_flags(&command, &parsed)?;
 
     let loaded_config = resolve_loaded_config(&parsed)?;
     emit_config_warnings(loaded_config.as_ref(), parsed.json);
     let target_path = resolve_target_path(&parsed, loaded_config.as_ref())?;
     let analysis = analyze_project(&target_path)?;
+    let budget_evaluation = matches!(command, Command::Budget).then(|| {
+        evaluate_budget(
+            &analysis,
+            loaded_config
+                .as_ref()
+                .and_then(|item| item.config.budget_rules.as_ref()),
+        )
+    });
 
     if parsed.json {
-        println!("{}", serde_json::to_string_pretty(&analysis)?);
+        match command {
+            Command::Budget => println!(
+                "{}",
+                serde_json::to_string_pretty(
+                    budget_evaluation
+                        .as_ref()
+                        .expect("budget evaluation exists for budget command"),
+                )?
+            ),
+            _ => println!("{}", serde_json::to_string_pretty(&analysis)?),
+        }
         return Ok(());
     }
 
@@ -72,6 +97,12 @@ fn run() -> Result<()> {
         Command::Optimize => format_optimize_report(
             &analysis,
             resolve_optimize_top(&parsed, loaded_config.as_ref()),
+        ),
+        Command::Budget => format_budget_report(
+            &analysis,
+            budget_evaluation
+                .as_ref()
+                .expect("budget evaluation exists for budget command"),
         ),
         Command::Help | Command::Unknown(_) => unreachable!("handled above"),
     };
@@ -169,4 +200,20 @@ fn resolve_config_relative_path(config: &LoadedConfig, value: &str) -> PathBuf {
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."))
         .join(path)
+}
+
+fn validate_command_flags(command: &Command, parsed: &argv::CliArgs) -> Result<()> {
+    if matches!(command, Command::Budget) {
+        if parsed.limit.is_some() {
+            return Err(LegolasError::CliUsage(
+                "unknown flag \"--limit\"".to_string(),
+            ));
+        }
+
+        if parsed.top.is_some() {
+            return Err(LegolasError::CliUsage("unknown flag \"--top\"".to_string()));
+        }
+    }
+
+    Ok(())
 }

--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -1,4 +1,4 @@
-use legolas_core::Analysis;
+use legolas_core::{budget::BudgetEvaluation, Analysis};
 
 pub fn format_scan_report(analysis: &Analysis) -> String {
     let mut lines = Vec::new();
@@ -191,6 +191,33 @@ pub fn format_optimize_report(analysis: &Analysis, top: usize) -> String {
         "Projected savings: ~{} KB, with {} confidence.",
         analysis.impact.potential_kb_saved, analysis.impact.confidence
     ));
+
+    lines.join("\n")
+}
+
+pub fn format_budget_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "Legolas budget for {}",
+        analysis.package_summary.name
+    ));
+    append_warnings(&mut lines, &analysis.warnings);
+    lines.push(String::new());
+    lines.push(format!("Overall status: {:?}", evaluation.overall_status));
+    lines.push(String::new());
+    lines.push("Rule results:".to_string());
+    append_section(
+        &mut lines,
+        &evaluation.rules,
+        |item, _| {
+            format!(
+                "- {}: {:?} (actual: {}, warnAt: {}, failAt: {})",
+                item.key, item.status, item.actual, item.warn_at, item.fail_at
+            )
+        },
+        "- none",
+    );
 
     lines.join("\n")
 }

--- a/crates/legolas-cli/tests/budget_contract.rs
+++ b/crates/legolas-cli/tests/budget_contract.rs
@@ -1,0 +1,296 @@
+mod support;
+
+use std::{fs, path::Path};
+
+use assert_cmd::Command;
+use serde_json::json;
+use tempfile::tempdir;
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(args)
+        .output()
+        .expect("run command")
+}
+
+fn run_cli_in_dir(current_dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .current_dir(current_dir)
+        .args(args)
+        .output()
+        .expect("run command in directory")
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout")
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr")
+}
+
+fn normalize(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
+#[test]
+fn budget_text_output_uses_built_in_starter_thresholds() {
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = run_cli(&["budget", &basic_app.display().to_string()]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        stdout(&output),
+        "\
+Legolas budget for basic-parity-app
+
+Overall status: Fail
+
+Rule results:
+- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
+- dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)
+"
+    );
+    assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn budget_json_output_has_a_stable_shape() {
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = run_cli(&["budget", &basic_app.display().to_string(), "--json"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        support::normalize_budget_json_output(&stdout(&output)),
+        json!({
+            "overallStatus": "Fail",
+            "rules": [
+                {
+                    "key": "potentialKbSaved",
+                    "actual": 366,
+                    "warnAt": 40,
+                    "failAt": 80,
+                    "status": "Fail"
+                },
+                {
+                    "key": "duplicatePackageCount",
+                    "actual": 1,
+                    "warnAt": 2,
+                    "failAt": 4,
+                    "status": "Pass"
+                },
+                {
+                    "key": "dynamicImportCount",
+                    "actual": 0,
+                    "warnAt": 1,
+                    "failAt": 0,
+                    "status": "Fail"
+                }
+            ]
+        })
+    );
+    assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn budget_uses_config_threshold_overrides_and_starter_fallbacks_together() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("legolas.config.json");
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    fs::write(
+        &config_path,
+        format!(
+            r#"{{
+  "scan": {{ "path": "{}" }},
+  "budget": {{
+    "rules": {{
+      "potentialKbSaved": {{ "warnAt": 400, "failAt": 500 }},
+      "duplicatePackageCount": {{ "warnAt": 1, "failAt": 2 }}
+    }}
+  }}
+}}
+"#,
+            normalize(&basic_app.display().to_string())
+        ),
+    )
+    .expect("write config");
+
+    let output = run_cli(&[
+        "budget",
+        "--config",
+        &config_path.display().to_string(),
+        "--json",
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        support::normalize_budget_json_output(&stdout(&output)),
+        json!({
+            "overallStatus": "Fail",
+            "rules": [
+                {
+                    "key": "potentialKbSaved",
+                    "actual": 366,
+                    "warnAt": 400,
+                    "failAt": 500,
+                    "status": "Pass"
+                },
+                {
+                    "key": "duplicatePackageCount",
+                    "actual": 1,
+                    "warnAt": 1,
+                    "failAt": 2,
+                    "status": "Warn"
+                },
+                {
+                    "key": "dynamicImportCount",
+                    "actual": 0,
+                    "warnAt": 1,
+                    "failAt": 0,
+                    "status": "Fail"
+                }
+            ]
+        })
+    );
+    assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn budget_uses_discovered_config_from_project_root() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let project_root = temp_dir.path();
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    fs::write(
+        project_root.join("package.json"),
+        "{\"name\":\"budget-discovered\"}",
+    )
+    .expect("write package.json");
+    fs::write(
+        project_root.join("legolas.config.json"),
+        format!(
+            r#"{{
+  "scan": {{ "path": "{}" }},
+  "budget": {{
+    "rules": {{
+      "potentialKbSaved": {{ "warnAt": 40, "failAt": 80 }},
+      "duplicatePackageCount": {{ "warnAt": 2, "failAt": 4 }},
+      "dynamicImportCount": {{ "warnAt": 1, "failAt": 0 }}
+    }}
+  }}
+}}
+"#,
+            normalize(&basic_app.display().to_string())
+        ),
+    )
+    .expect("write config");
+    let output = run_cli_in_dir(project_root, &["budget", "--json"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        support::normalize_budget_json_output(&stdout(&output)),
+        json!({
+            "overallStatus": "Fail",
+            "rules": [
+                {
+                    "key": "potentialKbSaved",
+                    "actual": 366,
+                    "warnAt": 40,
+                    "failAt": 80,
+                    "status": "Fail"
+                },
+                {
+                    "key": "duplicatePackageCount",
+                    "actual": 1,
+                    "warnAt": 2,
+                    "failAt": 4,
+                    "status": "Pass"
+                },
+                {
+                    "key": "dynamicImportCount",
+                    "actual": 0,
+                    "warnAt": 1,
+                    "failAt": 0,
+                    "status": "Fail"
+                }
+            ]
+        })
+    );
+    assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn budget_rejects_command_specific_numeric_flags() {
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    let cases = [
+        (
+            vec![
+                "budget".to_string(),
+                basic_app.display().to_string(),
+                "--limit".to_string(),
+                "1".to_string(),
+            ],
+            "legolas: unknown flag \"--limit\"\n",
+        ),
+        (
+            vec![
+                "budget".to_string(),
+                basic_app.display().to_string(),
+                "--top".to_string(),
+                "1".to_string(),
+            ],
+            "legolas: unknown flag \"--top\"\n",
+        ),
+        (
+            vec![
+                "budget".to_string(),
+                basic_app.display().to_string(),
+                "--top".to_string(),
+                "NaN".to_string(),
+            ],
+            "legolas: unknown flag \"--top\"\n",
+        ),
+        (
+            vec![
+                "budget".to_string(),
+                basic_app.display().to_string(),
+                "--limit".to_string(),
+                "-1".to_string(),
+            ],
+            "legolas: unknown flag \"--limit\"\n",
+        ),
+        (
+            vec![
+                "--top".to_string(),
+                "NaN".to_string(),
+                "budget".to_string(),
+                basic_app.display().to_string(),
+            ],
+            "legolas: unknown flag \"--top\"\n",
+        ),
+        (
+            vec![
+                "--limit".to_string(),
+                "-1".to_string(),
+                "budget".to_string(),
+                basic_app.display().to_string(),
+            ],
+            "legolas: unknown flag \"--limit\"\n",
+        ),
+    ];
+
+    for (args, expected_stderr) in cases {
+        let output = Command::cargo_bin("legolas-cli")
+            .expect("build binary")
+            .args(args)
+            .output()
+            .expect("run invalid budget command");
+
+        assert!(!output.status.success());
+        assert_eq!(output.status.code(), Some(1));
+        assert_eq!(stdout(&output), "");
+        assert_eq!(stderr(&output), expected_stderr);
+    }
+}

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -54,6 +54,10 @@ fn matches_scan_visualize_and_optimize_oracles() {
             vec!["optimize".to_string(), fixture.display().to_string()],
             "basic-app/optimize.txt",
         ),
+        (
+            vec!["budget".to_string(), fixture.display().to_string()],
+            "basic-app/budget.txt",
+        ),
     ];
 
     for (args, oracle) in cases {
@@ -104,10 +108,28 @@ fn matches_validation_error_oracles() {
         ),
         (
             vec![
+                "visualize".to_string(),
+                fixture.display().to_string(),
+                "--limit".to_string(),
+                "-1".to_string(),
+            ],
+            "errors/visualize-limit.txt",
+        ),
+        (
+            vec![
                 "optimize".to_string(),
                 fixture.display().to_string(),
                 "--top".to_string(),
                 "NaN".to_string(),
+            ],
+            "errors/optimize-top.txt",
+        ),
+        (
+            vec![
+                "optimize".to_string(),
+                fixture.display().to_string(),
+                "--top".to_string(),
+                "-1".to_string(),
             ],
             "errors/optimize-top.txt",
         ),
@@ -148,9 +170,27 @@ fn matches_missing_number_and_unknown_flag_contracts() {
         ),
         (
             vec![
+                "--limit".to_string(),
+                "-1".to_string(),
+                "visualize".to_string(),
+                fixture.display().to_string(),
+            ],
+            "legolas: --limit expects a number\n",
+        ),
+        (
+            vec![
                 "optimize".to_string(),
                 fixture.display().to_string(),
                 "--top".to_string(),
+            ],
+            "legolas: --top expects a number\n",
+        ),
+        (
+            vec![
+                "--top".to_string(),
+                "-1".to_string(),
+                "optimize".to_string(),
+                fixture.display().to_string(),
             ],
             "legolas: --top expects a number\n",
         ),

--- a/crates/legolas-cli/tests/support/mod.rs
+++ b/crates/legolas-cli/tests/support/mod.rs
@@ -41,6 +41,11 @@ pub fn normalize_analysis_json_output(output: &str) -> Value {
 }
 
 #[allow(dead_code)]
+pub fn normalize_budget_json_output(output: &str) -> Value {
+    serde_json::from_str::<Value>(output).expect("parse budget json")
+}
+
+#[allow(dead_code)]
 fn normalize_analysis_value(analysis: &mut Value) {
     replace_string_field(analysis, &["projectRoot"], "<PROJECT_ROOT>");
     replace_string_field(analysis, &["metadata", "generatedAt"], "<GENERATED_AT>");

--- a/tests/oracles/basic-app/budget.txt
+++ b/tests/oracles/basic-app/budget.txt
@@ -1,0 +1,8 @@
+Legolas budget for basic-parity-app
+
+Overall status: Fail
+
+Rule results:
+- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
+- dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)

--- a/tests/oracles/cli/help.txt
+++ b/tests/oracles/cli/help.txt
@@ -5,6 +5,7 @@ Usage:
   legolas scan [path] [--config file] [--json]
   legolas visualize [path] [--config file] [--limit 10]
   legolas optimize [path] [--config file] [--top 5]
+  legolas budget [path] [--config file] [--json]
   legolas help
 
 Examples:
@@ -12,3 +13,4 @@ Examples:
   legolas scan --config ./legolas.config.json
   legolas visualize ./apps/storefront --limit 12
   legolas optimize --top 7
+  legolas budget ./apps/storefront --json


### PR DESCRIPTION
## 배경
- `PR-CLI-006A`에서 예산 평가 코어를 추가한 뒤, CLI 표면에 `budget` 커맨드와 출력 계약을 연결할 필요가 있었습니다.
- 이번 PR은 Rust CLI에서 `budget`을 실제로 실행하고, text/JSON 출력 및 argv validation 계약을 고정합니다.

## 변경 사항
- `budget` 커맨드를 argv 파서와 main 실행 경로에 연결했습니다.
- text reporter에 budget 전용 포맷터를 추가하고, help oracle에 사용법을 반영했습니다.
- `budget_contract.rs`를 추가해 built-in 규칙, discovered config, config override, JSON shape, invalid numeric-flag 계약을 고정했습니다.
- numeric flag parser를 보강해 `budget`에서는 `--limit`/`--top`이 토큰 순서와 무관하게 `unknown flag`로 수렴하고, 기존 `visualize`/`optimize`의 legacy 에러 문구는 유지되도록 했습니다.
- `tests/oracles/basic-app/budget.txt`를 추가해 기본 text 출력 계약을 oracle로 고정했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p legolas-cli --test budget_contract`
- `cargo test -p legolas-cli --test cli_contract`
- `cargo test --workspace`
- `cargo run -q -p legolas-cli -- --limit -1 visualize tests/fixtures/parity/basic-app`
- `cargo run -q -p legolas-cli -- visualize tests/fixtures/parity/basic-app --limit -1`
- `cargo run -q -p legolas-cli -- --limit -1 budget tests/fixtures/parity/basic-app`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/cli-006b-budget-command-surface`
- 현재 워크트리: `/Users/pjw/workspace/legolas`
- 포함된 추가 source branch/worktree: 없음

## 이슈 연결
- 별도 이슈 연결 없음
