### PR TITLE
feat: alias-aware import scanner 적용

### DIFF
--- a/crates/legolas-core/src/aliases.rs
+++ b/crates/legolas-core/src/aliases.rs
@@ -271,9 +271,23 @@ fn parse_paths(
     // Keep more-specific rules first so later matchers can use this order directly.
     rules.sort_by(|left, right| {
         right
-            .specifier_prefix
-            .len()
-            .cmp(&left.specifier_prefix.len())
+            .pattern
+            .chars()
+            .filter(|character| *character != '*')
+            .count()
+            .cmp(
+                &left
+                    .pattern
+                    .chars()
+                    .filter(|character| *character != '*')
+                    .count(),
+            )
+            .then_with(|| {
+                right
+                    .specifier_prefix
+                    .len()
+                    .cmp(&left.specifier_prefix.len())
+            })
             .then_with(|| left.wildcard.cmp(&right.wildcard))
             .then_with(|| left.pattern.cmp(&right.pattern))
     });
@@ -317,17 +331,21 @@ fn parse_rule_pattern(value: &str, config_path: &Path, key_path: &str) -> Result
         });
     }
 
-    if wildcard_count != 1 || !(value == "*" || value.ends_with("/*")) {
+    if wildcard_count != 1 {
         return unsupported_shape(
             config_path,
             key_path,
-            "expected exact value, catch-all *, or a single trailing /* wildcard pattern",
+            "expected exact value or a single * wildcard pattern",
         );
     }
 
+    let (prefix, _) = value
+        .split_once('*')
+        .expect("single wildcard patterns always split");
+
     Ok(ParsedPattern {
         original: value.to_string(),
-        prefix: value.trim_end_matches('*').to_string(),
+        prefix: prefix.to_string(),
         wildcard: true,
     })
 }

--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use crate::{
     error::Result,
     impact::estimate_impact,
-    import_scanner::{collect_source_files, scan_imports, SourceAnalysis},
+    import_scanner::{collect_source_files, scan_imports_with_aliases, SourceAnalysis},
     lockfiles::parse_duplicate_packages,
     models::{
         Analysis, HeavyDependency, LazyLoadCandidate, Metadata, PackageSummary, SourceSummary,
@@ -20,7 +20,7 @@ use crate::{
     },
     package_intelligence::get_package_intel,
     project_shape::{detect_frameworks, detect_package_manager},
-    workspace::{find_project_root, read_json_if_exists},
+    workspace::{find_project_root, load_alias_config, read_json_if_exists},
     LegolasError,
 };
 
@@ -44,8 +44,13 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
 
     let package_manager = detect_package_manager(&project_root, &manifest)?;
     let frameworks = detect_frameworks(&project_root, &manifest)?;
+    let alias_config = load_alias_config(&project_root)?;
     let source_files = collect_source_files(&project_root)?;
-    let source_analysis = scan_imports(&project_root, &source_files)?;
+    let source_analysis = scan_imports_with_aliases(
+        &project_root,
+        &source_files,
+        alias_config.as_ref().map(|loaded| &loaded.config),
+    )?;
     let duplicate_analysis = parse_duplicate_packages(&project_root, &package_manager)?;
     let heavy_dependencies = build_heavy_dependency_report(&manifest, &source_analysis);
     let lazy_load_candidates = build_lazy_load_candidates(&source_analysis, &heavy_dependencies);

--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -373,40 +373,59 @@ fn is_local_alias_import(specifier: &str, alias_config: Option<&AliasConfig>) ->
     };
 
     alias_config.rules.iter().any(|rule| {
-        match_alias_rule(rule, specifier).is_some_and(|suffix| {
+        match_alias_rule(rule, specifier).is_some_and(|capture| {
             rule.replacement_targets
                 .iter()
-                .any(|target| alias_target_exists(target, suffix))
+                .any(|target| alias_target_exists(target, capture))
         })
     })
 }
 
 fn match_alias_rule<'a>(rule: &crate::aliases::AliasRule, specifier: &'a str) -> Option<&'a str> {
-    if rule.wildcard {
-        specifier.strip_prefix(&rule.specifier_prefix)
-    } else if specifier == rule.specifier_prefix {
-        Some("")
+    if !rule.wildcard {
+        return (specifier == rule.specifier_prefix).then_some("");
+    }
+
+    let capture = specifier.strip_prefix(&rule.specifier_prefix)?;
+    let suffix = wildcard_suffix(&rule.pattern);
+
+    if suffix.is_empty() {
+        Some(capture)
     } else {
-        None
+        capture.strip_suffix(suffix)
     }
 }
 
-fn alias_target_exists(target: &AliasTarget, suffix: &str) -> bool {
-    resolved_alias_candidates(target, suffix)
-        .into_iter()
-        .any(|candidate| !is_package_install_path(&candidate) && path_exists(&candidate))
+fn wildcard_suffix(pattern: &str) -> &str {
+    pattern
+        .split_once('*')
+        .map(|(_, suffix)| suffix)
+        .unwrap_or("")
 }
 
-fn alias_candidate_path(target: &AliasTarget, suffix: &str) -> PathBuf {
-    if suffix.is_empty() {
+fn alias_target_exists(target: &AliasTarget, capture: &str) -> bool {
+    resolved_alias_candidates(target, capture)
+        .into_iter()
+        .any(|candidate| is_local_alias_candidate(&candidate))
+}
+
+fn alias_candidate_path(target: &AliasTarget, capture: &str) -> PathBuf {
+    if !target.pattern.contains('*') {
         return target.path_candidate.clone();
     }
 
-    target.path_candidate.join(Path::new(suffix))
+    let relative_tail = format!("{capture}{}", wildcard_suffix(&target.pattern));
+    let relative_tail = relative_tail.trim_start_matches('/');
+
+    if relative_tail.is_empty() {
+        target.path_candidate.clone()
+    } else {
+        target.path_candidate.join(Path::new(relative_tail))
+    }
 }
 
-fn resolved_alias_candidates(target: &AliasTarget, suffix: &str) -> Vec<PathBuf> {
-    let candidate = alias_candidate_path(target, suffix);
+fn resolved_alias_candidates(target: &AliasTarget, capture: &str) -> Vec<PathBuf> {
+    let candidate = alias_candidate_path(target, capture);
     let mut candidates = vec![candidate.clone()];
 
     if candidate.extension().is_none() {
@@ -425,6 +444,17 @@ fn resolved_alias_candidates(target: &AliasTarget, suffix: &str) -> Vec<PathBuf>
 
 fn path_exists(path: &Path) -> bool {
     fs::metadata(path).is_ok()
+}
+
+fn is_local_alias_candidate(path: &Path) -> bool {
+    if !path_exists(path) || is_package_install_path(path) {
+        return false;
+    }
+
+    match fs::canonicalize(path) {
+        Ok(canonical) => !is_package_install_path(&canonical),
+        Err(_) => true,
+    }
 }
 
 fn is_package_install_path(path: &Path) -> bool {

--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -166,6 +166,10 @@ pub fn scan_imports_with_aliases<P: AsRef<Path>>(
             scan_source_file(&scannable_contents, supports_jsx_text_guard(&absolute_path));
 
         for entry in scanned.imports {
+            if entry.kind == ImportKind::Dynamic {
+                dynamic_import_count += 1;
+            }
+
             if is_local_alias_import(&entry.specifier, alias_config) {
                 continue;
             }
@@ -181,7 +185,6 @@ pub fn scan_imports_with_aliases<P: AsRef<Path>>(
             record.files.insert(relative_path.clone());
             if entry.kind == ImportKind::Dynamic {
                 record.dynamic_files.insert(relative_path.clone());
-                dynamic_import_count += 1;
             } else {
                 record.static_files.insert(relative_path.clone());
             }
@@ -389,11 +392,9 @@ fn match_alias_rule<'a>(rule: &crate::aliases::AliasRule, specifier: &'a str) ->
 }
 
 fn alias_target_exists(target: &AliasTarget, suffix: &str) -> bool {
-    let candidate = alias_candidate_path(target, suffix);
-    path_exists(&candidate)
-        || resolve_with_source_suffixes(&candidate)
-            .into_iter()
-            .any(|candidate| path_exists(&candidate))
+    resolved_alias_candidates(target, suffix)
+        .into_iter()
+        .any(|candidate| !is_package_install_path(&candidate) && path_exists(&candidate))
 }
 
 fn alias_candidate_path(target: &AliasTarget, suffix: &str) -> PathBuf {
@@ -404,8 +405,9 @@ fn alias_candidate_path(target: &AliasTarget, suffix: &str) -> PathBuf {
     target.path_candidate.join(Path::new(suffix))
 }
 
-fn resolve_with_source_suffixes(candidate: &Path) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
+fn resolved_alias_candidates(target: &AliasTarget, suffix: &str) -> Vec<PathBuf> {
+    let candidate = alias_candidate_path(target, suffix);
+    let mut candidates = vec![candidate.clone()];
 
     if candidate.extension().is_none() {
         let base = candidate.to_string_lossy();
@@ -423,6 +425,13 @@ fn resolve_with_source_suffixes(candidate: &Path) -> Vec<PathBuf> {
 
 fn path_exists(path: &Path) -> bool {
     fs::metadata(path).is_ok()
+}
+
+fn is_package_install_path(path: &Path) -> bool {
+    path.components().any(|component| match component {
+        std::path::Component::Normal(segment) => segment == "node_modules",
+        _ => false,
+    })
 }
 
 fn merge_tree_shaking_warnings(warnings: Vec<TreeShakingWarning>) -> Vec<TreeShakingWarning> {

--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -8,7 +8,10 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::{
-    error::Result, models::TreeShakingWarning, FindingEvidence, FindingMetadata, LegolasError,
+    aliases::{AliasConfig, AliasTarget},
+    error::Result,
+    models::TreeShakingWarning,
+    FindingEvidence, FindingMetadata, LegolasError,
 };
 
 const IGNORED_DIRECTORIES: &[&str] = &[
@@ -137,6 +140,14 @@ pub fn scan_imports<P: AsRef<Path>>(
     project_root: P,
     source_files: &[PathBuf],
 ) -> Result<SourceAnalysis> {
+    scan_imports_with_aliases(project_root, source_files, None)
+}
+
+pub fn scan_imports_with_aliases<P: AsRef<Path>>(
+    project_root: P,
+    source_files: &[PathBuf],
+    alias_config: Option<&AliasConfig>,
+) -> Result<SourceAnalysis> {
     let project_root = project_root.as_ref();
     ensure_directory_exists(project_root)?;
 
@@ -155,6 +166,10 @@ pub fn scan_imports<P: AsRef<Path>>(
             scan_source_file(&scannable_contents, supports_jsx_text_guard(&absolute_path));
 
         for entry in scanned.imports {
+            if is_local_alias_import(&entry.specifier, alias_config) {
+                continue;
+            }
+
             let Some(package_name) = normalize_package_name(&entry.specifier) else {
                 continue;
             };
@@ -347,6 +362,67 @@ fn normalize_package_name(specifier: &str) -> Option<String> {
             .expect("split always returns at least one segment")
             .to_string(),
     )
+}
+
+fn is_local_alias_import(specifier: &str, alias_config: Option<&AliasConfig>) -> bool {
+    let Some(alias_config) = alias_config else {
+        return false;
+    };
+
+    alias_config.rules.iter().any(|rule| {
+        match_alias_rule(rule, specifier).is_some_and(|suffix| {
+            rule.replacement_targets
+                .iter()
+                .any(|target| alias_target_exists(target, suffix))
+        })
+    })
+}
+
+fn match_alias_rule<'a>(rule: &crate::aliases::AliasRule, specifier: &'a str) -> Option<&'a str> {
+    if rule.wildcard {
+        specifier.strip_prefix(&rule.specifier_prefix)
+    } else if specifier == rule.specifier_prefix {
+        Some("")
+    } else {
+        None
+    }
+}
+
+fn alias_target_exists(target: &AliasTarget, suffix: &str) -> bool {
+    let candidate = alias_candidate_path(target, suffix);
+    path_exists(&candidate)
+        || resolve_with_source_suffixes(&candidate)
+            .into_iter()
+            .any(|candidate| path_exists(&candidate))
+}
+
+fn alias_candidate_path(target: &AliasTarget, suffix: &str) -> PathBuf {
+    if suffix.is_empty() {
+        return target.path_candidate.clone();
+    }
+
+    target.path_candidate.join(Path::new(suffix))
+}
+
+fn resolve_with_source_suffixes(candidate: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if candidate.extension().is_none() {
+        let base = candidate.to_string_lossy();
+        for suffix in SOURCE_FILE_SUFFIXES {
+            candidates.push(PathBuf::from(format!("{base}{suffix}")));
+        }
+    }
+
+    for suffix in SOURCE_FILE_SUFFIXES {
+        candidates.push(candidate.join(format!("index{suffix}")));
+    }
+
+    candidates
+}
+
+fn path_exists(path: &Path) -> bool {
+    fs::metadata(path).is_ok()
 }
 
 fn merge_tree_shaking_warnings(warnings: Vec<TreeShakingWarning>) -> Vec<TreeShakingWarning> {

--- a/crates/legolas-core/tests/alias_resolution.rs
+++ b/crates/legolas-core/tests/alias_resolution.rs
@@ -24,6 +24,16 @@ fn load_alias_config_reads_tsconfig_paths_deterministically() {
         loaded.config.rules,
         vec![
             AliasRule {
+                pattern: "components/*".to_string(),
+                specifier_prefix: "components/".to_string(),
+                replacement_targets: vec![AliasTarget {
+                    pattern: "src/components/*".to_string(),
+                    replacement_prefix: "src/components/".to_string(),
+                    path_candidate: project_root.join("src/components"),
+                }],
+                wildcard: true,
+            },
+            AliasRule {
                 pattern: "@shared".to_string(),
                 specifier_prefix: "@shared".to_string(),
                 replacement_targets: vec![
@@ -69,6 +79,16 @@ fn load_alias_config_reads_jsconfig_paths_when_tsconfig_is_absent() {
             AliasRule {
                 pattern: "#env".to_string(),
                 specifier_prefix: "#env".to_string(),
+                replacement_targets: vec![AliasTarget {
+                    pattern: "config/env.js".to_string(),
+                    replacement_prefix: "config/env.js".to_string(),
+                    path_candidate: project_root.join("src/config/env.js"),
+                }],
+                wildcard: false,
+            },
+            AliasRule {
+                pattern: "env".to_string(),
+                specifier_prefix: "env".to_string(),
                 replacement_targets: vec![AliasTarget {
                     pattern: "config/env.js".to_string(),
                     replacement_prefix: "config/env.js".to_string(),

--- a/crates/legolas-core/tests/alias_resolution.rs
+++ b/crates/legolas-core/tests/alias_resolution.rs
@@ -223,6 +223,44 @@ fn load_alias_config_preserves_fallback_targets_and_catch_all_rules() {
 }
 
 #[test]
+fn load_alias_config_accepts_middle_wildcard_targets() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("tsconfig.json");
+    fs::write(
+        &config_path,
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*": ["src/components/*/index"]
+    }
+  }
+}
+"#,
+    )
+    .expect("write middle-wildcard tsconfig");
+
+    let loaded = load_alias_config(temp_dir.path())
+        .expect("load alias config")
+        .expect("tsconfig.json should be discovered");
+
+    assert_eq!(loaded.path, config_path);
+    assert_eq!(
+        loaded.config.rules,
+        vec![AliasRule {
+            pattern: "components/*".to_string(),
+            specifier_prefix: "components/".to_string(),
+            replacement_targets: vec![AliasTarget {
+                pattern: "src/components/*/index".to_string(),
+                replacement_prefix: "src/components/".to_string(),
+                path_candidate: temp_dir.path().join("src/components"),
+            }],
+            wildcard: true,
+        }]
+    );
+}
+
+#[test]
 fn load_alias_config_preserves_raw_package_remap_targets() {
     let temp_dir = tempdir().expect("create temp dir");
     let config_path = temp_dir.path().join("tsconfig.json");

--- a/crates/legolas-core/tests/analyze_parity.rs
+++ b/crates/legolas-core/tests/analyze_parity.rs
@@ -209,6 +209,94 @@ fn analyze_project_surfaces_malformed_alias_configs_instead_of_falling_back() {
     }
 }
 
+#[test]
+fn analyze_project_keeps_node_modules_package_remaps_as_used_dependencies() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "package-remap-analysis-app",
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "react": ["node_modules/preact/compat"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "import { h } from \"react\";\nexport const App = h;\n",
+    );
+    write_file(
+        root,
+        "node_modules/preact/compat/index.js",
+        "export const h = () => null;\n",
+    );
+
+    let analysis = analyze_project(root).expect("analyze package-remap project");
+
+    assert_eq!(analysis.source_summary.imported_packages, 1);
+    assert_eq!(analysis.source_summary.dynamic_imports, 0);
+    assert!(analysis.unused_dependency_candidates.is_empty());
+}
+
+#[test]
+fn analyze_project_counts_dynamic_alias_entries_even_without_package_usage() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "dynamic-alias-analysis-app",
+  "private": true
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "routes/*": ["src/routes/*"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "export async function load() {\n  await import(\"routes/dashboard\");\n  await import(\"./local\");\n}\n",
+    );
+    write_file(
+        root,
+        "src/routes/dashboard.tsx",
+        "export default 'dashboard';\n",
+    );
+    write_file(root, "src/local.ts", "export default 'local';\n");
+
+    let analysis = analyze_project(root).expect("analyze dynamic-alias project");
+
+    assert_eq!(analysis.source_summary.imported_packages, 0);
+    assert_eq!(analysis.source_summary.dynamic_imports, 2);
+}
+
 fn write_file(root: &Path, relative_path: &str, contents: &str) {
     let path = root.join(relative_path);
     let parent = path.parent().expect("fixture file parent");

--- a/crates/legolas-core/tests/analyze_parity.rs
+++ b/crates/legolas-core/tests/analyze_parity.rs
@@ -2,7 +2,7 @@ mod support;
 
 use std::{fs, path::Path};
 
-use legolas_core::analyze_project;
+use legolas_core::{analyze_project, LegolasError};
 use regex::Regex;
 use tempfile::tempdir;
 
@@ -112,6 +112,101 @@ fn analyze_project_emits_iso_8601_generated_at_metadata() {
         Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$").expect("valid regex");
 
     assert!(iso8601_utc.is_match(&analysis.metadata.generated_at));
+}
+
+#[test]
+fn analyze_project_uses_alias_config_to_ignore_local_alias_imports() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "alias-analysis-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "components": "^1.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*": ["src/components/*"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "import { Button } from \"components/Button\";\nimport \"chart.js/auto\";\nexport const App = Button;\n",
+    );
+    write_file(
+        root,
+        "src/components/Button.tsx",
+        "export const Button = 'button';\n",
+    );
+
+    let analysis = analyze_project(root).expect("analyze alias-aware project");
+
+    assert_eq!(analysis.source_summary.imported_packages, 1);
+    assert_eq!(
+        analysis
+            .unused_dependency_candidates
+            .iter()
+            .map(|item| item.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["components"]
+    );
+}
+
+#[test]
+fn analyze_project_surfaces_malformed_alias_configs_instead_of_falling_back() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+    let config_path = root.join("tsconfig.json");
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "malformed-alias-app",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}"#,
+    );
+    write_file(root, "src/App.ts", "import { chunk } from \"lodash\";\n");
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "paths": "@/src/*"
+  }
+}"#,
+    );
+
+    let error = analyze_project(root).expect_err("malformed alias config should fail");
+
+    match error {
+        LegolasError::UnsupportedConfigShape {
+            path,
+            key_path,
+            message,
+        } => {
+            assert_eq!(path, config_path.display().to_string());
+            assert_eq!(key_path, "compilerOptions.paths");
+            assert_eq!(message, "expected object");
+        }
+        other => panic!("expected unsupported config shape error, got {other:?}"),
+    }
 }
 
 fn write_file(root: &Path, relative_path: &str, contents: &str) {

--- a/crates/legolas-core/tests/analyze_parity.rs
+++ b/crates/legolas-core/tests/analyze_parity.rs
@@ -2,6 +2,11 @@ mod support;
 
 use std::{fs, path::Path};
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink as create_dir_symlink;
+#[cfg(windows)]
+use std::os::windows::fs::symlink_dir as create_dir_symlink;
+
 use legolas_core::{analyze_project, LegolasError};
 use regex::Regex;
 use tempfile::tempdir;
@@ -210,6 +215,58 @@ fn analyze_project_surfaces_malformed_alias_configs_instead_of_falling_back() {
 }
 
 #[test]
+fn analyze_project_uses_middle_wildcard_alias_targets_to_ignore_local_imports() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "middle-wildcard-alias-analysis-app",
+  "dependencies": {
+    "components": "^1.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*": ["src/components/*/index"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "import Button from \"components/button\";\nexport default Button;\n",
+    );
+    write_file(
+        root,
+        "src/components/button/index.ts",
+        "const Button = 'button';\nexport default Button;\n",
+    );
+
+    let analysis = analyze_project(root).expect("analyze middle-wildcard alias project");
+
+    assert_eq!(analysis.source_summary.imported_packages, 0);
+    assert_eq!(analysis.source_summary.dynamic_imports, 0);
+    assert_eq!(
+        analysis
+            .unused_dependency_candidates
+            .iter()
+            .map(|item| item.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["components"]
+    );
+}
+
+#[test]
 fn analyze_project_keeps_node_modules_package_remaps_as_used_dependencies() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();
@@ -295,6 +352,56 @@ fn analyze_project_counts_dynamic_alias_entries_even_without_package_usage() {
 
     assert_eq!(analysis.source_summary.imported_packages, 0);
     assert_eq!(analysis.source_summary.dynamic_imports, 2);
+}
+
+#[test]
+fn analyze_project_keeps_symlinked_package_remaps_as_used_dependencies() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "symlink-package-remap-analysis-app",
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "react": ["vendor/react"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "import { h } from \"react\";\nexport const App = h;\n",
+    );
+    write_file(
+        root,
+        "node_modules/preact/compat/index.js",
+        "export const h = () => null;\n",
+    );
+    fs::create_dir_all(root.join("vendor")).expect("create vendor dir");
+    create_dir_symlink(
+        root.join("node_modules/preact/compat"),
+        root.join("vendor/react"),
+    )
+    .expect("create vendor symlink");
+
+    let analysis = analyze_project(root).expect("analyze symlink package-remap project");
+
+    assert_eq!(analysis.source_summary.imported_packages, 1);
+    assert!(analysis.unused_dependency_candidates.is_empty());
 }
 
 fn write_file(root: &Path, relative_path: &str, contents: &str) {

--- a/crates/legolas-core/tests/import_scanner.rs
+++ b/crates/legolas-core/tests/import_scanner.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use legolas_core::{
-    import_scanner::{collect_source_files, scan_imports, ImportedPackageRecord},
+    import_scanner::{
+        collect_source_files, scan_imports, scan_imports_with_aliases, ImportedPackageRecord,
+    },
+    workspace::load_alias_config,
     TreeShakingWarning,
 };
 use tempfile::tempdir;
@@ -196,6 +199,60 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
             },
         ]
     );
+}
+
+#[test]
+fn scan_imports_excludes_tsconfig_backed_local_aliases_from_package_usage() {
+    let root = support::fixture_path("tests/fixtures/aliases/tsconfig-paths");
+    let files = collect_source_files(&root).expect("collect tsconfig fixture source files");
+    let alias_config = load_alias_config(&root)
+        .expect("load tsconfig alias config")
+        .expect("tsconfig alias config should exist");
+
+    assert_eq!(
+        to_posix_paths(&root, &files),
+        vec![
+            "src/App.tsx",
+            "src/components/Button.tsx",
+            "src/shared/fallback.ts",
+            "src/shared/index.ts",
+        ]
+    );
+
+    let legacy = scan_imports(&root, &files).expect("scan imports without alias config");
+    let alias_aware = scan_imports_with_aliases(&root, &files, Some(&alias_config.config))
+        .expect("scan imports with alias config");
+
+    assert!(legacy.by_package.contains_key("components"));
+    assert!(legacy.by_package.contains_key("chart.js"));
+    assert!(!alias_aware.by_package.contains_key("components"));
+    assert!(alias_aware.by_package.contains_key("chart.js"));
+    assert_eq!(alias_aware.imported_packages.len(), 1);
+    assert_eq!(alias_aware.dynamic_import_count, 0);
+}
+
+#[test]
+fn scan_imports_excludes_jsconfig_backed_exact_aliases_from_package_usage() {
+    let root = support::fixture_path("tests/fixtures/aliases/jsconfig-paths");
+    let files = collect_source_files(&root).expect("collect jsconfig fixture source files");
+    let alias_config = load_alias_config(&root)
+        .expect("load jsconfig alias config")
+        .expect("jsconfig alias config should exist");
+
+    assert_eq!(
+        to_posix_paths(&root, &files),
+        vec!["src/config/env.js", "src/index.jsx"]
+    );
+
+    let legacy = scan_imports(&root, &files).expect("scan imports without alias config");
+    let alias_aware = scan_imports_with_aliases(&root, &files, Some(&alias_config.config))
+        .expect("scan imports with alias config");
+
+    assert!(legacy.by_package.contains_key("env"));
+    assert!(legacy.by_package.contains_key("react-icons"));
+    assert!(!alias_aware.by_package.contains_key("env"));
+    assert!(alias_aware.by_package.contains_key("react-icons"));
+    assert_eq!(alias_aware.imported_packages.len(), 1);
 }
 
 fn write_file(root: &Path, relative_path: &str, contents: &str) {

--- a/crates/legolas-core/tests/import_scanner.rs
+++ b/crates/legolas-core/tests/import_scanner.rs
@@ -5,6 +5,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink as create_dir_symlink;
+#[cfg(windows)]
+use std::os::windows::fs::symlink_dir as create_dir_symlink;
+
 use legolas_core::{
     import_scanner::{
         collect_source_files, scan_imports, scan_imports_with_aliases, ImportedPackageRecord,
@@ -256,6 +261,56 @@ fn scan_imports_excludes_jsconfig_backed_exact_aliases_from_package_usage() {
 }
 
 #[test]
+fn scan_imports_excludes_middle_wildcard_alias_patterns_from_package_usage() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "middle-wildcard-alias-app",
+  "private": true
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*/public": ["src/components/*/index"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "import Button from \"components/button/public\";\nexport default Button;\n",
+    );
+    write_file(
+        root,
+        "src/components/button/index.ts",
+        "const Button = 'button';\nexport default Button;\n",
+    );
+
+    let files = collect_source_files(root).expect("collect middle-wildcard source files");
+    let alias_config = load_alias_config(root)
+        .expect("load middle-wildcard alias config")
+        .expect("middle-wildcard alias config should exist");
+
+    let legacy = scan_imports(root, &files).expect("scan imports without alias config");
+    let alias_aware = scan_imports_with_aliases(root, &files, Some(&alias_config.config))
+        .expect("scan imports with alias config");
+
+    assert!(legacy.by_package.contains_key("components"));
+    assert!(alias_aware.by_package.is_empty());
+    assert_eq!(alias_aware.imported_packages.len(), 0);
+    assert_eq!(alias_aware.dynamic_import_count, 0);
+}
+
+#[test]
 fn scan_imports_keeps_node_modules_package_remaps_counted_as_packages() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();
@@ -346,6 +401,58 @@ fn scan_imports_counts_dynamic_entries_even_when_aliases_are_local() {
 
     assert_eq!(alias_aware.imported_packages.len(), 0);
     assert_eq!(alias_aware.dynamic_import_count, 2);
+}
+
+#[test]
+fn scan_imports_keeps_symlinked_package_remaps_counted_as_packages() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "symlink-package-remap-app",
+  "private": true
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "react": ["vendor/react"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "import { h } from \"react\";\nexport const App = h;\n",
+    );
+    write_file(
+        root,
+        "node_modules/preact/compat/index.js",
+        "export const h = () => null;\n",
+    );
+    fs::create_dir_all(root.join("vendor")).expect("create vendor dir");
+    create_dir_symlink(
+        root.join("node_modules/preact/compat"),
+        root.join("vendor/react"),
+    )
+    .expect("create vendor symlink");
+
+    let files = collect_source_files(root).expect("collect symlink-remap source files");
+    let alias_config = load_alias_config(root)
+        .expect("load symlink-remap alias config")
+        .expect("symlink-remap alias config should exist");
+    let alias_aware = scan_imports_with_aliases(root, &files, Some(&alias_config.config))
+        .expect("scan imports with alias config");
+
+    assert!(alias_aware.by_package.contains_key("react"));
+    assert_eq!(alias_aware.imported_packages.len(), 1);
 }
 
 fn write_file(root: &Path, relative_path: &str, contents: &str) {

--- a/crates/legolas-core/tests/import_scanner.rs
+++ b/crates/legolas-core/tests/import_scanner.rs
@@ -78,7 +78,7 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
 
     let analysis = scan_imports(&root, &files).expect("scan fixture imports");
 
-    assert_eq!(analysis.dynamic_import_count, 2);
+    assert_eq!(analysis.dynamic_import_count, 4);
     assert_eq!(
         analysis.by_package.keys().cloned().collect::<Vec<_>>(),
         vec![
@@ -253,6 +253,99 @@ fn scan_imports_excludes_jsconfig_backed_exact_aliases_from_package_usage() {
     assert!(!alias_aware.by_package.contains_key("env"));
     assert!(alias_aware.by_package.contains_key("react-icons"));
     assert_eq!(alias_aware.imported_packages.len(), 1);
+}
+
+#[test]
+fn scan_imports_keeps_node_modules_package_remaps_counted_as_packages() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "package-remap-app",
+  "private": true
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "react": ["node_modules/preact/compat"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "import { h } from \"react\";\nexport const App = h;\n",
+    );
+    write_file(
+        root,
+        "node_modules/preact/compat/index.js",
+        "export const h = () => null;\n",
+    );
+
+    let files = collect_source_files(root).expect("collect package-remap source files");
+    let alias_config = load_alias_config(root)
+        .expect("load package-remap alias config")
+        .expect("package-remap alias config should exist");
+    let alias_aware = scan_imports_with_aliases(root, &files, Some(&alias_config.config))
+        .expect("scan imports with alias config");
+
+    assert!(alias_aware.by_package.contains_key("react"));
+    assert_eq!(alias_aware.imported_packages.len(), 1);
+}
+
+#[test]
+fn scan_imports_counts_dynamic_entries_even_when_aliases_are_local() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "dynamic-alias-app",
+  "private": true
+}"#,
+    );
+    write_file(
+        root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "routes/*": ["src/routes/*"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/App.tsx",
+        "export async function load() {\n  await import(\"routes/dashboard\");\n  await import(\"./local\");\n}\n",
+    );
+    write_file(
+        root,
+        "src/routes/dashboard.tsx",
+        "export default 'dashboard';\n",
+    );
+    write_file(root, "src/local.ts", "export default 'local';\n");
+
+    let files = collect_source_files(root).expect("collect dynamic-alias source files");
+    let alias_config = load_alias_config(root)
+        .expect("load dynamic-alias alias config")
+        .expect("dynamic-alias alias config should exist");
+    let alias_aware = scan_imports_with_aliases(root, &files, Some(&alias_config.config))
+        .expect("scan imports with alias config");
+
+    assert_eq!(alias_aware.imported_packages.len(), 0);
+    assert_eq!(alias_aware.dynamic_import_count, 2);
 }
 
 fn write_file(root: &Path, relative_path: &str, contents: &str) {

--- a/tests/fixtures/aliases/jsconfig-paths/jsconfig.json
+++ b/tests/fixtures/aliases/jsconfig-paths/jsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "src",
     "paths": {
+      "env": ["config/env.js"],
       "~/*": ["components/*", "fallback/*"],
       "#env": ["config/env.js"]
     }

--- a/tests/fixtures/aliases/jsconfig-paths/src/config/env.js
+++ b/tests/fixtures/aliases/jsconfig-paths/src/config/env.js
@@ -1,0 +1,3 @@
+export default {
+  mode: "test",
+};

--- a/tests/fixtures/aliases/jsconfig-paths/src/index.jsx
+++ b/tests/fixtures/aliases/jsconfig-paths/src/index.jsx
@@ -1,0 +1,6 @@
+import env from "env";
+import { FiAlertCircle } from "react-icons/fi";
+
+export function boot() {
+  return `${env.mode}-${FiAlertCircle.displayName ?? "icon"}`;
+}

--- a/tests/fixtures/aliases/tsconfig-paths/src/App.tsx
+++ b/tests/fixtures/aliases/tsconfig-paths/src/App.tsx
@@ -1,0 +1,7 @@
+import { Button } from "components/Button";
+import { sharedValue } from "@shared";
+import "chart.js/auto";
+
+export function App() {
+  return `${Button}-${sharedValue}`;
+}

--- a/tests/fixtures/aliases/tsconfig-paths/src/components/Button.tsx
+++ b/tests/fixtures/aliases/tsconfig-paths/src/components/Button.tsx
@@ -1,0 +1,1 @@
+export const Button = "button";

--- a/tests/fixtures/aliases/tsconfig-paths/src/shared/fallback.ts
+++ b/tests/fixtures/aliases/tsconfig-paths/src/shared/fallback.ts
@@ -1,0 +1,1 @@
+export const fallbackValue = "fallback";

--- a/tests/fixtures/aliases/tsconfig-paths/src/shared/index.ts
+++ b/tests/fixtures/aliases/tsconfig-paths/src/shared/index.ts
@@ -1,0 +1,1 @@
+export const sharedValue = "shared";

--- a/tests/fixtures/aliases/tsconfig-paths/tsconfig.json
+++ b/tests/fixtures/aliases/tsconfig-paths/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "components/*": ["src/components/*"],
       "@/*": ["src/*"],
       "@shared": ["src/shared/index.ts", "src/shared/fallback.ts"]
     }


### PR DESCRIPTION
## 배경
- `TODO.md` 기준 현재 unlocked phase인 `Phase 2 Trustable Finding Core`의 `PR-FIT-003B`를 구현합니다.
- Phase 1에서 만든 alias loader seam을 실제 `analyze/import scanner` 경로에 채택해서 local alias import를 외부 패키지 usage로 잘못 세는 false positive를 줄이는 것이 목적입니다.

## 변경 사항
- `analyze_project`가 project root 기준으로 `tsconfig.json` / `jsconfig.json` alias config를 로드하고 scanner에 전달하도록 연결했습니다.
- `import_scanner`에 alias-aware 경로를 추가해 실제 local file/dir로 해석되는 alias import만 package usage에서 제외하도록 보강했습니다.
- package remap은 계속 package usage로 남도록 direct `node_modules` target과 symlinked package-install target까지 구분하도록 수정했습니다.
- `dynamicImportCount`가 package count가 아니라 entry count 계약을 유지하도록 local alias dynamic import도 집계에 반영했습니다.
- alias fixture와 regression test를 확장해 local alias, malformed alias config, direct/symlinked package remap, dynamic alias import를 모두 고정했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Devil's Advocate review loop 3 rounds
  - Round 1 accepted: package remap into `node_modules` 오판, local alias dynamic import 카운트 누락
  - Round 2 accepted: symlinked package remap 오판
  - Round 3: High/Critical finding 없음

## 브랜치 / 워크트리
- 대상 브랜치: `codex/fit-alias-adoption`
- 현재 워크트리: `/Users/pjw/workspace/legolas`
- 별도 source worktree publish: 없음

## 이슈 연결
- 없음
