### PR TITLE
feat: Phase 1 shared seam 추가

### DIFF
--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -109,6 +109,7 @@ fn optimize_and_visualize_reports_clamp_zero_limits_and_cover_lazy_load_fallback
         files: Vec::new(),
         reason: "chart.js is statically imported in UI surfaces that usually tolerate lazy loading"
             .to_string(),
+        ..LazyLoadCandidate::default()
     }];
 
     assert_eq!(

--- a/crates/legolas-core/src/aliases.rs
+++ b/crates/legolas-core/src/aliases.rs
@@ -1,0 +1,396 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use crate::workspace::{find_project_root, normalize_path, read_text_if_exists};
+use crate::{error::Result, LegolasError};
+
+const ALIAS_CONFIG_FILES: [&str; 2] = ["tsconfig.json", "jsconfig.json"];
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AliasConfig {
+    pub base_url: Option<PathBuf>,
+    pub rules: Vec<AliasRule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AliasRule {
+    pub pattern: String,
+    pub specifier_prefix: String,
+    pub replacement_targets: Vec<AliasTarget>,
+    pub wildcard: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AliasTarget {
+    pub pattern: String,
+    pub replacement_prefix: String,
+    pub path_candidate: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedAliasConfig {
+    pub path: PathBuf,
+    pub config: AliasConfig,
+}
+
+pub fn load_alias_config<P: AsRef<Path>>(input_path: P) -> Result<Option<LoadedAliasConfig>> {
+    let project_root = resolve_project_root(input_path.as_ref())?;
+
+    for file_name in ALIAS_CONFIG_FILES {
+        let config_path = project_root.join(file_name);
+        let Some(raw_contents) = read_text_if_exists(&config_path)? else {
+            continue;
+        };
+
+        let config = parse_alias_config(&config_path, &raw_contents)?;
+        return Ok(Some(LoadedAliasConfig {
+            path: config_path,
+            config,
+        }));
+    }
+
+    Ok(None)
+}
+
+fn resolve_project_root(input_path: &Path) -> Result<PathBuf> {
+    let project_root = find_project_root(input_path)?;
+    Ok(normalize_path(&project_root))
+}
+
+fn parse_alias_config(config_path: &Path, raw_contents: &str) -> Result<AliasConfig> {
+    let normalized_contents = strip_jsonc(config_path, raw_contents)?;
+    let json_value = serde_json::from_str::<Value>(&normalized_contents).map_err(|error| {
+        LegolasError::MalformedConfig {
+            path: config_path.display().to_string(),
+            message: error.to_string(),
+        }
+    })?;
+    let root = expect_object(&json_value, config_path, "$")?;
+    let compiler_options = root
+        .get("compilerOptions")
+        .map(|value| expect_object(value, config_path, "compilerOptions"))
+        .transpose()?;
+    let config_dir = config_path.parent().unwrap_or(Path::new("."));
+    let base_url = compiler_options
+        .and_then(|options| options.get("baseUrl"))
+        .map(|value| parse_base_url(value, config_path, config_dir))
+        .transpose()?;
+    let rules = compiler_options
+        .and_then(|options| options.get("paths"))
+        .map(|value| parse_paths(value, config_path, config_dir, base_url.as_deref()))
+        .transpose()?
+        .unwrap_or_default();
+
+    Ok(AliasConfig { base_url, rules })
+}
+
+fn strip_jsonc(config_path: &Path, raw_contents: &str) -> Result<String> {
+    let without_comments = strip_json_comments(config_path, raw_contents)?;
+    Ok(strip_trailing_commas(&without_comments))
+}
+
+fn strip_json_comments(config_path: &Path, raw_contents: &str) -> Result<String> {
+    let chars: Vec<char> = raw_contents.chars().collect();
+    let mut cleaned = String::with_capacity(raw_contents.len());
+    let mut index = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut block_comment = false;
+
+    while index < chars.len() {
+        let current = chars[index];
+        let next = chars.get(index + 1).copied();
+
+        if line_comment {
+            if matches!(current, '\n' | '\r') {
+                line_comment = false;
+                cleaned.push(current);
+            }
+            index += 1;
+            continue;
+        }
+
+        if block_comment {
+            if current == '*' && next == Some('/') {
+                block_comment = false;
+                index += 2;
+                continue;
+            }
+
+            if matches!(current, '\n' | '\r') {
+                cleaned.push(current);
+            }
+            index += 1;
+            continue;
+        }
+
+        if in_string {
+            cleaned.push(current);
+            if escaped {
+                escaped = false;
+            } else if current == '\\' {
+                escaped = true;
+            } else if current == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if current == '"' {
+            in_string = true;
+            cleaned.push(current);
+            index += 1;
+            continue;
+        }
+
+        if current == '/' && next == Some('/') {
+            line_comment = true;
+            index += 2;
+            continue;
+        }
+
+        if current == '/' && next == Some('*') {
+            block_comment = true;
+            index += 2;
+            continue;
+        }
+
+        cleaned.push(current);
+        index += 1;
+    }
+
+    if block_comment {
+        return Err(LegolasError::MalformedConfig {
+            path: config_path.display().to_string(),
+            message: "unterminated block comment".to_string(),
+        });
+    }
+
+    Ok(cleaned)
+}
+
+fn strip_trailing_commas(raw_contents: &str) -> String {
+    let chars: Vec<char> = raw_contents.chars().collect();
+    let mut cleaned = String::with_capacity(raw_contents.len());
+    let mut index = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while index < chars.len() {
+        let current = chars[index];
+
+        if in_string {
+            cleaned.push(current);
+            if escaped {
+                escaped = false;
+            } else if current == '\\' {
+                escaped = true;
+            } else if current == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if current == '"' {
+            in_string = true;
+            cleaned.push(current);
+            index += 1;
+            continue;
+        }
+
+        if current == ',' {
+            let mut lookahead = index + 1;
+            while lookahead < chars.len() && chars[lookahead].is_whitespace() {
+                lookahead += 1;
+            }
+
+            if matches!(chars.get(lookahead), Some('}') | Some(']')) {
+                index += 1;
+                continue;
+            }
+        }
+
+        cleaned.push(current);
+        index += 1;
+    }
+
+    cleaned
+}
+
+fn parse_base_url(value: &Value, config_path: &Path, config_dir: &Path) -> Result<PathBuf> {
+    let base_url = expect_string(value, config_path, "compilerOptions.baseUrl")?;
+
+    Ok(resolve_config_path(config_dir, base_url))
+}
+
+fn parse_paths(
+    value: &Value,
+    config_path: &Path,
+    config_dir: &Path,
+    base_url: Option<&Path>,
+) -> Result<Vec<AliasRule>> {
+    let paths = expect_object(value, config_path, "compilerOptions.paths")?;
+    let target_root = base_url.unwrap_or(config_dir);
+    let mut rules = Vec::new();
+
+    for (pattern, targets) in paths {
+        let key_path = format!("compilerOptions.paths[{pattern}]");
+        let alias_pattern = parse_rule_pattern(pattern, config_path, &key_path)?;
+        let target_patterns = parse_targets(targets, config_path, &key_path)?;
+        let replacement_targets = target_patterns
+            .into_iter()
+            .map(|target_pattern| {
+                if alias_pattern.wildcard != target_pattern.wildcard {
+                    return unsupported_shape(
+                        config_path,
+                        &key_path,
+                        "expected alias key and target entries to use the same wildcard shape",
+                    );
+                }
+
+                Ok(AliasTarget {
+                    pattern: target_pattern.original.clone(),
+                    replacement_prefix: target_pattern.prefix.clone(),
+                    path_candidate: resolve_config_path(target_root, &target_pattern.prefix),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        rules.push(AliasRule {
+            pattern: alias_pattern.original,
+            specifier_prefix: alias_pattern.prefix,
+            replacement_targets,
+            wildcard: alias_pattern.wildcard,
+        });
+    }
+
+    // Keep more-specific rules first so later matchers can use this order directly.
+    rules.sort_by(|left, right| {
+        right
+            .specifier_prefix
+            .len()
+            .cmp(&left.specifier_prefix.len())
+            .then_with(|| left.wildcard.cmp(&right.wildcard))
+            .then_with(|| left.pattern.cmp(&right.pattern))
+    });
+
+    Ok(rules)
+}
+
+fn parse_targets(value: &Value, config_path: &Path, key_path: &str) -> Result<Vec<ParsedPattern>> {
+    let targets = expect_array(value, config_path, key_path)?;
+    if targets.is_empty() {
+        return unsupported_shape(
+            config_path,
+            key_path,
+            "expected at least one target entry in alias path array",
+        );
+    }
+
+    targets
+        .iter()
+        .enumerate()
+        .map(|(index, target)| {
+            let target_key_path = format!("{key_path}[{index}]");
+            let target = expect_string(target, config_path, &target_key_path)?;
+
+            parse_rule_pattern(target, config_path, &target_key_path)
+        })
+        .collect()
+}
+
+fn parse_rule_pattern(value: &str, config_path: &Path, key_path: &str) -> Result<ParsedPattern> {
+    if value.is_empty() {
+        return unsupported_shape(config_path, key_path, "expected non-empty alias pattern");
+    }
+
+    let wildcard_count = value.matches('*').count();
+    if wildcard_count == 0 {
+        return Ok(ParsedPattern {
+            original: value.to_string(),
+            prefix: value.to_string(),
+            wildcard: false,
+        });
+    }
+
+    if wildcard_count != 1 || !(value == "*" || value.ends_with("/*")) {
+        return unsupported_shape(
+            config_path,
+            key_path,
+            "expected exact value, catch-all *, or a single trailing /* wildcard pattern",
+        );
+    }
+
+    Ok(ParsedPattern {
+        original: value.to_string(),
+        prefix: value.trim_end_matches('*').to_string(),
+        wildcard: true,
+    })
+}
+
+fn resolve_config_path(root: &Path, value: &str) -> PathBuf {
+    let path = Path::new(value);
+
+    if path.is_absolute() {
+        normalize_path(path)
+    } else {
+        normalize_path(&root.join(path))
+    }
+}
+
+fn expect_object<'a>(
+    value: &'a Value,
+    config_path: &Path,
+    key_path: &str,
+) -> Result<&'a Map<String, Value>> {
+    value
+        .as_object()
+        .ok_or_else(|| LegolasError::UnsupportedConfigShape {
+            path: config_path.display().to_string(),
+            key_path: key_path.to_string(),
+            message: "expected object".to_string(),
+        })
+}
+
+fn expect_array<'a>(
+    value: &'a Value,
+    config_path: &Path,
+    key_path: &str,
+) -> Result<&'a Vec<Value>> {
+    value
+        .as_array()
+        .ok_or_else(|| LegolasError::UnsupportedConfigShape {
+            path: config_path.display().to_string(),
+            key_path: key_path.to_string(),
+            message: "expected array".to_string(),
+        })
+}
+
+fn expect_string<'a>(value: &'a Value, config_path: &Path, key_path: &str) -> Result<&'a str> {
+    value
+        .as_str()
+        .ok_or_else(|| LegolasError::UnsupportedConfigShape {
+            path: config_path.display().to_string(),
+            key_path: key_path.to_string(),
+            message: "expected string".to_string(),
+        })
+}
+
+fn unsupported_shape<T>(config_path: &Path, key_path: &str, message: &str) -> Result<T> {
+    Err(LegolasError::UnsupportedConfigShape {
+        path: config_path.display().to_string(),
+        key_path: key_path.to_string(),
+        message: message.to_string(),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedPattern {
+    original: String,
+    prefix: String,
+    wildcard: bool,
+}

--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -136,6 +136,7 @@ fn build_heavy_dependency_report(
                 .map(|item| item.dynamic_files.clone())
                 .unwrap_or_default(),
             import_count: import_info.map(|item| item.files.len()).unwrap_or(0),
+            finding: Default::default(),
         });
     }
 
@@ -206,6 +207,7 @@ fn build_lazy_load_candidates(
                 "{} is statically imported in UI surfaces that usually tolerate lazy loading",
                 imported_package.name
             ),
+            finding: Default::default(),
         });
     }
 

--- a/crates/legolas-core/src/artifacts/detect.rs
+++ b/crates/legolas-core/src/artifacts/detect.rs
@@ -1,0 +1,1 @@
+//! Placeholder parser namespace for upcoming generic artifact detection work.

--- a/crates/legolas-core/src/artifacts/esbuild.rs
+++ b/crates/legolas-core/src/artifacts/esbuild.rs
@@ -1,0 +1,1 @@
+//! Placeholder parser namespace for upcoming esbuild artifact parsing work.

--- a/crates/legolas-core/src/artifacts/mod.rs
+++ b/crates/legolas-core/src/artifacts/mod.rs
@@ -1,0 +1,8 @@
+pub mod models;
+
+pub mod detect;
+pub mod esbuild;
+pub mod rollup;
+pub mod webpack;
+
+pub use models::{ArtifactChunk, ArtifactModuleContribution, ArtifactSummary};

--- a/crates/legolas-core/src/artifacts/models.rs
+++ b/crates/legolas-core/src/artifacts/models.rs
@@ -1,0 +1,82 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactSummary {
+    pub bundler: String,
+    pub entrypoints: Vec<String>,
+    pub chunks: Vec<ArtifactChunk>,
+    pub modules: Vec<ArtifactModuleContribution>,
+    pub total_bytes: usize,
+}
+
+impl ArtifactSummary {
+    pub fn normalize(&mut self) {
+        sort_and_dedup(&mut self.entrypoints);
+
+        for chunk in &mut self.chunks {
+            chunk.normalize();
+        }
+        self.chunks.sort_unstable_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then(left.initial.cmp(&right.initial))
+                .then(left.bytes.cmp(&right.bytes))
+                .then(left.entrypoints.cmp(&right.entrypoints))
+                .then(left.files.cmp(&right.files))
+        });
+
+        for module in &mut self.modules {
+            module.normalize();
+        }
+        self.modules.sort_unstable_by(|left, right| {
+            left.id
+                .cmp(&right.id)
+                .then(left.package_name.cmp(&right.package_name))
+                .then(left.bytes.cmp(&right.bytes))
+                .then(left.chunks.cmp(&right.chunks))
+        });
+    }
+
+    pub fn normalized(mut self) -> Self {
+        self.normalize();
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactChunk {
+    pub name: String,
+    pub entrypoints: Vec<String>,
+    pub files: Vec<String>,
+    pub initial: bool,
+    pub bytes: usize,
+}
+
+impl ArtifactChunk {
+    pub fn normalize(&mut self) {
+        sort_and_dedup(&mut self.entrypoints);
+        sort_and_dedup(&mut self.files);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactModuleContribution {
+    pub id: String,
+    pub package_name: Option<String>,
+    pub chunks: Vec<String>,
+    pub bytes: usize,
+}
+
+impl ArtifactModuleContribution {
+    pub fn normalize(&mut self) {
+        sort_and_dedup(&mut self.chunks);
+    }
+}
+
+fn sort_and_dedup(values: &mut Vec<String>) {
+    values.sort_unstable();
+    values.dedup();
+}

--- a/crates/legolas-core/src/artifacts/rollup.rs
+++ b/crates/legolas-core/src/artifacts/rollup.rs
@@ -1,0 +1,1 @@
+//! Placeholder parser namespace for upcoming Rollup/Vite artifact parsing work.

--- a/crates/legolas-core/src/artifacts/webpack.rs
+++ b/crates/legolas-core/src/artifacts/webpack.rs
@@ -1,0 +1,1 @@
+//! Placeholder parser namespace for upcoming webpack artifact parsing work.

--- a/crates/legolas-core/src/findings.rs
+++ b/crates/legolas-core/src/findings.rs
@@ -1,0 +1,82 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FindingAnalysisSource {
+    Heuristic,
+    SourceImport,
+    LockfileTrace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct FindingEvidence {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub specifier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl FindingEvidence {
+    pub fn new(kind: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_file(mut self, file: impl Into<String>) -> Self {
+        self.file = Some(file.into());
+        self
+    }
+
+    pub fn with_specifier(mut self, specifier: impl Into<String>) -> Self {
+        self.specifier = Some(specifier.into());
+        self
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct FindingMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finding_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub analysis_source: Option<FindingAnalysisSource>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<FindingEvidence>,
+}
+
+impl FindingMetadata {
+    pub fn new(finding_id: impl Into<String>, analysis_source: FindingAnalysisSource) -> Self {
+        Self {
+            finding_id: Some(finding_id.into()),
+            analysis_source: Some(analysis_source),
+            evidence: Vec::new(),
+        }
+    }
+
+    pub fn with_evidence<I>(mut self, evidence: I) -> Self
+    where
+        I: IntoIterator<Item = FindingEvidence>,
+    {
+        self.evidence = evidence.into_iter().collect();
+        self
+    }
+
+    pub fn push_evidence(&mut self, evidence: FindingEvidence) {
+        self.evidence.push(evidence);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.finding_id.is_none() && self.analysis_source.is_none() && self.evidence.is_empty()
+    }
+}

--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -7,7 +7,9 @@ use std::{
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use crate::{error::Result, models::TreeShakingWarning, LegolasError};
+use crate::{
+    error::Result, models::TreeShakingWarning, FindingEvidence, FindingMetadata, LegolasError,
+};
 
 const IGNORED_DIRECTORIES: &[&str] = &[
     ".git",
@@ -118,6 +120,7 @@ struct WarningAccumulator {
     recommendation: String,
     estimated_kb: usize,
     files: BTreeSet<String>,
+    finding: FindingMetadata,
 }
 
 pub fn collect_source_files<P: AsRef<Path>>(project_root: P) -> Result<Vec<PathBuf>> {
@@ -358,6 +361,7 @@ fn merge_tree_shaking_warnings(warnings: Vec<TreeShakingWarning>) -> Vec<TreeSha
                 existing.files.insert(file);
             }
             existing.estimated_kb = existing.estimated_kb.max(warning.estimated_kb);
+            merge_finding_metadata(&mut existing.finding, warning.finding);
             continue;
         }
 
@@ -369,6 +373,7 @@ fn merge_tree_shaking_warnings(warnings: Vec<TreeShakingWarning>) -> Vec<TreeSha
             recommendation: warning.recommendation,
             estimated_kb: warning.estimated_kb,
             files: warning.files.into_iter().collect(),
+            finding: warning.finding,
         });
     }
 
@@ -381,8 +386,38 @@ fn merge_tree_shaking_warnings(warnings: Vec<TreeShakingWarning>) -> Vec<TreeSha
             recommendation: warning.recommendation,
             estimated_kb: warning.estimated_kb,
             files: warning.files.into_iter().collect(),
+            finding: warning.finding,
         })
         .collect()
+}
+
+fn merge_finding_metadata(existing: &mut FindingMetadata, mut incoming: FindingMetadata) {
+    if existing.finding_id.is_none() {
+        existing.finding_id = incoming.finding_id.take();
+    }
+
+    if existing.analysis_source.is_none() {
+        existing.analysis_source = incoming.analysis_source.take();
+    }
+
+    existing.evidence.append(&mut incoming.evidence);
+    normalize_finding_evidence(&mut existing.evidence);
+}
+
+fn normalize_finding_evidence(evidence: &mut Vec<FindingEvidence>) {
+    evidence.sort_by(|left, right| {
+        left.kind
+            .cmp(&right.kind)
+            .then(left.file.cmp(&right.file))
+            .then(left.specifier.cmp(&right.specifier))
+            .then(left.detail.cmp(&right.detail))
+    });
+    evidence.dedup_by(|left, right| {
+        left.kind == right.kind
+            && left.file == right.file
+            && left.specifier == right.specifier
+            && left.detail == right.detail
+    });
 }
 
 fn get_scannable_contents(file_path: &Path, contents: &str) -> String {
@@ -529,6 +564,7 @@ fn build_tree_shaking_hint(specifier: &str, clause: &str) -> Option<TreeShakingW
             recommendation: "Import only the symbols you need from direct subpaths.".to_string(),
             estimated_kb: 35,
             files: Vec::new(),
+            finding: Default::default(),
         });
     }
 
@@ -541,6 +577,7 @@ fn build_tree_shaking_hint(specifier: &str, clause: &str) -> Option<TreeShakingW
             recommendation: "Prefer per-method imports or lodash-es.".to_string(),
             estimated_kb: 26,
             files: Vec::new(),
+            finding: Default::default(),
         });
     }
 
@@ -552,6 +589,7 @@ fn build_tree_shaking_hint(specifier: &str, clause: &str) -> Option<TreeShakingW
             recommendation: "Import from the specific icon pack path instead.".to_string(),
             estimated_kb: 22,
             files: Vec::new(),
+            finding: Default::default(),
         });
     }
 
@@ -1049,4 +1087,75 @@ fn to_posix_relative(project_root: &Path, file_path: &Path) -> String {
         .unwrap_or(file_path)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_tree_shaking_warnings;
+    use crate::{FindingAnalysisSource, FindingEvidence, FindingMetadata, TreeShakingWarning};
+
+    #[test]
+    fn merge_tree_shaking_warnings_preserves_and_dedupes_finding_metadata() {
+        let warnings = vec![
+            TreeShakingWarning {
+                key: "lodash-root-import".to_string(),
+                package_name: "lodash".to_string(),
+                message: "Root imports can keep extra code.".to_string(),
+                recommendation: "Prefer per-method imports.".to_string(),
+                estimated_kb: 20,
+                files: vec!["src/App.tsx".to_string()],
+                finding: FindingMetadata::new(
+                    "tree-shaking:lodash-root-import",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_evidence([FindingEvidence::new("source-file")
+                    .with_file("src/App.tsx")
+                    .with_specifier("lodash")]),
+            },
+            TreeShakingWarning {
+                key: "lodash-root-import".to_string(),
+                package_name: "lodash".to_string(),
+                message: "Root imports can keep extra code.".to_string(),
+                recommendation: "Prefer per-method imports.".to_string(),
+                estimated_kb: 26,
+                files: vec!["src/Dashboard.tsx".to_string()],
+                finding: FindingMetadata::new(
+                    "tree-shaking:lodash-root-import",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_evidence([
+                    FindingEvidence::new("source-file")
+                        .with_file("src/Dashboard.tsx")
+                        .with_specifier("lodash"),
+                    FindingEvidence::new("source-file")
+                        .with_file("src/App.tsx")
+                        .with_specifier("lodash"),
+                ]),
+            },
+        ];
+
+        let merged = merge_tree_shaking_warnings(warnings);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].estimated_kb, 26);
+        assert_eq!(
+            merged[0].files,
+            vec!["src/App.tsx".to_string(), "src/Dashboard.tsx".to_string()]
+        );
+        assert_eq!(
+            merged[0].finding,
+            FindingMetadata::new(
+                "tree-shaking:lodash-root-import",
+                FindingAnalysisSource::SourceImport,
+            )
+            .with_evidence([
+                FindingEvidence::new("source-file")
+                    .with_file("src/App.tsx")
+                    .with_specifier("lodash"),
+                FindingEvidence::new("source-file")
+                    .with_file("src/Dashboard.tsx")
+                    .with_specifier("lodash"),
+            ])
+        );
+    }
 }

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -1,7 +1,10 @@
+pub mod aliases;
 pub mod analyze;
+pub mod artifacts;
 pub mod budget;
 pub mod config;
 pub mod error;
+pub mod findings;
 pub mod impact;
 pub mod import_scanner;
 pub mod lockfiles;
@@ -12,4 +15,5 @@ pub mod workspace;
 
 pub use analyze::analyze_project;
 pub use error::{LegolasError, Result};
+pub use findings::*;
 pub use models::*;

--- a/crates/legolas-core/src/lockfiles.rs
+++ b/crates/legolas-core/src/lockfiles.rs
@@ -361,6 +361,7 @@ fn summarize_duplicates(versions_by_name: VersionsByName) -> Vec<DuplicatePackag
             count: versions.len(),
             versions,
             estimated_extra_kb,
+            finding: Default::default(),
         });
     }
 

--- a/crates/legolas-core/src/models.rs
+++ b/crates/legolas-core/src/models.rs
@@ -1,3 +1,4 @@
+use crate::findings::FindingMetadata;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -47,6 +48,8 @@ pub struct HeavyDependency {
     pub imported_by: Vec<String>,
     pub dynamic_imported_by: Vec<String>,
     pub import_count: usize,
+    #[serde(flatten, default, skip_serializing_if = "FindingMetadata::is_empty")]
+    pub finding: FindingMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -56,6 +59,8 @@ pub struct DuplicatePackage {
     pub versions: Vec<String>,
     pub count: usize,
     pub estimated_extra_kb: usize,
+    #[serde(flatten, default, skip_serializing_if = "FindingMetadata::is_empty")]
+    pub finding: FindingMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -66,6 +71,8 @@ pub struct LazyLoadCandidate {
     pub recommendation: String,
     pub files: Vec<String>,
     pub reason: String,
+    #[serde(flatten, default, skip_serializing_if = "FindingMetadata::is_empty")]
+    pub finding: FindingMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -77,6 +84,8 @@ pub struct TreeShakingWarning {
     pub recommendation: String,
     pub estimated_kb: usize,
     pub files: Vec<String>,
+    #[serde(flatten, default, skip_serializing_if = "FindingMetadata::is_empty")]
+    pub finding: FindingMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/crates/legolas-core/src/workspace.rs
+++ b/crates/legolas-core/src/workspace.rs
@@ -6,6 +6,9 @@ use std::{
 
 use serde::de::DeserializeOwned;
 
+pub use crate::aliases::{
+    load_alias_config, AliasConfig, AliasRule, AliasTarget, LoadedAliasConfig,
+};
 use crate::{error::Result, LegolasError};
 
 const ROOT_MARKERS: [&str; 6] = [
@@ -106,18 +109,46 @@ fn resolve_absolute(input_path: &Path) -> Result<PathBuf> {
     Ok(normalize_path(&absolute))
 }
 
-fn normalize_path(path: &Path) -> PathBuf {
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     let mut normalized = PathBuf::new();
 
     for component in path.components() {
         match component {
             Component::CurDir => {}
             Component::ParentDir => {
-                normalized.pop();
+                let can_pop = matches!(
+                    normalized.components().next_back(),
+                    Some(Component::Normal(_))
+                );
+
+                if can_pop {
+                    normalized.pop();
+                } else if !path.is_absolute() {
+                    normalized.push(component.as_os_str());
+                }
             }
             other => normalized.push(other.as_os_str()),
         }
     }
 
     normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::normalize_path;
+
+    #[test]
+    fn normalize_path_preserves_leading_parent_components_for_relative_paths() {
+        assert_eq!(
+            normalize_path(Path::new("../shared/../src/module.ts")),
+            Path::new("../src/module.ts")
+        );
+        assert_eq!(
+            normalize_path(Path::new("../../src/./lib.ts")),
+            Path::new("../../src/lib.ts")
+        );
+    }
 }

--- a/crates/legolas-core/tests/alias_resolution.rs
+++ b/crates/legolas-core/tests/alias_resolution.rs
@@ -1,0 +1,450 @@
+#[allow(dead_code)]
+mod support;
+
+use std::{fs, path::PathBuf, sync::Mutex};
+
+use legolas_core::{
+    workspace::{load_alias_config, AliasRule, AliasTarget},
+    LegolasError,
+};
+use tempfile::tempdir;
+
+static CURRENT_DIR_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn load_alias_config_reads_tsconfig_paths_deterministically() {
+    let project_root = support::fixture_path("tests/fixtures/aliases/tsconfig-paths");
+    let loaded = load_alias_config(&project_root)
+        .expect("load alias config")
+        .expect("tsconfig.json should be discovered");
+
+    assert_eq!(loaded.path, project_root.join("tsconfig.json"));
+    assert_eq!(loaded.config.base_url, Some(project_root.clone()));
+    assert_eq!(
+        loaded.config.rules,
+        vec![
+            AliasRule {
+                pattern: "@shared".to_string(),
+                specifier_prefix: "@shared".to_string(),
+                replacement_targets: vec![
+                    AliasTarget {
+                        pattern: "src/shared/index.ts".to_string(),
+                        replacement_prefix: "src/shared/index.ts".to_string(),
+                        path_candidate: project_root.join("src/shared/index.ts"),
+                    },
+                    AliasTarget {
+                        pattern: "src/shared/fallback.ts".to_string(),
+                        replacement_prefix: "src/shared/fallback.ts".to_string(),
+                        path_candidate: project_root.join("src/shared/fallback.ts"),
+                    },
+                ],
+                wildcard: false,
+            },
+            AliasRule {
+                pattern: "@/*".to_string(),
+                specifier_prefix: "@/".to_string(),
+                replacement_targets: vec![AliasTarget {
+                    pattern: "src/*".to_string(),
+                    replacement_prefix: "src/".to_string(),
+                    path_candidate: project_root.join("src"),
+                }],
+                wildcard: true,
+            },
+        ]
+    );
+}
+
+#[test]
+fn load_alias_config_reads_jsconfig_paths_when_tsconfig_is_absent() {
+    let project_root = support::fixture_path("tests/fixtures/aliases/jsconfig-paths");
+    let loaded = load_alias_config(&project_root)
+        .expect("load alias config")
+        .expect("jsconfig.json should be discovered");
+
+    assert_eq!(loaded.path, project_root.join("jsconfig.json"));
+    assert_eq!(loaded.config.base_url, Some(project_root.join("src")));
+    assert_eq!(
+        loaded.config.rules,
+        vec![
+            AliasRule {
+                pattern: "#env".to_string(),
+                specifier_prefix: "#env".to_string(),
+                replacement_targets: vec![AliasTarget {
+                    pattern: "config/env.js".to_string(),
+                    replacement_prefix: "config/env.js".to_string(),
+                    path_candidate: project_root.join("src/config/env.js"),
+                }],
+                wildcard: false,
+            },
+            AliasRule {
+                pattern: "~/*".to_string(),
+                specifier_prefix: "~/".to_string(),
+                replacement_targets: vec![
+                    AliasTarget {
+                        pattern: "components/*".to_string(),
+                        replacement_prefix: "components/".to_string(),
+                        path_candidate: project_root.join("src/components"),
+                    },
+                    AliasTarget {
+                        pattern: "fallback/*".to_string(),
+                        replacement_prefix: "fallback/".to_string(),
+                        path_candidate: project_root.join("src/fallback"),
+                    },
+                ],
+                wildcard: true,
+            },
+        ]
+    );
+}
+
+#[test]
+fn load_alias_config_accepts_jsonc_comments_and_trailing_commas() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("tsconfig.json");
+    fs::write(
+        &config_path,
+        r#"{
+  // common tsconfig comment
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*",],
+    },
+  },
+}
+"#,
+    )
+    .expect("write jsonc tsconfig");
+
+    let loaded = load_alias_config(temp_dir.path())
+        .expect("load jsonc alias config")
+        .expect("tsconfig.json should be discovered");
+
+    assert_eq!(loaded.path, config_path);
+    assert_eq!(loaded.config.base_url, Some(temp_dir.path().to_path_buf()));
+    assert_eq!(
+        loaded.config.rules,
+        vec![AliasRule {
+            pattern: "@/*".to_string(),
+            specifier_prefix: "@/".to_string(),
+            replacement_targets: vec![AliasTarget {
+                pattern: "src/*".to_string(),
+                replacement_prefix: "src/".to_string(),
+                path_candidate: temp_dir.path().join("src"),
+            }],
+            wildcard: true,
+        }]
+    );
+}
+
+#[test]
+fn load_alias_config_preserves_fallback_targets_and_catch_all_rules() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("tsconfig.json");
+    fs::write(
+        &config_path,
+        r##"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@ui": ["src/ui/index.ts", "src/ui/index.js"],
+      "*": ["src/*", "generated/*"]
+    }
+  }
+}
+"##,
+    )
+    .expect("write fallback tsconfig");
+
+    let loaded = load_alias_config(temp_dir.path())
+        .expect("load alias config")
+        .expect("tsconfig.json should be discovered");
+
+    assert_eq!(loaded.path, config_path);
+    assert_eq!(
+        loaded.config.rules,
+        vec![
+            AliasRule {
+                pattern: "@ui".to_string(),
+                specifier_prefix: "@ui".to_string(),
+                replacement_targets: vec![
+                    AliasTarget {
+                        pattern: "src/ui/index.ts".to_string(),
+                        replacement_prefix: "src/ui/index.ts".to_string(),
+                        path_candidate: temp_dir.path().join("src/ui/index.ts"),
+                    },
+                    AliasTarget {
+                        pattern: "src/ui/index.js".to_string(),
+                        replacement_prefix: "src/ui/index.js".to_string(),
+                        path_candidate: temp_dir.path().join("src/ui/index.js"),
+                    },
+                ],
+                wildcard: false,
+            },
+            AliasRule {
+                pattern: "*".to_string(),
+                specifier_prefix: "".to_string(),
+                replacement_targets: vec![
+                    AliasTarget {
+                        pattern: "src/*".to_string(),
+                        replacement_prefix: "src/".to_string(),
+                        path_candidate: temp_dir.path().join("src"),
+                    },
+                    AliasTarget {
+                        pattern: "generated/*".to_string(),
+                        replacement_prefix: "generated/".to_string(),
+                        path_candidate: temp_dir.path().join("generated"),
+                    },
+                ],
+                wildcard: true,
+            },
+        ]
+    );
+}
+
+#[test]
+fn load_alias_config_preserves_raw_package_remap_targets() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("tsconfig.json");
+    fs::write(
+        &config_path,
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@react": ["react"],
+      "@scope/*": ["@vendor/pkg/*"]
+    }
+  }
+}
+"#,
+    )
+    .expect("write package-remap tsconfig");
+
+    let loaded = load_alias_config(temp_dir.path())
+        .expect("load alias config")
+        .expect("tsconfig.json should be discovered");
+
+    assert_eq!(loaded.path, config_path);
+    assert_eq!(
+        loaded.config.rules,
+        vec![
+            AliasRule {
+                pattern: "@scope/*".to_string(),
+                specifier_prefix: "@scope/".to_string(),
+                replacement_targets: vec![AliasTarget {
+                    pattern: "@vendor/pkg/*".to_string(),
+                    replacement_prefix: "@vendor/pkg/".to_string(),
+                    path_candidate: temp_dir.path().join("@vendor/pkg"),
+                }],
+                wildcard: true,
+            },
+            AliasRule {
+                pattern: "@react".to_string(),
+                specifier_prefix: "@react".to_string(),
+                replacement_targets: vec![AliasTarget {
+                    pattern: "react".to_string(),
+                    replacement_prefix: "react".to_string(),
+                    path_candidate: temp_dir.path().join("react"),
+                }],
+                wildcard: false,
+            },
+        ]
+    );
+}
+
+#[test]
+fn load_alias_config_resolves_parent_segments_from_relative_project_roots() {
+    struct CurrentDirGuard {
+        original: PathBuf,
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.original).expect("restore current dir");
+        }
+    }
+
+    let _cwd_lock = CURRENT_DIR_LOCK.lock().expect("lock current dir");
+    let original_dir = std::env::current_dir().expect("read current dir");
+    let _current_dir_guard = CurrentDirGuard {
+        original: original_dir,
+    };
+
+    let temp_dir = tempdir().expect("create temp dir");
+    let project_root = temp_dir.path().join("project");
+    let shared_root = temp_dir.path().join("shared");
+    let source_root = temp_dir.path().join("src");
+    fs::create_dir_all(&project_root).expect("create project root");
+    fs::create_dir_all(&shared_root).expect("create shared root");
+    fs::create_dir_all(&source_root).expect("create source root");
+    let config_path = project_root.join("tsconfig.json");
+    fs::write(
+        &config_path,
+        r#"{
+  "compilerOptions": {
+    "baseUrl": "../shared",
+    "paths": {
+      "@/*": ["../src/*"]
+    }
+  }
+}
+"#,
+    )
+    .expect("write relative-root tsconfig");
+
+    std::env::set_current_dir(&project_root).expect("enter project root");
+
+    let loaded = load_alias_config(".")
+        .expect("load alias config from relative root")
+        .expect("tsconfig.json should be discovered");
+
+    assert_eq!(
+        fs::canonicalize(&loaded.path).expect("canonicalize loaded config path"),
+        fs::canonicalize(&config_path).expect("canonicalize expected config path")
+    );
+    assert_eq!(
+        fs::canonicalize(
+            loaded
+                .config
+                .base_url
+                .as_ref()
+                .expect("baseUrl should be resolved"),
+        )
+        .expect("canonicalize loaded baseUrl"),
+        fs::canonicalize(&shared_root).expect("canonicalize expected shared root")
+    );
+    assert_eq!(loaded.config.rules.len(), 1);
+    assert_eq!(loaded.config.rules[0].pattern, "@/*");
+    assert_eq!(loaded.config.rules[0].specifier_prefix, "@/");
+    assert!(loaded.config.rules[0].wildcard);
+    assert_eq!(loaded.config.rules[0].replacement_targets.len(), 1);
+    assert_eq!(
+        fs::canonicalize(&loaded.config.rules[0].replacement_targets[0].path_candidate)
+            .expect("canonicalize loaded replacement target"),
+        fs::canonicalize(&source_root).expect("canonicalize expected source root")
+    );
+}
+
+#[test]
+fn load_alias_config_accepts_file_and_nested_directory_inputs() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let project_root = temp_dir.path().join("alias-project");
+    let nested_dir = project_root.join("src/nested");
+    let file_input = nested_dir.join("App.tsx");
+    fs::create_dir_all(&nested_dir).expect("create nested source dir");
+    fs::write(
+        project_root.join("package.json"),
+        "{\n  \"name\": \"alias-project\"\n}\n",
+    )
+    .expect("write package.json");
+    fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}
+"#,
+    )
+    .expect("write tsconfig");
+    fs::write(&file_input, "export const App = () => null;\n").expect("write source file");
+
+    let from_directory = load_alias_config(project_root.join("src"))
+        .expect("load alias config from directory input")
+        .expect("tsconfig should be discovered from directory input");
+    let from_file = load_alias_config(&file_input)
+        .expect("load alias config from file input")
+        .expect("tsconfig should be discovered from file input");
+
+    for loaded in [from_directory, from_file] {
+        assert_eq!(loaded.path, project_root.join("tsconfig.json"));
+        assert_eq!(loaded.config.base_url, Some(project_root.clone()));
+        assert_eq!(
+            loaded.config.rules,
+            vec![AliasRule {
+                pattern: "@/*".to_string(),
+                specifier_prefix: "@/".to_string(),
+                replacement_targets: vec![AliasTarget {
+                    pattern: "src/*".to_string(),
+                    replacement_prefix: "src/".to_string(),
+                    path_candidate: project_root.join("src"),
+                }],
+                wildcard: true,
+            }]
+        );
+    }
+}
+
+#[test]
+fn load_alias_config_returns_none_when_project_has_no_supported_config_file() {
+    let project_root = support::fixture_path("tests/fixtures/workspace/vite-project");
+
+    assert_eq!(
+        load_alias_config(&project_root).expect("load alias config"),
+        None
+    );
+}
+
+#[test]
+fn load_alias_config_keeps_missing_and_malformed_config_states_distinct() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("tsconfig.json");
+    fs::write(
+        &config_path,
+        r#"{
+  "compilerOptions": {
+    "paths": "@/src/*"
+  }
+}
+"#,
+    )
+    .expect("write malformed tsconfig");
+
+    let error = load_alias_config(temp_dir.path()).expect_err("malformed config should fail");
+
+    match error {
+        LegolasError::UnsupportedConfigShape {
+            path,
+            key_path,
+            message,
+        } => {
+            assert_eq!(path, config_path.display().to_string());
+            assert_eq!(key_path, "compilerOptions.paths");
+            assert_eq!(message, "expected object");
+        }
+        other => panic!("expected unsupported config shape error, got {other:?}"),
+    }
+}
+
+#[test]
+fn load_alias_config_rejects_unterminated_block_comments_in_jsonc() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("tsconfig.json");
+    fs::write(
+        &config_path,
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+} /* unterminated
+"#,
+    )
+    .expect("write malformed jsonc tsconfig");
+
+    let error = load_alias_config(temp_dir.path()).expect_err("unterminated block comment");
+
+    match error {
+        LegolasError::MalformedConfig { path, message } => {
+            assert_eq!(path, config_path.display().to_string());
+            assert_eq!(message, "unterminated block comment");
+        }
+        other => panic!("expected malformed config error, got {other:?}"),
+    }
+}

--- a/crates/legolas-core/tests/artifact_models.rs
+++ b/crates/legolas-core/tests/artifact_models.rs
@@ -1,0 +1,114 @@
+use legolas_core::artifacts::{ArtifactChunk, ArtifactModuleContribution, ArtifactSummary};
+
+#[test]
+fn artifact_namespace_exposes_models_and_parser_seams() {
+    #[allow(unused_imports)]
+    use legolas_core::artifacts::{detect, esbuild, rollup, webpack, ArtifactSummary};
+
+    let _ = std::mem::size_of::<ArtifactSummary>();
+}
+
+#[test]
+fn artifact_summary_normalization_produces_a_deterministic_json_shape() {
+    let summary = ArtifactSummary {
+        bundler: "webpack".to_string(),
+        entrypoints: vec!["main".to_string(), "admin".to_string(), "main".to_string()],
+        chunks: vec![
+            ArtifactChunk {
+                name: "vendor".to_string(),
+                entrypoints: vec!["main".to_string(), "admin".to_string(), "main".to_string()],
+                files: vec![
+                    "dist/vendor.js".to_string(),
+                    "dist/vendor.css".to_string(),
+                    "dist/vendor.js".to_string(),
+                ],
+                initial: true,
+                bytes: 64_000,
+            },
+            ArtifactChunk {
+                name: "admin".to_string(),
+                entrypoints: vec!["admin".to_string()],
+                files: vec!["dist/admin.js".to_string()],
+                initial: false,
+                bytes: 12_000,
+            },
+        ],
+        modules: vec![
+            ArtifactModuleContribution {
+                id: "src/admin.tsx".to_string(),
+                package_name: None,
+                chunks: vec![
+                    "vendor".to_string(),
+                    "admin".to_string(),
+                    "admin".to_string(),
+                ],
+                bytes: 5_000,
+            },
+            ArtifactModuleContribution {
+                id: "node_modules/react/index.js".to_string(),
+                package_name: Some("react".to_string()),
+                chunks: vec!["vendor".to_string(), "vendor".to_string()],
+                bytes: 7_000,
+            },
+        ],
+        total_bytes: 76_000,
+    }
+    .normalized();
+
+    let actual = serde_json::to_string_pretty(&summary).expect("serialize artifact summary");
+    let expected = r#"{
+  "bundler": "webpack",
+  "entrypoints": [
+    "admin",
+    "main"
+  ],
+  "chunks": [
+    {
+      "name": "admin",
+      "entrypoints": [
+        "admin"
+      ],
+      "files": [
+        "dist/admin.js"
+      ],
+      "initial": false,
+      "bytes": 12000
+    },
+    {
+      "name": "vendor",
+      "entrypoints": [
+        "admin",
+        "main"
+      ],
+      "files": [
+        "dist/vendor.css",
+        "dist/vendor.js"
+      ],
+      "initial": true,
+      "bytes": 64000
+    }
+  ],
+  "modules": [
+    {
+      "id": "node_modules/react/index.js",
+      "packageName": "react",
+      "chunks": [
+        "vendor"
+      ],
+      "bytes": 7000
+    },
+    {
+      "id": "src/admin.tsx",
+      "packageName": null,
+      "chunks": [
+        "admin",
+        "vendor"
+      ],
+      "bytes": 5000
+    }
+  ],
+  "totalBytes": 76000
+}"#;
+
+    assert_eq!(actual, expected);
+}

--- a/crates/legolas-core/tests/finding_support.rs
+++ b/crates/legolas-core/tests/finding_support.rs
@@ -1,0 +1,103 @@
+use legolas_core::{
+    DuplicatePackage, FindingAnalysisSource, FindingEvidence, FindingMetadata, HeavyDependency,
+    LazyLoadCandidate, TreeShakingWarning,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::{json, Value};
+
+#[test]
+fn finding_metadata_serializes_as_flat_camel_case_fields() {
+    let payload = serde_json::to_value(HeavyDependency {
+        name: "lodash".to_string(),
+        version_range: "^4.17.21".to_string(),
+        estimated_kb: 26,
+        category: "utility".to_string(),
+        rationale: "Large helper surface".to_string(),
+        recommendation: "Prefer lodash-es.".to_string(),
+        imported_by: vec!["src/App.tsx".to_string()],
+        dynamic_imported_by: Vec::new(),
+        import_count: 1,
+        finding: FindingMetadata::new("heavy-dependency", FindingAnalysisSource::SourceImport)
+            .with_evidence([FindingEvidence::new("source-file")
+                .with_file("src/App.tsx")
+                .with_specifier("lodash")
+                .with_detail("static import")]),
+    })
+    .expect("serialize heavy dependency");
+
+    assert_eq!(payload["findingId"], json!("heavy-dependency"));
+    assert_eq!(payload["analysisSource"], json!("source-import"));
+    assert_eq!(
+        payload["evidence"],
+        json!([{
+            "kind": "source-file",
+            "file": "src/App.tsx",
+            "specifier": "lodash",
+            "detail": "static import"
+        }])
+    );
+}
+
+#[test]
+fn default_finding_metadata_keeps_legacy_shapes_deserializable() {
+    assert_default_finding_round_trip::<HeavyDependency>(
+        json!({
+            "name": "lodash",
+            "versionRange": "^4.17.21",
+            "estimatedKb": 26,
+            "category": "utility",
+            "rationale": "Large helper surface",
+            "recommendation": "Prefer lodash-es.",
+            "importedBy": ["src/App.tsx"],
+            "dynamicImportedBy": [],
+            "importCount": 1
+        }),
+        |item| &item.finding,
+    );
+
+    assert_default_finding_round_trip::<DuplicatePackage>(
+        json!({
+            "name": "lodash",
+            "versions": ["4.17.20", "4.17.21"],
+            "count": 2,
+            "estimatedExtraKb": 18
+        }),
+        |item| &item.finding,
+    );
+
+    assert_default_finding_round_trip::<LazyLoadCandidate>(
+        json!({
+            "name": "chart.js",
+            "estimatedSavingsKb": 48,
+            "recommendation": "Split the route bundle.",
+            "files": ["src/routes/Admin.tsx"],
+            "reason": "Admin route is statically imported."
+        }),
+        |item| &item.finding,
+    );
+
+    assert_default_finding_round_trip::<TreeShakingWarning>(
+        json!({
+            "key": "lodash-root-import",
+            "packageName": "lodash",
+            "message": "Root imports can keep extra code.",
+            "recommendation": "Prefer per-method imports.",
+            "estimatedKb": 26,
+            "files": ["src/App.tsx"]
+        }),
+        |item| &item.finding,
+    );
+}
+
+fn assert_default_finding_round_trip<T>(legacy_payload: Value, finding: fn(&T) -> &FindingMetadata)
+where
+    T: DeserializeOwned + Serialize,
+{
+    let item: T = serde_json::from_value(legacy_payload).expect("deserialize legacy payload");
+    assert_eq!(finding(&item), &FindingMetadata::default());
+
+    let serialized = serde_json::to_value(&item).expect("serialize with default finding");
+    assert!(serialized.get("findingId").is_none());
+    assert!(serialized.get("analysisSource").is_none());
+    assert!(serialized.get("evidence").is_none());
+}

--- a/crates/legolas-core/tests/import_scanner.rs
+++ b/crates/legolas-core/tests/import_scanner.rs
@@ -169,6 +169,7 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                 recommendation: "Prefer per-method imports or lodash-es.".to_string(),
                 estimated_kb: 26,
                 files: vec!["basic/Dashboard.tsx".to_string()],
+                finding: Default::default(),
             },
             TreeShakingWarning {
                 key: "react-icons-root-import".to_string(),
@@ -180,6 +181,7 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                     "basic/Dashboard.tsx".to_string(),
                     "vue/Widget.vue".to_string()
                 ],
+                finding: Default::default(),
             },
             TreeShakingWarning {
                 key: "namespace-ui-import".to_string(),
@@ -190,6 +192,7 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                     .to_string(),
                 estimated_kb: 35,
                 files: vec!["jsx/View.jsx".to_string()],
+                finding: Default::default(),
             },
         ]
     );

--- a/crates/legolas-core/tests/lockfiles.rs
+++ b/crates/legolas-core/tests/lockfiles.rs
@@ -83,6 +83,7 @@ fn parses_npm_v1_duplicates_from_dependency_trees_and_sorts_versions_naturally()
                     ],
                     count: 3,
                     estimated_extra_kb: 36,
+                    finding: Default::default(),
                 },
                 duplicate("left-pad", &["1.0.0", "1.0.1"]),
             ],
@@ -306,6 +307,7 @@ fn sorts_versions_like_js_locale_compare_numeric() {
             versions: expected_versions,
             count: input_versions.len(),
             estimated_extra_kb: 162,
+            finding: Default::default(),
         }]
     );
 }
@@ -360,6 +362,7 @@ fn duplicate(name: &str, versions: &[&str]) -> DuplicatePackage {
         versions: versions.iter().map(|value| (*value).to_string()).collect(),
         count: versions.len(),
         estimated_extra_kb: usize::max((versions.len().saturating_sub(1)) * 18, 18),
+        finding: Default::default(),
     }
 }
 

--- a/tests/fixtures/aliases/jsconfig-paths/jsconfig.json
+++ b/tests/fixtures/aliases/jsconfig-paths/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "~/*": ["components/*", "fallback/*"],
+      "#env": ["config/env.js"]
+    }
+  }
+}

--- a/tests/fixtures/aliases/jsconfig-paths/package.json
+++ b/tests/fixtures/aliases/jsconfig-paths/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "alias-jsconfig-paths",
+  "private": true
+}

--- a/tests/fixtures/aliases/tsconfig-paths/package.json
+++ b/tests/fixtures/aliases/tsconfig-paths/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "alias-tsconfig-paths",
+  "private": true
+}

--- a/tests/fixtures/aliases/tsconfig-paths/tsconfig.json
+++ b/tests/fixtures/aliases/tsconfig-paths/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@shared": ["src/shared/index.ts", "src/shared/fallback.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## 배경
- `TODO.md` 기준 현재 unlocked phase인 `Phase 1 Shared Seams`를 실제 Rust core seam으로 고정합니다.
- 이번 PR은 병렬로 구현한 `PR-FIT-001A`, `PR-FIT-003A`, `PR-FIT-007A`를 하나의 publish unit으로 묶었습니다.
- 이유는 `crates/legolas-core/src/lib.rs`가 세 seam의 공통 접점이라, 현재 작업트리 상태를 그대로 올리는 편이 partial publish보다 안전했기 때문입니다.

## 변경 사항
- finding metadata/evidence seam 추가
  - `crates/legolas-core/src/findings.rs`
  - `crates/legolas-core/src/models.rs`
  - `crates/legolas-core/tests/finding_support.rs`
- tsconfig/jsconfig alias loader seam 추가
  - `crates/legolas-core/src/aliases.rs`
  - `crates/legolas-core/src/workspace.rs`
  - `crates/legolas-core/tests/alias_resolution.rs`
  - `tests/fixtures/aliases/**`
- artifact summary model / parser namespace seam 추가
  - `crates/legolas-core/src/artifacts/mod.rs`
  - `crates/legolas-core/src/artifacts/models.rs`
  - `crates/legolas-core/tests/artifact_models.rs`
- follow-through 보정
  - 기존 finding constructor / 테스트가 새 `finding` field와 함께 compile 되도록 기본값 연결
  - tree-shaking warning merge가 finding metadata를 보존하도록 보강
  - alias loader가 JSONC comment / trailing comma를 허용하고 unterminated block comment는 malformed 로 거절하도록 보강
  - artifact namespace test가 source file 우회가 아니라 crate public API를 직접 검증하도록 수정

## 검증
- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Devil's Advocate review loop 2 rounds
  - Round 1 accepted: tree-shaking metadata merge 보존, alias JSONC 허용, artifact public API test 보강
  - Round 2 accepted: unterminated block comment malformed 처리

## 브랜치 / 워크트리
- 대상 브랜치: `codex/fit-phase1-shared-seams`
- 현재 워크트리: `/Users/pjw/workspace/legolas`
- 별도 source worktree publish는 없음

## 이슈 연결
- 없음
