### PR TITLE
feat: finding confidence label 추가

### DIFF
--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -10,6 +10,7 @@ use regex::Regex;
 use serde_json::Value;
 
 use crate::{
+    confidence::{score_duplicate_package, score_heavy_dependency, score_lazy_load_candidate},
     error::Result,
     findings::{FindingAnalysisSource, FindingEvidence, FindingMetadata},
     impact::estimate_impact,
@@ -54,7 +55,8 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
         &source_files,
         alias_config.as_ref().map(|loaded| &loaded.config),
     )?;
-    let duplicate_analysis = parse_duplicate_packages(&project_root, &package_manager)?;
+    let mut duplicate_analysis = parse_duplicate_packages(&project_root, &package_manager)?;
+    enrich_duplicate_package_findings(&mut duplicate_analysis.duplicates);
     let heavy_dependencies = build_heavy_dependency_report(&manifest, &source_analysis);
     let lazy_load_candidates = build_lazy_load_candidates(&source_analysis, &heavy_dependencies);
     let tree_shaking_warnings = build_tree_shaking_warnings(&source_analysis);
@@ -230,6 +232,16 @@ fn build_tree_shaking_warnings(source_analysis: &SourceAnalysis) -> Vec<TreeShak
     warnings
 }
 
+fn enrich_duplicate_package_findings(duplicates: &mut [crate::models::DuplicatePackage]) {
+    for duplicate in duplicates {
+        duplicate.finding = FindingMetadata::new(
+            format!("duplicate-package:{}", duplicate.name),
+            FindingAnalysisSource::LockfileTrace,
+        )
+        .with_confidence(score_duplicate_package());
+    }
+}
+
 fn build_heavy_dependency_finding(
     package_name: &str,
     rationale: &str,
@@ -269,6 +281,7 @@ fn build_heavy_dependency_finding(
     }
 
     FindingMetadata::new(format!("heavy-dependency:{package_name}"), analysis_source)
+        .with_confidence(score_heavy_dependency(import_info))
         .with_evidence(evidence)
 }
 
@@ -287,6 +300,7 @@ fn build_lazy_load_finding(package_name: &str, files: &[String]) -> FindingMetad
         format!("lazy-load:{package_name}"),
         FindingAnalysisSource::Heuristic,
     )
+    .with_confidence(score_lazy_load_candidate())
     .with_evidence(evidence)
 }
 

--- a/crates/legolas-core/src/confidence.rs
+++ b/crates/legolas-core/src/confidence.rs
@@ -1,0 +1,21 @@
+use crate::{findings::FindingConfidence, import_scanner::ImportedPackageRecord};
+
+pub fn score_heavy_dependency(import_info: Option<&ImportedPackageRecord>) -> FindingConfidence {
+    if import_info.is_some_and(|item| !item.files.is_empty()) {
+        FindingConfidence::High
+    } else {
+        FindingConfidence::Low
+    }
+}
+
+pub fn score_duplicate_package() -> FindingConfidence {
+    FindingConfidence::High
+}
+
+pub fn score_lazy_load_candidate() -> FindingConfidence {
+    FindingConfidence::Medium
+}
+
+pub fn score_tree_shaking_warning() -> FindingConfidence {
+    FindingConfidence::High
+}

--- a/crates/legolas-core/src/findings.rs
+++ b/crates/legolas-core/src/findings.rs
@@ -8,6 +8,14 @@ pub enum FindingAnalysisSource {
     LockfileTrace,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FindingConfidence {
+    Low,
+    Medium,
+    High,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase", default)]
 pub struct FindingEvidence {
@@ -51,6 +59,8 @@ pub struct FindingMetadata {
     pub finding_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub analysis_source: Option<FindingAnalysisSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<FindingConfidence>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<FindingEvidence>,
 }
@@ -60,8 +70,14 @@ impl FindingMetadata {
         Self {
             finding_id: Some(finding_id.into()),
             analysis_source: Some(analysis_source),
+            confidence: None,
             evidence: Vec::new(),
         }
+    }
+
+    pub fn with_confidence(mut self, confidence: FindingConfidence) -> Self {
+        self.confidence = Some(confidence);
+        self
     }
 
     pub fn with_evidence<I>(mut self, evidence: I) -> Self
@@ -77,6 +93,9 @@ impl FindingMetadata {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.finding_id.is_none() && self.analysis_source.is_none() && self.evidence.is_empty()
+        self.finding_id.is_none()
+            && self.analysis_source.is_none()
+            && self.confidence.is_none()
+            && self.evidence.is_empty()
     }
 }

--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -9,6 +9,7 @@ use regex::Regex;
 
 use crate::{
     aliases::{AliasConfig, AliasTarget},
+    confidence::score_tree_shaking_warning,
     error::Result,
     models::TreeShakingWarning,
     FindingAnalysisSource, FindingEvidence, FindingMetadata, LegolasError,
@@ -517,6 +518,16 @@ fn merge_finding_metadata(existing: &mut FindingMetadata, mut incoming: FindingM
         existing.analysis_source = incoming.analysis_source.take();
     }
 
+    match (existing.confidence, incoming.confidence.take()) {
+        (Some(current), Some(next)) if next > current => {
+            existing.confidence = Some(next);
+        }
+        (None, Some(next)) => {
+            existing.confidence = Some(next);
+        }
+        _ => {}
+    }
+
     existing.evidence.append(&mut incoming.evidence);
     normalize_finding_evidence(&mut existing.evidence);
 }
@@ -730,6 +741,7 @@ fn build_tree_shaking_finding(
         format!("tree-shaking:{warning_key}"),
         FindingAnalysisSource::SourceImport,
     )
+    .with_confidence(score_tree_shaking_warning())
     .with_evidence([evidence])
 }
 
@@ -1237,7 +1249,10 @@ fn to_posix_relative(project_root: &Path, file_path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::merge_tree_shaking_warnings;
-    use crate::{FindingAnalysisSource, FindingEvidence, FindingMetadata, TreeShakingWarning};
+    use crate::{
+        FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata,
+        TreeShakingWarning,
+    };
 
     #[test]
     fn merge_tree_shaking_warnings_preserves_and_dedupes_finding_metadata() {
@@ -1253,6 +1268,7 @@ mod tests {
                     "tree-shaking:lodash-root-import",
                     FindingAnalysisSource::SourceImport,
                 )
+                .with_confidence(FindingConfidence::Medium)
                 .with_evidence([FindingEvidence::new("source-file")
                     .with_file("src/App.tsx")
                     .with_specifier("lodash")]),
@@ -1268,6 +1284,7 @@ mod tests {
                     "tree-shaking:lodash-root-import",
                     FindingAnalysisSource::SourceImport,
                 )
+                .with_confidence(FindingConfidence::High)
                 .with_evidence([
                     FindingEvidence::new("source-file")
                         .with_file("src/Dashboard.tsx")
@@ -1293,6 +1310,7 @@ mod tests {
                 "tree-shaking:lodash-root-import",
                 FindingAnalysisSource::SourceImport,
             )
+            .with_confidence(FindingConfidence::High)
             .with_evidence([
                 FindingEvidence::new("source-file")
                     .with_file("src/App.tsx")

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod aliases;
 pub mod analyze;
 pub mod artifacts;
 pub mod budget;
+pub mod confidence;
 pub mod config;
 pub mod error;
 pub mod findings;
@@ -14,6 +15,7 @@ pub mod project_shape;
 pub mod workspace;
 
 pub use analyze::analyze_project;
+pub use confidence::*;
 pub use error::{LegolasError, Result};
 pub use findings::*;
 pub use models::*;

--- a/crates/legolas-core/tests/confidence_labels.rs
+++ b/crates/legolas-core/tests/confidence_labels.rs
@@ -1,0 +1,84 @@
+mod support;
+
+use legolas_core::{analyze_project, FindingConfidence};
+
+#[test]
+fn analyze_project_marks_direct_import_findings_as_high_confidence() {
+    let analysis = analyze_project(support::fixture_path(
+        "tests/fixtures/confidence/high-confidence",
+    ))
+    .expect("analyze high confidence fixture");
+
+    let heavy_dependency = analysis
+        .heavy_dependencies
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js heavy dependency");
+    let tree_shaking_warning = analysis
+        .tree_shaking_warnings
+        .iter()
+        .find(|item| item.key == "lodash-root-import")
+        .expect("lodash tree-shaking warning");
+
+    assert_eq!(
+        heavy_dependency.finding.confidence,
+        Some(FindingConfidence::High)
+    );
+    assert_eq!(
+        tree_shaking_warning.finding.confidence,
+        Some(FindingConfidence::High)
+    );
+}
+
+#[test]
+fn analyze_project_marks_lazy_load_candidates_as_medium_confidence() {
+    let analysis = analyze_project(support::fixture_path(
+        "tests/fixtures/confidence/high-confidence",
+    ))
+    .expect("analyze high confidence fixture");
+    let candidate = analysis
+        .lazy_load_candidates
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js lazy-load candidate");
+
+    assert_eq!(
+        candidate.finding.confidence,
+        Some(FindingConfidence::Medium)
+    );
+}
+
+#[test]
+fn analyze_project_marks_manifest_only_heavy_dependencies_as_low_confidence() {
+    let analysis = analyze_project(support::fixture_path(
+        "tests/fixtures/confidence/low-confidence",
+    ))
+    .expect("analyze low confidence fixture");
+    let heavy_dependency = analysis
+        .heavy_dependencies
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js heavy dependency");
+
+    assert_eq!(heavy_dependency.import_count, 0);
+    assert_eq!(
+        heavy_dependency.finding.confidence,
+        Some(FindingConfidence::Low)
+    );
+}
+
+#[test]
+fn analyze_project_marks_lockfile_duplicate_findings_as_high_confidence() {
+    let analysis = analyze_project(support::fixture_path("tests/fixtures/parity/basic-app"))
+        .expect("analyze parity fixture");
+    let duplicate_package = analysis
+        .duplicate_packages
+        .iter()
+        .find(|item| item.name == "lodash")
+        .expect("lodash duplicate package");
+
+    assert_eq!(
+        duplicate_package.finding.confidence,
+        Some(FindingConfidence::High)
+    );
+}

--- a/crates/legolas-core/tests/finding_evidence.rs
+++ b/crates/legolas-core/tests/finding_evidence.rs
@@ -2,7 +2,9 @@ mod support;
 
 use std::fs;
 
-use legolas_core::{analyze_project, FindingAnalysisSource, FindingEvidence, FindingMetadata};
+use legolas_core::{
+    analyze_project, FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -23,6 +25,7 @@ fn analyze_project_populates_heavy_dependency_evidence() {
             "heavy-dependency:chart.js",
             FindingAnalysisSource::SourceImport,
         )
+        .with_confidence(FindingConfidence::High)
         .with_evidence([FindingEvidence::new("source-file")
             .with_file("src/AdminDashboard.tsx")
             .with_specifier("chart.js")
@@ -46,12 +49,12 @@ fn analyze_project_populates_lazy_load_candidate_evidence() {
 
     assert_eq!(
         candidate.finding,
-        FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic).with_evidence(
-            [FindingEvidence::new("source-file")
+        FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic)
+            .with_confidence(FindingConfidence::Medium)
+            .with_evidence([FindingEvidence::new("source-file")
                 .with_file("src/AdminDashboard.tsx")
                 .with_specifier("chart.js")
-                .with_detail("route-like UI surface matched `admin` keyword")]
-        )
+                .with_detail("route-like UI surface matched `admin` keyword")])
     );
 }
 
@@ -73,6 +76,7 @@ fn analyze_project_populates_tree_shaking_warning_evidence() {
             "tree-shaking:lodash-root-import",
             FindingAnalysisSource::SourceImport,
         )
+        .with_confidence(FindingConfidence::High)
         .with_evidence([FindingEvidence::new("source-file")
             .with_file("src/AdminDashboard.tsx")
             .with_specifier("lodash")
@@ -116,12 +120,12 @@ fn analyze_project_limits_lazy_load_evidence_to_candidate_files() {
     assert_eq!(candidate.files, vec!["src/Dashboard.tsx".to_string()]);
     assert_eq!(
         candidate.finding,
-        FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic).with_evidence(
-            [FindingEvidence::new("source-file")
+        FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic)
+            .with_confidence(FindingConfidence::Medium)
+            .with_evidence([FindingEvidence::new("source-file")
                 .with_file("src/Dashboard.tsx")
                 .with_specifier("chart.js")
-                .with_detail("route-like UI surface matched `dashboard` keyword")]
-        )
+                .with_detail("route-like UI surface matched `dashboard` keyword")])
     );
 }
 

--- a/crates/legolas-core/tests/finding_support.rs
+++ b/crates/legolas-core/tests/finding_support.rs
@@ -1,6 +1,6 @@
 use legolas_core::{
-    DuplicatePackage, FindingAnalysisSource, FindingEvidence, FindingMetadata, HeavyDependency,
-    LazyLoadCandidate, TreeShakingWarning,
+    DuplicatePackage, FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata,
+    HeavyDependency, LazyLoadCandidate, TreeShakingWarning,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
@@ -18,6 +18,7 @@ fn finding_metadata_serializes_as_flat_camel_case_fields() {
         dynamic_imported_by: Vec::new(),
         import_count: 1,
         finding: FindingMetadata::new("heavy-dependency", FindingAnalysisSource::SourceImport)
+            .with_confidence(FindingConfidence::High)
             .with_evidence([FindingEvidence::new("source-file")
                 .with_file("src/App.tsx")
                 .with_specifier("lodash")
@@ -27,6 +28,7 @@ fn finding_metadata_serializes_as_flat_camel_case_fields() {
 
     assert_eq!(payload["findingId"], json!("heavy-dependency"));
     assert_eq!(payload["analysisSource"], json!("source-import"));
+    assert_eq!(payload["confidence"], json!("high"));
     assert_eq!(
         payload["evidence"],
         json!([{
@@ -99,5 +101,6 @@ where
     let serialized = serde_json::to_value(&item).expect("serialize with default finding");
     assert!(serialized.get("findingId").is_none());
     assert!(serialized.get("analysisSource").is_none());
+    assert!(serialized.get("confidence").is_none());
     assert!(serialized.get("evidence").is_none());
 }

--- a/crates/legolas-core/tests/import_scanner.rs
+++ b/crates/legolas-core/tests/import_scanner.rs
@@ -15,7 +15,7 @@ use legolas_core::{
         collect_source_files, scan_imports, scan_imports_with_aliases, ImportedPackageRecord,
     },
     workspace::load_alias_config,
-    FindingAnalysisSource, FindingEvidence, FindingMetadata, TreeShakingWarning,
+    FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata, TreeShakingWarning,
 };
 use tempfile::tempdir;
 
@@ -181,6 +181,7 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                     "tree-shaking:lodash-root-import",
                     FindingAnalysisSource::SourceImport,
                 )
+                .with_confidence(FindingConfidence::High)
                 .with_evidence([FindingEvidence::new("source-file")
                     .with_file("basic/Dashboard.tsx")
                     .with_specifier("lodash")
@@ -200,6 +201,7 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                     "tree-shaking:react-icons-root-import",
                     FindingAnalysisSource::SourceImport,
                 )
+                .with_confidence(FindingConfidence::High)
                 .with_evidence([
                     FindingEvidence::new("source-file")
                         .with_file("basic/Dashboard.tsx")
@@ -224,6 +226,7 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
                     "tree-shaking:namespace-ui-import",
                     FindingAnalysisSource::SourceImport,
                 )
+                .with_confidence(FindingConfidence::High)
                 .with_evidence([FindingEvidence::new("source-file")
                     .with_file("jsx/View.jsx")
                     .with_specifier("lucide-react")

--- a/tests/fixtures/confidence/high-confidence/package.json
+++ b/tests/fixtures/confidence/high-confidence/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "high-confidence-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "lodash": "^4.17.21"
+  }
+}

--- a/tests/fixtures/confidence/high-confidence/src/Dashboard.tsx
+++ b/tests/fixtures/confidence/high-confidence/src/Dashboard.tsx
@@ -1,0 +1,6 @@
+import { Chart } from "chart.js";
+import _ from "lodash";
+
+export function Dashboard() {
+  return [Chart, _.shuffle([1, 2, 3])].length;
+}

--- a/tests/fixtures/confidence/low-confidence/package.json
+++ b/tests/fixtures/confidence/low-confidence/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "low-confidence-app",
+  "dependencies": {
+    "chart.js": "^4.4.1"
+  }
+}

--- a/tests/fixtures/confidence/low-confidence/src/shared.ts
+++ b/tests/fixtures/confidence/low-confidence/src/shared.ts
@@ -1,0 +1,1 @@
+export const shared = "no package imports here";

--- a/tests/oracles/basic-app/scan.json
+++ b/tests/oracles/basic-app/scan.json
@@ -31,6 +31,7 @@
       "importCount": 1,
       "findingId": "heavy-dependency:chart.js",
       "analysisSource": "source-import",
+      "confidence": "high",
       "evidence": [
         {
           "kind": "source-file",
@@ -54,6 +55,7 @@
       "importCount": 1,
       "findingId": "heavy-dependency:react-icons",
       "analysisSource": "source-import",
+      "confidence": "high",
       "evidence": [
         {
           "kind": "source-file",
@@ -77,6 +79,7 @@
       "importCount": 1,
       "findingId": "heavy-dependency:lodash",
       "analysisSource": "source-import",
+      "confidence": "high",
       "evidence": [
         {
           "kind": "source-file",
@@ -95,7 +98,10 @@
         "4.17.21"
       ],
       "count": 2,
-      "estimatedExtraKb": 18
+      "estimatedExtraKb": 18,
+      "findingId": "duplicate-package:lodash",
+      "analysisSource": "lockfile-trace",
+      "confidence": "high"
     }
   ],
   "lazyLoadCandidates": [
@@ -109,6 +115,7 @@
       "reason": "chart.js is statically imported in UI surfaces that usually tolerate lazy loading",
       "findingId": "lazy-load:chart.js",
       "analysisSource": "heuristic",
+      "confidence": "medium",
       "evidence": [
         {
           "kind": "source-file",
@@ -128,6 +135,7 @@
       "reason": "react-icons is statically imported in UI surfaces that usually tolerate lazy loading",
       "findingId": "lazy-load:react-icons",
       "analysisSource": "heuristic",
+      "confidence": "medium",
       "evidence": [
         {
           "kind": "source-file",
@@ -147,6 +155,7 @@
       "reason": "lodash is statically imported in UI surfaces that usually tolerate lazy loading",
       "findingId": "lazy-load:lodash",
       "analysisSource": "heuristic",
+      "confidence": "medium",
       "evidence": [
         {
           "kind": "source-file",
@@ -169,6 +178,7 @@
       ],
       "findingId": "tree-shaking:lodash-root-import",
       "analysisSource": "source-import",
+      "confidence": "high",
       "evidence": [
         {
           "kind": "source-file",
@@ -189,6 +199,7 @@
       ],
       "findingId": "tree-shaking:react-icons-root-import",
       "analysisSource": "source-import",
+      "confidence": "high",
       "evidence": [
         {
           "kind": "source-file",


### PR DESCRIPTION
배경

- finding metadata에 `confidence`(`high`/`medium`/`low`)를 추가해 core 분석 결과의 신호 강도를 명시합니다.

변경 사항

- `FindingMetadata`에 optional `confidence` 필드를 추가하고 기존 JSON 역직렬화 호환성을 유지했습니다.
- `crates/legolas-core/src/confidence.rs`를 추가해 heavy dependency, duplicate package, lazy-load candidate, tree-shaking warning의 공통 scoring helper를 도입했습니다.
- `analyze.rs`와 `import_scanner.rs`에서 finding confidence를 채우고 tree-shaking warning merge 시 가장 강한 confidence를 유지하도록 정리했습니다.
- confidence fixture/test를 추가하고 `tests/oracles/basic-app/scan.json` parity oracle을 갱신했습니다.

검증

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `[$devils-advocate-review-loop](/Users/pjw/.codex/skills/devils-advocate-review-loop/SKILL.md)` Round 1 결과: Critical/High 0건

브랜치 / 워크트리

- base: `master`
- head: `codex/fit-confidence-labels`
- current worktree: `/Users/pjw/workspace/legolas`
- source branches/worktrees: 없음

이슈 연결

- 없음
