### PR TITLE
feat: Rust CI 게이트 커맨드와 종료 정책 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           node ./bin/legolas.js --version
           node ./bin/legolas.js help
+          node ./scripts/smoke-ci-command.mjs launcher
 
   rust-workspace:
     name: Rust Workspace
@@ -124,6 +125,7 @@ jobs:
           node ./bin/legolas.js --version
           node ./bin/legolas.js help
           node ./bin/legolas.js scan tests/fixtures/parity/basic-app
+          node ./scripts/smoke-ci-command.mjs launcher
 
       - name: Verify package tarball
         run: npm run pack:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,7 @@ jobs:
           node ./bin/legolas.js --version
           node ./bin/legolas.js help
           node ./bin/legolas.js scan tests/fixtures/parity/basic-app
+          node ./scripts/smoke-ci-command.mjs launcher
 
       - name: Copy release asset
         shell: bash
@@ -225,6 +226,7 @@ jobs:
           node ./bin/legolas.js --version
           node ./bin/legolas.js help
           node ./bin/legolas.js scan tests/fixtures/parity/basic-app
+          node ./scripts/smoke-ci-command.mjs launcher
 
       - name: Verify package tarball
         run: npm run pack:check

--- a/crates/legolas-cli/src/argv.rs
+++ b/crates/legolas-cli/src/argv.rs
@@ -8,6 +8,7 @@ pub enum Command {
     Visualize,
     Optimize,
     Budget,
+    Ci,
     Help,
     Unknown(String),
 }
@@ -113,6 +114,10 @@ where
         index += 1;
     }
 
+    if parsed.help || parsed.version {
+        return Ok(parsed);
+    }
+
     parsed.limit = finalize_numeric_flag(parsed.command.as_ref(), pending_limit, "--limit")?;
     parsed.top = finalize_numeric_flag(parsed.command.as_ref(), pending_top, "--top")?;
 
@@ -125,6 +130,7 @@ fn parse_command(token: &str) -> Command {
         "visualize" => Command::Visualize,
         "optimize" => Command::Optimize,
         "budget" => Command::Budget,
+        "ci" => Command::Ci,
         "help" => Command::Help,
         other => Command::Unknown(other.to_string()),
     }
@@ -148,7 +154,7 @@ fn finalize_numeric_flag(
         return Ok(None);
     };
 
-    if matches!(command, Some(Command::Budget)) {
+    if matches!(command, Some(Command::Budget | Command::Ci)) {
         return Err(LegolasError::CliUsage(format!("unknown flag \"{token}\"")));
     }
 

--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -3,16 +3,17 @@ use std::{fs, path::PathBuf};
 use legolas_cli::{
     argv::{self, Command},
     reporters::text::{
-        format_budget_report, format_optimize_report, format_scan_report,
+        format_budget_report, format_ci_report, format_optimize_report, format_scan_report,
         format_visualization_report,
     },
 };
 use legolas_core::{
     analyze_project,
-    budget::evaluate_budget,
+    budget::{evaluate_budget, BudgetEvaluation},
     config::{load_config_file, load_discovered_config, LoadedConfig},
     LegolasError, Result,
 };
+use serde_json::json;
 
 const HELP_TEXT: &str = r#"Legolas
 Slim bundles with precision.
@@ -22,6 +23,7 @@ Usage:
   legolas visualize [path] [--config file] [--limit 10]
   legolas optimize [path] [--config file] [--top 5]
   legolas budget [path] [--config file] [--json]
+  legolas ci [path] [--config file] [--json]
   legolas help
 
 Examples:
@@ -30,26 +32,30 @@ Examples:
   legolas visualize ./apps/storefront --limit 12
   legolas optimize --top 7
   legolas budget ./apps/storefront --json
+  legolas ci ./apps/storefront
 "#;
 
 fn main() {
-    if let Err(error) = run() {
-        eprintln!("legolas: {error}");
-        std::process::exit(1);
+    match run() {
+        Ok(exit_code) => std::process::exit(exit_code),
+        Err(error) => {
+            eprintln!("legolas: {error}");
+            std::process::exit(1);
+        }
     }
 }
 
-fn run() -> Result<()> {
+fn run() -> Result<i32> {
     let parsed = argv::parse_argv(std::env::args().skip(1))?;
 
     if parsed.version {
         println!("{}", read_package_version()?);
-        return Ok(());
+        return Ok(0);
     }
 
     if parsed.help || parsed.command.is_none() || matches!(parsed.command, Some(Command::Help)) {
         print!("{HELP_TEXT}");
-        return Ok(());
+        return Ok(0);
     }
 
     let command = parsed.command.clone().expect("command already checked");
@@ -58,20 +64,12 @@ fn run() -> Result<()> {
             "unknown command \"{command}\""
         )));
     }
-    validate_command_flags(&command, &parsed)?;
 
     let loaded_config = resolve_loaded_config(&parsed)?;
-    emit_config_warnings(loaded_config.as_ref(), parsed.json);
+    emit_config_warnings(&command, loaded_config.as_ref(), parsed.json);
     let target_path = resolve_target_path(&parsed, loaded_config.as_ref())?;
     let analysis = analyze_project(&target_path)?;
-    let budget_evaluation = matches!(command, Command::Budget).then(|| {
-        evaluate_budget(
-            &analysis,
-            loaded_config
-                .as_ref()
-                .and_then(|item| item.config.budget_rules.as_ref()),
-        )
-    });
+    let budget_evaluation = resolve_budget_evaluation(&command, &analysis, loaded_config.as_ref());
 
     if parsed.json {
         match command {
@@ -83,9 +81,44 @@ fn run() -> Result<()> {
                         .expect("budget evaluation exists for budget command"),
                 )?
             ),
+            Command::Ci => println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "passed": !budget_evaluation
+                        .as_ref()
+                        .expect("budget evaluation exists for ci command")
+                        .has_failures(),
+                    "overallStatus": budget_evaluation
+                        .as_ref()
+                        .expect("budget evaluation exists for ci command")
+                        .overall_status,
+                    "rules": budget_evaluation
+                        .as_ref()
+                        .expect("budget evaluation exists for ci command")
+                        .rules,
+                }))?
+            ),
             _ => println!("{}", serde_json::to_string_pretty(&analysis)?),
         }
-        return Ok(());
+
+        if matches!(command, Command::Ci)
+            && budget_evaluation
+                .as_ref()
+                .expect("budget evaluation exists for ci command")
+                .has_failures()
+        {
+            eprintln!(
+                "{}",
+                ci_failure_message(
+                    budget_evaluation
+                        .as_ref()
+                        .expect("budget evaluation exists for ci command"),
+                )
+            );
+            return Ok(1);
+        }
+
+        return Ok(0);
     }
 
     let output = match command {
@@ -104,11 +137,34 @@ fn run() -> Result<()> {
                 .as_ref()
                 .expect("budget evaluation exists for budget command"),
         ),
+        Command::Ci => format_ci_report(
+            &analysis,
+            budget_evaluation
+                .as_ref()
+                .expect("budget evaluation exists for ci command"),
+        ),
         Command::Help | Command::Unknown(_) => unreachable!("handled above"),
     };
 
     println!("{output}");
-    Ok(())
+    if matches!(command, Command::Ci)
+        && budget_evaluation
+            .as_ref()
+            .expect("budget evaluation exists for ci command")
+            .has_failures()
+    {
+        eprintln!(
+            "{}",
+            ci_failure_message(
+                budget_evaluation
+                    .as_ref()
+                    .expect("budget evaluation exists for ci command"),
+            )
+        );
+        return Ok(1);
+    }
+
+    Ok(0)
 }
 
 fn read_package_version() -> Result<String> {
@@ -142,8 +198,8 @@ fn resolve_loaded_config(parsed: &argv::CliArgs) -> Result<Option<LoadedConfig>>
     load_discovered_config(discovery_input)
 }
 
-fn emit_config_warnings(config: Option<&LoadedConfig>, json_mode: bool) {
-    if json_mode {
+fn emit_config_warnings(command: &Command, config: Option<&LoadedConfig>, json_mode: bool) {
+    if json_mode || matches!(command, Command::Ci) {
         return;
     }
 
@@ -189,6 +245,19 @@ fn resolve_optimize_top(parsed: &argv::CliArgs, config: Option<&LoadedConfig>) -
         .unwrap_or(5)
 }
 
+fn resolve_budget_evaluation(
+    command: &Command,
+    analysis: &legolas_core::Analysis,
+    config: Option<&LoadedConfig>,
+) -> Option<BudgetEvaluation> {
+    matches!(command, Command::Budget | Command::Ci).then(|| {
+        evaluate_budget(
+            analysis,
+            config.and_then(|item| item.config.budget_rules.as_ref()),
+        )
+    })
+}
+
 fn resolve_config_relative_path(config: &LoadedConfig, value: &str) -> PathBuf {
     let path = PathBuf::from(value);
     if path.is_absolute() {
@@ -202,18 +271,24 @@ fn resolve_config_relative_path(config: &LoadedConfig, value: &str) -> PathBuf {
         .join(path)
 }
 
-fn validate_command_flags(command: &Command, parsed: &argv::CliArgs) -> Result<()> {
-    if matches!(command, Command::Budget) {
-        if parsed.limit.is_some() {
-            return Err(LegolasError::CliUsage(
-                "unknown flag \"--limit\"".to_string(),
-            ));
-        }
+fn ci_failure_message(evaluation: &BudgetEvaluation) -> String {
+    let failing_rules = evaluation
+        .rules
+        .iter()
+        .filter(|item| item.status == legolas_core::budget::BudgetStatus::Fail)
+        .map(|item| item.key.as_str())
+        .collect::<Vec<_>>();
 
-        if parsed.top.is_some() {
-            return Err(LegolasError::CliUsage("unknown flag \"--top\"".to_string()));
-        }
+    if failing_rules.is_empty() {
+        return format!(
+            "CI gate failed: overall status {:?}",
+            evaluation.overall_status
+        );
     }
 
-    Ok(())
+    format!(
+        "CI gate failed: overall status {:?} (failing rules: {})",
+        evaluation.overall_status,
+        failing_rules.join(", ")
+    )
 }

--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -222,6 +222,34 @@ pub fn format_budget_report(analysis: &Analysis, evaluation: &BudgetEvaluation) 
     lines.join("\n")
 }
 
+pub fn format_ci_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(format!("Legolas CI for {}", analysis.package_summary.name));
+    append_warnings(&mut lines, &analysis.warnings);
+    lines.push(String::new());
+    lines.push(format!(
+        "Gate result: {}",
+        match evaluation.overall_status {
+            legolas_core::budget::BudgetStatus::Pass => "PASS",
+            legolas_core::budget::BudgetStatus::Warn => "WARN",
+            legolas_core::budget::BudgetStatus::Fail => "FAIL",
+        }
+    ));
+    lines.push(format!("Overall status: {:?}", evaluation.overall_status));
+    lines.push(format!(
+        "Rule statuses: {}",
+        evaluation
+            .rules
+            .iter()
+            .map(|item| format!("{}={:?}", item.key, item.status))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    lines.join("\n")
+}
+
 #[derive(Clone)]
 struct BarItem {
     label: String,

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -1,0 +1,277 @@
+mod support;
+
+use std::{fs, path::Path};
+
+use assert_cmd::Command;
+use serde_json::json;
+use tempfile::TempDir;
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(args)
+        .output()
+        .expect("run command")
+}
+
+fn run_cli_in_dir(current_dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .current_dir(current_dir)
+        .args(args)
+        .output()
+        .expect("run command in directory")
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout")
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr")
+}
+
+fn normalize(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
+#[test]
+fn ci_fail_returns_exit_code_one_and_fixed_failure_prefix() {
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = run_cli(&["ci", &basic_app.display().to_string()]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        stdout(&output),
+        "\
+Legolas CI for basic-parity-app
+
+Gate result: FAIL
+Overall status: Fail
+Rule statuses: potentialKbSaved=Fail, duplicatePackageCount=Pass, dynamicImportCount=Fail
+"
+    );
+    assert_eq!(
+        stderr(&output),
+        "CI gate failed: overall status Fail (failing rules: potentialKbSaved, dynamicImportCount)\n"
+    );
+}
+
+#[test]
+fn ci_warn_keeps_exit_code_zero() {
+    let project = dynamic_import_project("ci-warn-app", 1);
+    let output = run_cli_in_dir(project.path(), &["ci"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        stdout(&output),
+        "\
+Legolas CI for ci-warn-app
+
+Gate result: WARN
+Overall status: Warn
+Rule statuses: potentialKbSaved=Pass, duplicatePackageCount=Pass, dynamicImportCount=Warn
+"
+    );
+    assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn ci_pass_keeps_exit_code_zero() {
+    let project = dynamic_import_project("ci-pass-app", 2);
+    let output = run_cli_in_dir(project.path(), &["ci"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        stdout(&output),
+        "\
+Legolas CI for ci-pass-app
+
+Gate result: PASS
+Overall status: Pass
+Rule statuses: potentialKbSaved=Pass, duplicatePackageCount=Pass, dynamicImportCount=Pass
+"
+    );
+    assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn ci_json_output_uses_machine_readable_gate_shape() {
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = run_cli(&["ci", &basic_app.display().to_string(), "--json"]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        support::normalize_ci_json_output(&stdout(&output)),
+        json!({
+            "passed": false,
+            "overallStatus": "Fail",
+            "rules": [
+                {
+                    "key": "potentialKbSaved",
+                    "actual": 366,
+                    "warnAt": 40,
+                    "failAt": 80,
+                    "status": "Fail"
+                },
+                {
+                    "key": "duplicatePackageCount",
+                    "actual": 1,
+                    "warnAt": 2,
+                    "failAt": 4,
+                    "status": "Pass"
+                },
+                {
+                    "key": "dynamicImportCount",
+                    "actual": 0,
+                    "warnAt": 1,
+                    "failAt": 0,
+                    "status": "Fail"
+                }
+            ]
+        })
+    );
+    assert_eq!(
+        stderr(&output),
+        "CI gate failed: overall status Fail (failing rules: potentialKbSaved, dynamicImportCount)\n"
+    );
+}
+
+#[test]
+fn ci_rejects_command_specific_numeric_flags() {
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    let cases = [
+        (
+            vec![
+                "ci".to_string(),
+                basic_app.display().to_string(),
+                "--limit".to_string(),
+                "1".to_string(),
+            ],
+            "legolas: unknown flag \"--limit\"\n",
+        ),
+        (
+            vec![
+                "ci".to_string(),
+                basic_app.display().to_string(),
+                "--top".to_string(),
+                "1".to_string(),
+            ],
+            "legolas: unknown flag \"--top\"\n",
+        ),
+        (
+            vec![
+                "--limit".to_string(),
+                "-1".to_string(),
+                "ci".to_string(),
+                basic_app.display().to_string(),
+            ],
+            "legolas: unknown flag \"--limit\"\n",
+        ),
+    ];
+
+    for (args, expected_stderr) in cases {
+        let output = Command::cargo_bin("legolas-cli")
+            .expect("build binary")
+            .args(args)
+            .output()
+            .expect("run invalid ci command");
+
+        assert!(!output.status.success());
+        assert_eq!(output.status.code(), Some(1));
+        assert_eq!(stdout(&output), "");
+        assert_eq!(stderr(&output), expected_stderr);
+    }
+}
+
+#[test]
+fn malformed_config_fails_before_ci_gate_policy() {
+    let fixture = support::fixture_path("tests/fixtures/config/invalid-json");
+    let output = run_cli(&["ci", &fixture.display().to_string()]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout(&output), "");
+    assert!(normalize(&stderr(&output)).starts_with(&format!(
+        "legolas: malformed config {}/tests/fixtures/config/invalid-json/legolas.config.json:",
+        normalize(&support::workspace_root().display().to_string())
+    )));
+}
+
+#[test]
+fn ci_suppresses_config_warnings_to_keep_failure_prefix_stable() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("legolas.config.json");
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    fs::write(
+        &config_path,
+        format!(
+            r#"{{
+  "scan": {{ "path": "{}" }},
+  "budget": {{
+    "rules": {{
+      "potentialKbSaved": {{ "warnAt": 40, "failAt": 80, "note": "ignored" }}
+    }}
+  }},
+  "extra": true
+}}
+"#,
+            normalize(&basic_app.display().to_string())
+        ),
+    )
+    .expect("write config");
+
+    let output = run_cli(&["ci", "--config", &config_path.display().to_string()]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        stdout(&output),
+        "\
+Legolas CI for basic-parity-app
+
+Gate result: FAIL
+Overall status: Fail
+Rule statuses: potentialKbSaved=Fail, duplicatePackageCount=Pass, dynamicImportCount=Fail
+"
+    );
+    assert_eq!(
+        stderr(&output),
+        "CI gate failed: overall status Fail (failing rules: potentialKbSaved, dynamicImportCount)\n"
+    );
+}
+
+fn dynamic_import_project(name: &str, dynamic_imports: usize) -> TempDir {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let src_dir = temp_dir.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src dir");
+
+    let dependency_entries = (0..dynamic_imports)
+        .map(|entry| match entry {
+            0 => "\"left-pad\":\"^1.3.0\"".to_string(),
+            1 => "\"is-odd\":\"^3.0.1\"".to_string(),
+            other => format!("\"ci-dyn-{other}\":\"^1.0.0\""),
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    fs::write(
+        temp_dir.path().join("package.json"),
+        format!(r#"{{"name":"{name}","dependencies":{{{dependency_entries}}}}}"#),
+    )
+    .expect("write package.json");
+
+    let mut index = String::new();
+    for entry in 0..dynamic_imports {
+        let package_name = match entry {
+            0 => "left-pad".to_string(),
+            1 => "is-odd".to_string(),
+            other => format!("ci-dyn-{other}"),
+        };
+        index.push_str(&format!("void import(\"{package_name}\");\n"));
+    }
+    fs::write(src_dir.join("index.js"), index).expect("write entry module");
+
+    temp_dir
+}

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -4,7 +4,12 @@ use assert_cmd::Command;
 
 #[test]
 fn prints_version_without_a_command() {
-    for args in [vec!["--version"], vec!["-v"]] {
+    for args in [
+        vec!["--version"],
+        vec!["-v"],
+        vec!["budget", "--version", "--top", "1"],
+        vec!["ci", "--version", "--limit", "1"],
+    ] {
         let output = Command::cargo_bin("legolas-cli")
             .expect("build binary")
             .args(args)
@@ -22,7 +27,14 @@ fn prints_version_without_a_command() {
 
 #[test]
 fn prints_help_for_empty_command_and_help_variants() {
-    for args in [Vec::<&str>::new(), vec!["help"], vec!["--help"], vec!["-h"]] {
+    for args in [
+        Vec::<&str>::new(),
+        vec!["help"],
+        vec!["--help"],
+        vec!["-h"],
+        vec!["budget", "--help", "--limit", "1"],
+        vec!["ci", "--help", "--top", "1"],
+    ] {
         let output = Command::cargo_bin("legolas-cli")
             .expect("build binary")
             .args(args)

--- a/crates/legolas-cli/tests/support/mod.rs
+++ b/crates/legolas-cli/tests/support/mod.rs
@@ -46,6 +46,11 @@ pub fn normalize_budget_json_output(output: &str) -> Value {
 }
 
 #[allow(dead_code)]
+pub fn normalize_ci_json_output(output: &str) -> Value {
+    serde_json::from_str::<Value>(output).expect("parse ci json")
+}
+
+#[allow(dead_code)]
 fn normalize_analysis_value(analysis: &mut Value) {
     replace_string_field(analysis, &["projectRoot"], "<PROJECT_ROOT>");
     replace_string_field(analysis, &["metadata", "generatedAt"], "<GENERATED_AT>");

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "scan": "cargo run -p legolas-cli -- scan",
     "visualize": "cargo run -p legolas-cli -- visualize",
     "optimize": "cargo run -p legolas-cli -- optimize",
-    "smoke": "cargo run -p legolas-cli -- --version && cargo run -p legolas-cli -- help && cargo run -p legolas-cli -- scan . && cargo run -p legolas-cli -- visualize . && cargo run -p legolas-cli -- optimize .",
+    "smoke": "cargo run -p legolas-cli -- --version && cargo run -p legolas-cli -- help && cargo run -p legolas-cli -- scan . && cargo run -p legolas-cli -- visualize . && cargo run -p legolas-cli -- optimize . && node ./scripts/smoke-ci-command.mjs cargo",
     "pack:check": "node ./scripts/check-pack.mjs",
     "test": "cargo test --workspace"
   },

--- a/scripts/smoke-ci-command.mjs
+++ b/scripts/smoke-ci-command.mjs
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const mode = process.argv[2];
+const workspaceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const targetPath = path.join(workspaceRoot, "tests/fixtures/parity/basic-app");
+
+if (mode !== "cargo" && mode !== "launcher") {
+  console.error('usage: node ./scripts/smoke-ci-command.mjs <cargo|launcher>');
+  process.exit(1);
+}
+
+const invocation =
+  mode === "cargo"
+    ? {
+        cmd: "cargo",
+        args: ["run", "-q", "-p", "legolas-cli", "--", "ci", targetPath],
+      }
+    : {
+        cmd: process.execPath,
+        args: [path.join(workspaceRoot, "bin/legolas.js"), "ci", targetPath],
+      };
+
+const result = spawnSync(invocation.cmd, invocation.args, {
+  cwd: workspaceRoot,
+  encoding: "utf8",
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.status !== 1) {
+  console.error(`expected ci smoke to exit 1, got ${result.status ?? "null"}`);
+  if (result.stdout) {
+    process.stderr.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  process.exit(1);
+}
+
+if (!result.stdout.includes("Legolas CI for basic-parity-app")) {
+  console.error("expected ci smoke stdout summary for basic-parity-app");
+  process.stderr.write(result.stdout);
+  process.exit(1);
+}
+
+if (!result.stderr.includes("CI gate failed:")) {
+  console.error("expected ci smoke stderr prefix");
+  process.stderr.write(result.stderr);
+  process.exit(1);
+}
+
+process.stdout.write(result.stdout);
+process.stderr.write(result.stderr);

--- a/tests/oracles/cli/help.txt
+++ b/tests/oracles/cli/help.txt
@@ -6,6 +6,7 @@ Usage:
   legolas visualize [path] [--config file] [--limit 10]
   legolas optimize [path] [--config file] [--top 5]
   legolas budget [path] [--config file] [--json]
+  legolas ci [path] [--config file] [--json]
   legolas help
 
 Examples:
@@ -14,3 +15,4 @@ Examples:
   legolas visualize ./apps/storefront --limit 12
   legolas optimize --top 7
   legolas budget ./apps/storefront --json
+  legolas ci ./apps/storefront


### PR DESCRIPTION
## 배경
- `CLI-006`에서 추가한 budget evaluator를 CI gate surface에서 그대로 재사용할 필요가 있었습니다.
- 이번 PR은 `legolas ci` 명령을 추가하고, stdout/stderr/exit code 계약을 Rust CLI에서 고정합니다.

## 변경 사항
- `argv`와 `main`에 `ci [path] [--config file] [--json]` surface를 추가했습니다.
- `Fail`일 때만 exit code `1`, `Warn`/`Pass`일 때는 exit code `0`을 반환하도록 정책을 연결했습니다.
- text reporter에 compact CI formatter를 추가했고, JSON mode에서는 machine-readable gate payload를 출력하도록 했습니다.
- `CI gate failed:` stderr prefix와 `help`/`version` short-circuit 회귀를 함께 고쳤습니다.
- `ci_contract.rs`를 추가해 pass/warn/fail, malformed config failure, invalid numeric flag 계약을 고정했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo run -q -p legolas-cli -- ci tests/fixtures/parity/basic-app`
- temp warn fixture with one external dynamic import -> exit `0`
- temp pass fixture with two external dynamic imports -> exit `0`
- `cargo run -q -p legolas-cli -- budget --help --limit 1`
- `cargo run -q -p legolas-cli -- ci --version --top 1`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/cli-004a-ci-command-exit-policy`
- 현재 워크트리: `/Users/pjw/workspace/legolas`
- 포함된 추가 source branch/worktree: 없음

## 이슈 연결
- 별도 이슈 연결 없음
