### PR TITLE
feat: finding evidence 메타데이터 채우기

### DIFF
--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -11,8 +11,11 @@ use serde_json::Value;
 
 use crate::{
     error::Result,
+    findings::{FindingAnalysisSource, FindingEvidence, FindingMetadata},
     impact::estimate_impact,
-    import_scanner::{collect_source_files, scan_imports_with_aliases, SourceAnalysis},
+    import_scanner::{
+        collect_source_files, scan_imports_with_aliases, ImportedPackageRecord, SourceAnalysis,
+    },
     lockfiles::parse_duplicate_packages,
     models::{
         Analysis, HeavyDependency, LazyLoadCandidate, Metadata, PackageSummary, SourceSummary,
@@ -128,7 +131,7 @@ fn build_heavy_dependency_report(
 
         let import_info = source_analysis.by_package.get(&name);
         heavy_dependencies.push(HeavyDependency {
-            name,
+            name: name.clone(),
             version_range,
             estimated_kb: intel.estimated_kb,
             category: intel.category.to_string(),
@@ -141,7 +144,7 @@ fn build_heavy_dependency_report(
                 .map(|item| item.dynamic_files.clone())
                 .unwrap_or_default(),
             import_count: import_info.map(|item| item.files.len()).unwrap_or(0),
-            finding: Default::default(),
+            finding: build_heavy_dependency_finding(&name, intel.rationale, import_info),
         });
     }
 
@@ -203,6 +206,7 @@ fn build_lazy_load_candidates(
             continue;
         }
 
+        let evidence_files = split_friendly_files.clone();
         candidates.push(LazyLoadCandidate {
             name: imported_package.name.clone(),
             estimated_savings_kb: (heavy.estimated_kb as f64 * 0.75).round() as usize,
@@ -212,7 +216,7 @@ fn build_lazy_load_candidates(
                 "{} is statically imported in UI surfaces that usually tolerate lazy loading",
                 imported_package.name
             ),
-            finding: Default::default(),
+            finding: build_lazy_load_finding(&imported_package.name, &evidence_files),
         });
     }
 
@@ -224,6 +228,80 @@ fn build_tree_shaking_warnings(source_analysis: &SourceAnalysis) -> Vec<TreeShak
     let mut warnings = source_analysis.tree_shaking_warnings.clone();
     warnings.sort_by_key(|item| Reverse(item.estimated_kb));
     warnings
+}
+
+fn build_heavy_dependency_finding(
+    package_name: &str,
+    rationale: &str,
+    import_info: Option<&ImportedPackageRecord>,
+) -> FindingMetadata {
+    let analysis_source = import_info
+        .filter(|item| !item.files.is_empty())
+        .map(|_| FindingAnalysisSource::SourceImport)
+        .unwrap_or(FindingAnalysisSource::Heuristic);
+    let mut evidence = Vec::new();
+
+    if let Some(import_info) = import_info {
+        evidence.extend(
+            import_info
+                .static_files
+                .iter()
+                .map(|file| {
+                    FindingEvidence::new("source-file")
+                        .with_file(file.clone())
+                        .with_specifier(package_name.to_string())
+                        .with_detail(format!("static import; {rationale}"))
+                })
+                .collect::<Vec<_>>(),
+        );
+        evidence.extend(
+            import_info
+                .dynamic_files
+                .iter()
+                .map(|file| {
+                    FindingEvidence::new("source-file")
+                        .with_file(file.clone())
+                        .with_specifier(package_name.to_string())
+                        .with_detail(format!("dynamic import; {rationale}"))
+                })
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    FindingMetadata::new(format!("heavy-dependency:{package_name}"), analysis_source)
+        .with_evidence(evidence)
+}
+
+fn build_lazy_load_finding(package_name: &str, files: &[String]) -> FindingMetadata {
+    let evidence = files
+        .iter()
+        .map(|file| {
+            FindingEvidence::new("source-file")
+                .with_file(file.clone())
+                .with_specifier(package_name.to_string())
+                .with_detail(lazy_load_surface_detail(file))
+        })
+        .collect::<Vec<_>>();
+
+    FindingMetadata::new(
+        format!("lazy-load:{package_name}"),
+        FindingAnalysisSource::Heuristic,
+    )
+    .with_evidence(evidence)
+}
+
+fn lazy_load_surface_detail(file: &str) -> String {
+    let normalized = file.to_ascii_lowercase();
+
+    CANDIDATE_FILES_PATTERN
+        .find(&normalized)
+        .map(|matched| {
+            format!(
+                "route-like UI surface matched `{}` keyword",
+                matched.as_str()
+            )
+        })
+        .unwrap_or_else(|| "route-like UI surface heuristic".to_string())
 }
 
 fn build_unused_dependency_candidates(

--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -11,7 +11,7 @@ use crate::{
     aliases::{AliasConfig, AliasTarget},
     error::Result,
     models::TreeShakingWarning,
-    FindingEvidence, FindingMetadata, LegolasError,
+    FindingAnalysisSource, FindingEvidence, FindingMetadata, LegolasError,
 };
 
 const IGNORED_DIRECTORIES: &[&str] = &[
@@ -192,6 +192,8 @@ pub fn scan_imports_with_aliases<P: AsRef<Path>>(
 
         for mut hint in scanned.tree_shaking_hints {
             hint.files = vec![relative_path.clone()];
+            hint.finding =
+                build_tree_shaking_finding(&hint.key, &hint.package_name, &relative_path);
             tree_shaking_observations.push(hint);
         }
     }
@@ -709,6 +711,34 @@ fn build_tree_shaking_hint(specifier: &str, clause: &str) -> Option<TreeShakingW
     }
 
     None
+}
+
+fn build_tree_shaking_finding(
+    warning_key: &str,
+    package_name: &str,
+    relative_path: &str,
+) -> FindingMetadata {
+    let mut evidence = FindingEvidence::new("source-file")
+        .with_file(relative_path.to_string())
+        .with_specifier(package_name.to_string());
+
+    if let Some(detail) = tree_shaking_evidence_detail(warning_key) {
+        evidence = evidence.with_detail(detail);
+    }
+
+    FindingMetadata::new(
+        format!("tree-shaking:{warning_key}"),
+        FindingAnalysisSource::SourceImport,
+    )
+    .with_evidence([evidence])
+}
+
+fn tree_shaking_evidence_detail(warning_key: &str) -> Option<&'static str> {
+    match warning_key {
+        "namespace-ui-import" => Some("namespace import"),
+        "lodash-root-import" | "react-icons-root-import" => Some("root package import"),
+        _ => None,
+    }
 }
 
 fn is_type_only_clause(clause: &str) -> bool {

--- a/crates/legolas-core/tests/finding_evidence.rs
+++ b/crates/legolas-core/tests/finding_evidence.rs
@@ -1,0 +1,133 @@
+mod support;
+
+use std::fs;
+
+use legolas_core::{analyze_project, FindingAnalysisSource, FindingEvidence, FindingMetadata};
+use tempfile::tempdir;
+
+#[test]
+fn analyze_project_populates_heavy_dependency_evidence() {
+    let analysis = analyze_project(support::fixture_path(
+        "tests/fixtures/findings/evidence-app",
+    ))
+    .expect("analyze evidence fixture");
+    let heavy_dependency = analysis
+        .heavy_dependencies
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js heavy dependency");
+
+    assert_eq!(
+        heavy_dependency.finding,
+        FindingMetadata::new(
+            "heavy-dependency:chart.js",
+            FindingAnalysisSource::SourceImport,
+        )
+        .with_evidence([FindingEvidence::new("source-file")
+            .with_file("src/AdminDashboard.tsx")
+            .with_specifier("chart.js")
+            .with_detail(
+                "static import; Charting code is often only needed on a subset of screens.",
+            )])
+    );
+}
+
+#[test]
+fn analyze_project_populates_lazy_load_candidate_evidence() {
+    let analysis = analyze_project(support::fixture_path(
+        "tests/fixtures/findings/evidence-app",
+    ))
+    .expect("analyze evidence fixture");
+    let candidate = analysis
+        .lazy_load_candidates
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js lazy-load candidate");
+
+    assert_eq!(
+        candidate.finding,
+        FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic).with_evidence(
+            [FindingEvidence::new("source-file")
+                .with_file("src/AdminDashboard.tsx")
+                .with_specifier("chart.js")
+                .with_detail("route-like UI surface matched `admin` keyword")]
+        )
+    );
+}
+
+#[test]
+fn analyze_project_populates_tree_shaking_warning_evidence() {
+    let analysis = analyze_project(support::fixture_path(
+        "tests/fixtures/findings/evidence-app",
+    ))
+    .expect("analyze evidence fixture");
+    let warning = analysis
+        .tree_shaking_warnings
+        .iter()
+        .find(|item| item.key == "lodash-root-import")
+        .expect("lodash tree-shaking warning");
+
+    assert_eq!(
+        warning.finding,
+        FindingMetadata::new(
+            "tree-shaking:lodash-root-import",
+            FindingAnalysisSource::SourceImport,
+        )
+        .with_evidence([FindingEvidence::new("source-file")
+            .with_file("src/AdminDashboard.tsx")
+            .with_specifier("lodash")
+            .with_detail("root package import")])
+    );
+}
+
+#[test]
+fn analyze_project_limits_lazy_load_evidence_to_candidate_files() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "lazy-evidence-app",
+  "dependencies": {
+    "chart.js": "^4.4.1"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/Dashboard.tsx",
+        "import { Chart } from \"chart.js\";\nexport const Dashboard = Chart;\n",
+    );
+    write_file(
+        root,
+        "src/utils/shared.ts",
+        "import { Chart } from \"chart.js\";\nexport const shared = Chart;\n",
+    );
+
+    let analysis = analyze_project(root).expect("analyze lazy evidence project");
+    let candidate = analysis
+        .lazy_load_candidates
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js lazy-load candidate");
+
+    assert_eq!(candidate.files, vec!["src/Dashboard.tsx".to_string()]);
+    assert_eq!(
+        candidate.finding,
+        FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic).with_evidence(
+            [FindingEvidence::new("source-file")
+                .with_file("src/Dashboard.tsx")
+                .with_specifier("chart.js")
+                .with_detail("route-like UI surface matched `dashboard` keyword")]
+        )
+    );
+}
+
+fn write_file(root: &std::path::Path, relative_path: &str, contents: &str) {
+    let path = root.join(relative_path);
+    let parent = path.parent().expect("fixture file parent");
+    fs::create_dir_all(parent).expect("create fixture directory");
+    fs::write(path, contents).expect("write fixture file");
+}

--- a/crates/legolas-core/tests/import_scanner.rs
+++ b/crates/legolas-core/tests/import_scanner.rs
@@ -15,7 +15,7 @@ use legolas_core::{
         collect_source_files, scan_imports, scan_imports_with_aliases, ImportedPackageRecord,
     },
     workspace::load_alias_config,
-    TreeShakingWarning,
+    FindingAnalysisSource, FindingEvidence, FindingMetadata, TreeShakingWarning,
 };
 use tempfile::tempdir;
 
@@ -177,7 +177,14 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                 recommendation: "Prefer per-method imports or lodash-es.".to_string(),
                 estimated_kb: 26,
                 files: vec!["basic/Dashboard.tsx".to_string()],
-                finding: Default::default(),
+                finding: FindingMetadata::new(
+                    "tree-shaking:lodash-root-import",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_evidence([FindingEvidence::new("source-file")
+                    .with_file("basic/Dashboard.tsx")
+                    .with_specifier("lodash")
+                    .with_detail("root package import")]),
             },
             TreeShakingWarning {
                 key: "react-icons-root-import".to_string(),
@@ -189,7 +196,20 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                     "basic/Dashboard.tsx".to_string(),
                     "vue/Widget.vue".to_string()
                 ],
-                finding: Default::default(),
+                finding: FindingMetadata::new(
+                    "tree-shaking:react-icons-root-import",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_evidence([
+                    FindingEvidence::new("source-file")
+                        .with_file("basic/Dashboard.tsx")
+                        .with_specifier("react-icons")
+                        .with_detail("root package import"),
+                    FindingEvidence::new("source-file")
+                        .with_file("vue/Widget.vue")
+                        .with_specifier("react-icons")
+                        .with_detail("root package import"),
+                ]),
             },
             TreeShakingWarning {
                 key: "namespace-ui-import".to_string(),
@@ -200,7 +220,14 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                     .to_string(),
                 estimated_kb: 35,
                 files: vec!["jsx/View.jsx".to_string()],
-                finding: Default::default(),
+                finding: FindingMetadata::new(
+                    "tree-shaking:namespace-ui-import",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_evidence([FindingEvidence::new("source-file")
+                    .with_file("jsx/View.jsx")
+                    .with_specifier("lucide-react")
+                    .with_detail("namespace import")]),
             },
         ]
     );

--- a/crates/legolas-core/tests/support/mod.rs
+++ b/crates/legolas-core/tests/support/mod.rs
@@ -38,6 +38,7 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
         .map(|mut item| {
             item.imported_by = item.imported_by.into_iter().map(to_posix).collect();
             item.dynamic_imported_by = item.dynamic_imported_by.into_iter().map(to_posix).collect();
+            normalize_finding_files(&mut item.finding);
             item
         })
         .collect();
@@ -46,6 +47,7 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
         .into_iter()
         .map(|mut item| {
             item.files = item.files.into_iter().map(to_posix).collect();
+            normalize_finding_files(&mut item.finding);
             item
         })
         .collect();
@@ -54,6 +56,7 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
         .into_iter()
         .map(|mut item| {
             item.files = item.files.into_iter().map(to_posix).collect();
+            normalize_finding_files(&mut item.finding);
             item
         })
         .collect();
@@ -69,4 +72,12 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
 #[allow(dead_code)]
 fn to_posix(value: String) -> String {
     value.replace('\\', "/")
+}
+
+fn normalize_finding_files(finding: &mut legolas_core::FindingMetadata) {
+    for evidence in &mut finding.evidence {
+        if let Some(file) = evidence.file.take() {
+            evidence.file = Some(to_posix(file));
+        }
+    }
 }

--- a/tests/fixtures/findings/evidence-app/package.json
+++ b/tests/fixtures/findings/evidence-app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "evidence-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "lodash": "^4.17.21",
+    "react-icons": "^5.2.1"
+  }
+}

--- a/tests/fixtures/findings/evidence-app/src/AdminDashboard.tsx
+++ b/tests/fixtures/findings/evidence-app/src/AdminDashboard.tsx
@@ -1,0 +1,7 @@
+import _ from "lodash";
+import { Chart } from "chart.js";
+import { FaUser } from "react-icons";
+
+export function AdminDashboard() {
+  return [_.shuffle([1, 2, 3]), Chart, FaUser].length;
+}

--- a/tests/oracles/basic-app/scan.json
+++ b/tests/oracles/basic-app/scan.json
@@ -28,7 +28,17 @@
         "src/Dashboard.tsx"
       ],
       "dynamicImportedBy": [],
-      "importCount": 1
+      "importCount": 1,
+      "findingId": "heavy-dependency:chart.js",
+      "analysisSource": "source-import",
+      "evidence": [
+        {
+          "kind": "source-file",
+          "file": "src/Dashboard.tsx",
+          "specifier": "chart.js",
+          "detail": "static import; Charting code is often only needed on a subset of screens."
+        }
+      ]
     },
     {
       "name": "react-icons",
@@ -41,7 +51,17 @@
         "src/Dashboard.tsx"
       ],
       "dynamicImportedBy": [],
-      "importCount": 1
+      "importCount": 1,
+      "findingId": "heavy-dependency:react-icons",
+      "analysisSource": "source-import",
+      "evidence": [
+        {
+          "kind": "source-file",
+          "file": "src/Dashboard.tsx",
+          "specifier": "react-icons",
+          "detail": "static import; Wide icon-pack imports can defeat tree shaking."
+        }
+      ]
     },
     {
       "name": "lodash",
@@ -54,7 +74,17 @@
         "src/Dashboard.tsx"
       ],
       "dynamicImportedBy": [],
-      "importCount": 1
+      "importCount": 1,
+      "findingId": "heavy-dependency:lodash",
+      "analysisSource": "source-import",
+      "evidence": [
+        {
+          "kind": "source-file",
+          "file": "src/Dashboard.tsx",
+          "specifier": "lodash",
+          "detail": "static import; Root lodash imports are a classic source of tree-shaking misses."
+        }
+      ]
     }
   ],
   "duplicatePackages": [
@@ -76,7 +106,17 @@
       "files": [
         "src/Dashboard.tsx"
       ],
-      "reason": "chart.js is statically imported in UI surfaces that usually tolerate lazy loading"
+      "reason": "chart.js is statically imported in UI surfaces that usually tolerate lazy loading",
+      "findingId": "lazy-load:chart.js",
+      "analysisSource": "heuristic",
+      "evidence": [
+        {
+          "kind": "source-file",
+          "file": "src/Dashboard.tsx",
+          "specifier": "chart.js",
+          "detail": "route-like UI surface matched `dashboard` keyword"
+        }
+      ]
     },
     {
       "name": "react-icons",
@@ -85,7 +125,17 @@
       "files": [
         "src/Dashboard.tsx"
       ],
-      "reason": "react-icons is statically imported in UI surfaces that usually tolerate lazy loading"
+      "reason": "react-icons is statically imported in UI surfaces that usually tolerate lazy loading",
+      "findingId": "lazy-load:react-icons",
+      "analysisSource": "heuristic",
+      "evidence": [
+        {
+          "kind": "source-file",
+          "file": "src/Dashboard.tsx",
+          "specifier": "react-icons",
+          "detail": "route-like UI surface matched `dashboard` keyword"
+        }
+      ]
     },
     {
       "name": "lodash",
@@ -94,7 +144,17 @@
       "files": [
         "src/Dashboard.tsx"
       ],
-      "reason": "lodash is statically imported in UI surfaces that usually tolerate lazy loading"
+      "reason": "lodash is statically imported in UI surfaces that usually tolerate lazy loading",
+      "findingId": "lazy-load:lodash",
+      "analysisSource": "heuristic",
+      "evidence": [
+        {
+          "kind": "source-file",
+          "file": "src/Dashboard.tsx",
+          "specifier": "lodash",
+          "detail": "route-like UI surface matched `dashboard` keyword"
+        }
+      ]
     }
   ],
   "treeShakingWarnings": [
@@ -106,6 +166,16 @@
       "estimatedKb": 26,
       "files": [
         "src/Dashboard.tsx"
+      ],
+      "findingId": "tree-shaking:lodash-root-import",
+      "analysisSource": "source-import",
+      "evidence": [
+        {
+          "kind": "source-file",
+          "file": "src/Dashboard.tsx",
+          "specifier": "lodash",
+          "detail": "root package import"
+        }
       ]
     },
     {
@@ -116,6 +186,16 @@
       "estimatedKb": 22,
       "files": [
         "src/Dashboard.tsx"
+      ],
+      "findingId": "tree-shaking:react-icons-root-import",
+      "analysisSource": "source-import",
+      "evidence": [
+        {
+          "kind": "source-file",
+          "file": "src/Dashboard.tsx",
+          "specifier": "react-icons",
+          "detail": "root package import"
+        }
       ]
     }
   ],


### PR DESCRIPTION
## 배경
- `PR-FIT-001B` 범위에서 core analysis finding에 structured evidence를 실제로 채우는 작업이 필요했습니다.
- 기존 Rust analyzer는 finding metadata seam은 있었지만 `heavy dependency`, `lazy-load candidate`, `tree-shaking warning` 결과에 `findingId`, `analysisSource`, `evidence`가 비어 있었습니다.

## 변경 사항
- `crates/legolas-core/src/analyze.rs`
  - heavy dependency finding에 import source 기반 evidence를 채우도록 추가했습니다.
  - lazy-load candidate finding에 route-like candidate 파일 기준 evidence를 채우도록 추가했습니다.
- `crates/legolas-core/src/import_scanner.rs`
  - tree-shaking warning에 file/specifier/detail 기반 evidence를 채우도록 추가했습니다.
- `crates/legolas-core/tests/finding_evidence.rs`
  - heavy dependency / lazy-load / tree-shaking evidence shape 전용 회귀 테스트를 추가했습니다.
  - route-like 파일과 helper 파일이 섞인 경우 lazy-load evidence가 candidate 파일 subset만 반영하는 회귀 테스트를 추가했습니다.
- `tests/fixtures/findings/evidence-app/*`
  - finding evidence fixture를 추가했습니다.
- `tests/oracles/basic-app/scan.json`
  - additive JSON contract로 `findingId`, `analysisSource`, `evidence`를 반영했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p legolas-core --test finding_evidence --test analyze_parity`
- mixed import CLI repro
  - `Dashboard.tsx`와 `src/utils/shared.ts`가 함께 `chart.js`를 import하는 임시 프로젝트에서 `scan --json` 실행
  - lazy-load candidate evidence가 `src/Dashboard.tsx`만 포함하는 것 확인

## 브랜치 / 워크트리
- 대상 브랜치: `codex/fit-finding-evidence`
- 기준 브랜치: `master`
- 현재 워크트리: `/Users/pjw/workspace/legolas`
- 포함된 소스 워크트리/브랜치: 없음

## 리뷰 루프
- Devil's Advocate Round 1 독립 리뷰: `APPROVE`
- 추가 실행 repro에서 lazy-load evidence 범위 불일치(Medium) 확인 후 수정
- Devil's Advocate Round 2 delta review: `APPROVE`
- 최종 Critical / High: `0`
