### PR TITLE
fix: import scanner 정규식 경계 보강

### DIFF
--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -90,6 +90,13 @@ struct ParsedStringLiteral {
     next_index: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedTemplateString {
+    imports: Vec<ImportEntry>,
+    tree_shaking_hints: Vec<TreeShakingWarning>,
+    next_index: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct PackageAccumulator {
     name: String,
@@ -280,7 +287,10 @@ fn scan_source_file(contents: &str, jsx_text_guard: bool) -> ScannedSourceFile {
         }
 
         if character == '`' {
-            index = skip_template_string(contents, index);
+            let parsed_template = scan_template_string(contents, index, jsx_text_guard);
+            imports.extend(parsed_template.imports);
+            tree_shaking_hints.extend(parsed_template.tree_shaking_hints);
+            index = parsed_template.next_index;
             continue;
         }
 
@@ -335,6 +345,67 @@ fn scan_source_file(contents: &str, jsx_text_guard: bool) -> ScannedSourceFile {
     ScannedSourceFile {
         imports,
         tree_shaking_hints,
+    }
+}
+
+fn scan_template_string(
+    contents: &str,
+    start_index: usize,
+    jsx_text_guard: bool,
+) -> ParsedTemplateString {
+    let mut imports = Vec::new();
+    let mut tree_shaking_hints = Vec::new();
+    let mut index = start_index + 1;
+
+    while index < contents.len() {
+        let Some(character) = current_char(contents, index) else {
+            break;
+        };
+
+        if character == '\\' {
+            let next_index = advance_one(contents, index);
+            if next_index >= contents.len() {
+                return ParsedTemplateString {
+                    imports,
+                    tree_shaking_hints,
+                    next_index: contents.len(),
+                };
+            }
+            index = advance_one(contents, next_index);
+            continue;
+        }
+
+        if character == '`' {
+            return ParsedTemplateString {
+                imports,
+                tree_shaking_hints,
+                next_index: index + 1,
+            };
+        }
+
+        if character == '$' && peek_char(contents, index + 1) == Some('{') {
+            let expression_start = index + 2;
+            let expression_end = skip_balanced_expression(contents, expression_start);
+            let closing_index = expression_end.saturating_sub(1);
+
+            if closing_index >= expression_start {
+                let nested =
+                    scan_source_file(&contents[expression_start..closing_index], jsx_text_guard);
+                imports.extend(nested.imports);
+                tree_shaking_hints.extend(nested.tree_shaking_hints);
+            }
+
+            index = expression_end;
+            continue;
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    ParsedTemplateString {
+        imports,
+        tree_shaking_hints,
+        next_index: contents.len(),
     }
 }
 
@@ -1044,6 +1115,11 @@ fn skip_balanced_expression(contents: &str, start_index: usize) -> usize {
             continue;
         }
 
+        if character == '/' && is_regex_literal_start(contents, index) {
+            index = skip_regex_literal(contents, index);
+            continue;
+        }
+
         if character == '`' {
             index = skip_template_string(contents, index);
             continue;
@@ -1059,6 +1135,119 @@ fn skip_balanced_expression(contents: &str, start_index: usize) -> usize {
             stack.pop();
             index = advance_one(contents, index);
             continue;
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    index
+}
+
+fn is_regex_literal_start(contents: &str, start_index: usize) -> bool {
+    if peek_char(contents, start_index + 1).is_none()
+        || matches!(peek_char(contents, start_index + 1), Some('/' | '*' | '='))
+    {
+        return false;
+    }
+
+    let Some(previous_index) = find_previous_non_whitespace(contents, start_index) else {
+        return true;
+    };
+    let Some(previous_character) = current_char(contents, previous_index) else {
+        return true;
+    };
+
+    if matches!(
+        previous_character,
+        '(' | '{'
+            | '['
+            | ','
+            | ';'
+            | ':'
+            | '?'
+            | '!'
+            | '~'
+            | '^'
+            | '&'
+            | '|'
+            | '='
+            | '+'
+            | '-'
+            | '*'
+            | '%'
+            | '<'
+            | '>'
+    ) {
+        return true;
+    }
+
+    if is_identifier_character(previous_character) {
+        return previous_identifier_token(contents, previous_index).is_some_and(|token| {
+            matches!(
+                token,
+                "await"
+                    | "case"
+                    | "delete"
+                    | "in"
+                    | "instanceof"
+                    | "new"
+                    | "return"
+                    | "throw"
+                    | "typeof"
+                    | "void"
+                    | "yield"
+            )
+        });
+    }
+
+    if matches!(previous_character, ')' | ']' | '}' | '\'' | '"' | '`' | '.') {
+        return false;
+    }
+
+    false
+}
+
+fn skip_regex_literal(contents: &str, start_index: usize) -> usize {
+    let mut index = advance_one(contents, start_index);
+    let mut in_character_class = false;
+
+    while index < contents.len() {
+        let Some(character) = current_char(contents, index) else {
+            break;
+        };
+
+        if character == '\\' {
+            let next_index = advance_one(contents, index);
+            if next_index >= contents.len() {
+                return contents.len();
+            }
+            index = advance_one(contents, next_index);
+            continue;
+        }
+
+        if character == '[' {
+            in_character_class = true;
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if character == ']' && in_character_class {
+            in_character_class = false;
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if character == '/' && !in_character_class {
+            index = advance_one(contents, index);
+            while matches!(current_char(contents, index), Some(flag) if is_identifier_character(flag))
+            {
+                index = advance_one(contents, index);
+            }
+            return index;
+        }
+
+        if character == '\n' || character == '\r' {
+            return index;
         }
 
         index = advance_one(contents, index);
@@ -1177,6 +1366,23 @@ fn read_identifier(contents: &str, start_index: usize) -> &str {
         index = advance_one(contents, index);
     }
     &contents[start_index..index]
+}
+
+fn previous_identifier_token(contents: &str, end_index: usize) -> Option<&str> {
+    let current = current_char(contents, end_index)?;
+    if !is_identifier_character(current) {
+        return None;
+    }
+
+    let mut start = end_index;
+    while let Some((index, character)) = contents[..start].char_indices().next_back() {
+        if !is_identifier_character(character) {
+            break;
+        }
+        start = index;
+    }
+
+    Some(&contents[start..advance_one(contents, end_index)])
 }
 
 fn is_identifier_start(character: char) -> bool {

--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -4,9 +4,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use once_cell::sync::Lazy;
-use regex::Regex;
-
 use crate::{
     aliases::{AliasConfig, AliasTarget},
     confidence::score_tree_shaking_warning,
@@ -33,9 +30,6 @@ const SOURCE_FILE_SUFFIXES: &[&str] = &[
     ".js", ".jsx", ".ts", ".tsx", ".cjs", ".cjsx", ".cts", ".ctsx", ".mjs", ".mjsx", ".mts",
     ".mtsx", ".vue", ".svelte",
 ];
-
-static SCRIPT_BLOCK_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?is)<script\b[^>]*>(.*?)</script>").expect("valid script regex"));
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ImportedPackageRecord {
@@ -286,6 +280,13 @@ fn scan_source_file(contents: &str, jsx_text_guard: bool) -> ScannedSourceFile {
             continue;
         }
 
+        if character == '/' && is_regex_literal_start(contents, index) {
+            if let Some(next_index) = skip_regex_literal(contents, index) {
+                index = next_index;
+                continue;
+            }
+        }
+
         if character == '`' {
             let parsed_template = scan_template_string(contents, index, jsx_text_guard);
             imports.extend(parsed_template.imports);
@@ -323,6 +324,9 @@ fn scan_source_file(contents: &str, jsx_text_guard: bool) -> ScannedSourceFile {
             if let Some(parsed) = try_parse_export_from(contents, index) {
                 if let Some(import_entry) = parsed.import_entry {
                     imports.push(import_entry);
+                }
+                if let Some(tree_shaking_hint) = parsed.tree_shaking_hint {
+                    tree_shaking_hints.push(tree_shaking_hint);
                 }
                 index = parsed.next_index;
                 continue;
@@ -386,7 +390,16 @@ fn scan_template_string(
         if character == '$' && peek_char(contents, index + 1) == Some('{') {
             let expression_start = index + 2;
             let expression_end = skip_balanced_expression(contents, expression_start);
-            let closing_index = expression_end.saturating_sub(1);
+            let Some(closing_index) = expression_end
+                .checked_sub(1)
+                .filter(|_| previous_char(contents, expression_end) == Some('}'))
+            else {
+                return ParsedTemplateString {
+                    imports,
+                    tree_shaking_hints,
+                    next_index: contents.len(),
+                };
+            };
 
             if closing_index >= expression_start {
                 let nested =
@@ -627,11 +640,145 @@ fn get_scannable_contents(file_path: &Path, contents: &str) -> String {
 }
 
 fn extract_script_blocks(contents: &str) -> String {
-    SCRIPT_BLOCK_PATTERN
-        .captures_iter(contents)
-        .filter_map(|captures| captures.get(1).map(|value| value.as_str()))
-        .collect::<Vec<_>>()
-        .join("\n")
+    let mut blocks = Vec::new();
+    let mut search_index = 0;
+
+    while let Some((body_start, body_end, next_index)) =
+        find_next_script_block(contents, search_index)
+    {
+        blocks.push(contents[body_start..body_end].to_string());
+        search_index = next_index;
+    }
+
+    blocks.join("\n")
+}
+
+fn find_next_script_block(contents: &str, start_index: usize) -> Option<(usize, usize, usize)> {
+    let mut index = start_index;
+
+    while index < contents.len() {
+        if let Some(open_tag_end) = script_open_tag_end(contents, index) {
+            let body_end = find_script_block_end(contents, open_tag_end)?;
+            let close_tag_end = script_close_tag_end(contents, body_end)?;
+            return Some((open_tag_end, body_end, close_tag_end));
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    None
+}
+
+fn script_open_tag_end(contents: &str, start_index: usize) -> Option<usize> {
+    if current_char(contents, start_index) != Some('<')
+        || !starts_with_ascii_case_insensitive(contents, start_index, "<script")
+    {
+        return None;
+    }
+
+    let boundary_index = start_index + "<script".len();
+    let boundary_character = current_char(contents, boundary_index)?;
+    if !boundary_character.is_whitespace() && !matches!(boundary_character, '>' | '/') {
+        return None;
+    }
+
+    find_html_tag_end(contents, boundary_index).map(|tag_end| advance_one(contents, tag_end))
+}
+
+fn script_close_tag_end(contents: &str, start_index: usize) -> Option<usize> {
+    if current_char(contents, start_index) != Some('<')
+        || !starts_with_ascii_case_insensitive(contents, start_index, "</script")
+    {
+        return None;
+    }
+
+    let boundary_index = start_index + "</script".len();
+    let mut index = boundary_index;
+    while matches!(current_char(contents, index), Some(character) if character.is_whitespace()) {
+        index = advance_one(contents, index);
+    }
+
+    (current_char(contents, index) == Some('>')).then(|| advance_one(contents, index))
+}
+
+fn find_html_tag_end(contents: &str, start_index: usize) -> Option<usize> {
+    let mut index = start_index;
+    let mut quoted_by = None;
+
+    while index < contents.len() {
+        let character = current_char(contents, index)?;
+
+        if let Some(quote) = quoted_by {
+            if character == quote {
+                quoted_by = None;
+            }
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if matches!(character, '"' | '\'') {
+            quoted_by = Some(character);
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if character == '>' {
+            return Some(index);
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    None
+}
+
+fn find_script_block_end(contents: &str, start_index: usize) -> Option<usize> {
+    let mut index = start_index;
+
+    while index < contents.len() {
+        let character = current_char(contents, index)?;
+
+        if script_close_tag_end(contents, index).is_some() {
+            return Some(index);
+        }
+
+        if character == '/' && peek_char(contents, index + 1) == Some('/') {
+            index = skip_line_comment(contents, index);
+            continue;
+        }
+
+        if character == '/' && peek_char(contents, index + 1) == Some('*') {
+            index = skip_block_comment(contents, index);
+            continue;
+        }
+
+        if matches!(character, '"' | '\'') {
+            index = skip_quoted_string(contents, index, character);
+            continue;
+        }
+
+        if character == '/' && is_regex_literal_start(contents, index) {
+            if let Some(next_index) = skip_regex_literal(contents, index) {
+                index = next_index;
+                continue;
+            }
+        }
+
+        if character == '`' {
+            index = skip_template_string(contents, index);
+            continue;
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    None
+}
+
+fn starts_with_ascii_case_insensitive(contents: &str, start_index: usize, pattern: &str) -> bool {
+    contents
+        .get(start_index..start_index + pattern.len())
+        .is_some_and(|slice| slice.eq_ignore_ascii_case(pattern))
 }
 
 fn supports_jsx_text_guard(file_path: &Path) -> bool {
@@ -722,12 +869,15 @@ fn try_parse_export_from(contents: &str, start_index: usize) -> Option<ParsedTok
         });
     }
 
+    let specifier = parsed_specifier.value;
+    let tree_shaking_hint = build_tree_shaking_hint(&specifier, clause);
+
     Some(ParsedToken {
         import_entry: Some(ImportEntry {
             kind: ImportKind::Static,
-            specifier: parsed_specifier.value,
+            specifier,
         }),
-        tree_shaking_hint: None,
+        tree_shaking_hint,
         next_index: parsed_specifier.next_index,
     })
 }
@@ -1116,8 +1266,10 @@ fn skip_balanced_expression(contents: &str, start_index: usize) -> usize {
         }
 
         if character == '/' && is_regex_literal_start(contents, index) {
-            index = skip_regex_literal(contents, index);
-            continue;
+            if let Some(next_index) = skip_regex_literal(contents, index) {
+                index = next_index;
+                continue;
+            }
         }
 
         if character == '`' {
@@ -1145,17 +1297,23 @@ fn skip_balanced_expression(contents: &str, start_index: usize) -> usize {
 
 fn is_regex_literal_start(contents: &str, start_index: usize) -> bool {
     if peek_char(contents, start_index + 1).is_none()
-        || matches!(peek_char(contents, start_index + 1), Some('/' | '*' | '='))
+        || matches!(peek_char(contents, start_index + 1), Some('/' | '*'))
     {
         return false;
     }
 
-    let Some(previous_index) = find_previous_non_whitespace(contents, start_index) else {
+    let Some(previous_index) = find_previous_significant_index(contents, start_index) else {
         return true;
     };
     let Some(previous_character) = current_char(contents, previous_index) else {
         return true;
     };
+
+    if matches!(previous_character, '+' | '-')
+        && previous_char(contents, previous_index) == Some(previous_character)
+    {
+        return false;
+    }
 
     if matches!(
         previous_character,
@@ -1187,7 +1345,10 @@ fn is_regex_literal_start(contents: &str, start_index: usize) -> bool {
                 token,
                 "await"
                     | "case"
+                    | "do"
                     | "delete"
+                    | "else"
+                    | "of"
                     | "in"
                     | "instanceof"
                     | "new"
@@ -1200,14 +1361,302 @@ fn is_regex_literal_start(contents: &str, start_index: usize) -> bool {
         });
     }
 
-    if matches!(previous_character, ')' | ']' | '}' | '\'' | '"' | '`' | '.') {
+    if previous_character == ')' {
+        return regex_can_follow_parenthesized_construct(contents, previous_index);
+    }
+
+    if previous_character == '}' {
+        return regex_can_follow_braced_construct(contents, previous_index, start_index);
+    }
+
+    if matches!(previous_character, ']' | '\'' | '"' | '`' | '.') {
         return false;
     }
 
     false
 }
 
-fn skip_regex_literal(contents: &str, start_index: usize) -> usize {
+fn regex_can_follow_parenthesized_construct(contents: &str, close_index: usize) -> bool {
+    let Some(open_index) = find_matching_open_delimiter(contents, close_index, '(', ')') else {
+        return false;
+    };
+    let head = normalize_whitespace(statement_head_segment(contents, open_index));
+
+    head_ends_with_tokens(&head, &["if"])
+        || head_ends_with_tokens(&head, &["while"])
+        || head_ends_with_tokens(&head, &["for"])
+        || head_ends_with_tokens(&head, &["for", "await"])
+        || head_ends_with_tokens(&head, &["with"])
+        || head_ends_with_tokens(&head, &["switch"])
+        || head_ends_with_tokens(&head, &["catch"])
+}
+
+fn regex_can_follow_braced_construct(
+    contents: &str,
+    close_index: usize,
+    regex_start_index: usize,
+) -> bool {
+    let Some(open_index) = find_matching_open_delimiter(contents, close_index, '{', '}') else {
+        return false;
+    };
+    let Some(before_open_index) = find_previous_non_whitespace(contents, open_index) else {
+        return true;
+    };
+    let Some(before_open_character) = current_char(contents, before_open_index) else {
+        return true;
+    };
+    let head = normalize_whitespace(statement_head_segment(contents, open_index));
+    let follows_line_break = has_line_terminator_between(contents, close_index, regex_start_index);
+
+    if matches!(
+        before_open_character,
+        '=' | '(' | '[' | ',' | ':' | '?' | '.'
+    ) {
+        if before_open_character == ':' {
+            return follows_line_break && is_labeled_statement_head(&head);
+        }
+
+        return false;
+    }
+
+    if before_open_character == ')' {
+        return regex_can_follow_parenthesized_construct(contents, before_open_index)
+            || is_function_declaration_head(&head);
+    }
+
+    if before_open_character == '>' {
+        return follows_line_break && is_arrow_function_statement_head(&head);
+    }
+
+    if is_identifier_character(before_open_character) {
+        if head_ends_with_tokens(&head, &["catch"])
+            || head_ends_with_tokens(&head, &["else"])
+            || head_ends_with_tokens(&head, &["finally"])
+        {
+            return true;
+        }
+
+        return is_class_declaration_head(&head);
+    }
+
+    matches!(before_open_character, ';' | '{' | '}')
+}
+
+fn has_line_terminator_between(contents: &str, start_index: usize, end_index: usize) -> bool {
+    let mut index = start_index;
+
+    while index < end_index {
+        let Some(character) = current_char(contents, index) else {
+            break;
+        };
+
+        if matches!(character, '\n' | '\r') {
+            return true;
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    false
+}
+
+fn is_labeled_statement_head(head: &str) -> bool {
+    let Some(label) = head.strip_suffix(':') else {
+        return false;
+    };
+    let label = label.trim();
+    let mut characters = label.chars();
+    let Some(first) = characters.next() else {
+        return false;
+    };
+
+    is_identifier_start(first) && characters.all(is_identifier_character)
+}
+
+fn is_arrow_function_statement_head(head: &str) -> bool {
+    head.contains("=>") && contains_assignment_operator(head)
+}
+
+fn is_function_declaration_head(head: &str) -> bool {
+    let mut tokens = head.split_whitespace().peekable();
+    while matches!(
+        tokens.peek().copied(),
+        Some("export" | "default" | "async" | "declare" | "abstract")
+    ) {
+        tokens.next();
+    }
+
+    let Some(token) = tokens.next() else {
+        return false;
+    };
+
+    if token == "function*" {
+        return true;
+    }
+
+    if token != "function" {
+        return false;
+    }
+
+    if matches!(tokens.peek().copied(), Some("*")) {
+        tokens.next();
+    }
+
+    true
+}
+
+fn is_class_declaration_head(head: &str) -> bool {
+    let mut tokens = head.split_whitespace();
+    loop {
+        let Some(token) = tokens.next() else {
+            return false;
+        };
+        if matches!(token, "export" | "default" | "declare" | "abstract") {
+            continue;
+        }
+        return token == "class";
+    }
+}
+
+fn statement_head_segment(contents: &str, end_index: usize) -> &str {
+    let start_index = find_statement_head_start(contents, end_index);
+    contents[start_index..end_index].trim()
+}
+
+fn find_statement_head_start(contents: &str, end_index: usize) -> usize {
+    let mut last_boundary = 0;
+    let mut stack = Vec::<char>::new();
+    let mut index = 0;
+
+    while index < end_index {
+        let Some(character) = current_char(contents, index) else {
+            break;
+        };
+
+        if character == '/' && peek_char(contents, index + 1) == Some('/') {
+            index = skip_line_comment(contents, index);
+            continue;
+        }
+
+        if character == '/' && peek_char(contents, index + 1) == Some('*') {
+            index = skip_block_comment(contents, index);
+            continue;
+        }
+
+        if character == '\'' || character == '"' {
+            index = skip_quoted_string(contents, index, character);
+            continue;
+        }
+
+        if character == '/' && is_regex_literal_start(contents, index) {
+            if let Some(next_index) = skip_regex_literal(contents, index) {
+                index = next_index;
+                continue;
+            }
+        }
+
+        if character == '`' {
+            index = skip_template_string(contents, index);
+            continue;
+        }
+
+        if matches!(character, '{' | '(' | '[') {
+            stack.push(character);
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if matches!(character, '}' | ')' | ']') {
+            stack.pop();
+            if stack.is_empty() && character == '}' {
+                last_boundary = advance_one(contents, index);
+            }
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if stack.is_empty() && matches!(character, ';' | '{' | '}' | '\n' | '\r') {
+            last_boundary = advance_one(contents, index);
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    last_boundary
+}
+
+fn find_matching_open_delimiter(
+    contents: &str,
+    close_index: usize,
+    open_character: char,
+    close_character: char,
+) -> Option<usize> {
+    let mut stack = Vec::<(char, usize)>::new();
+    let mut index = 0;
+
+    while index <= close_index {
+        let character = current_char(contents, index)?;
+
+        if character == '/' && peek_char(contents, index + 1) == Some('/') {
+            index = skip_line_comment(contents, index);
+            continue;
+        }
+
+        if character == '/' && peek_char(contents, index + 1) == Some('*') {
+            index = skip_block_comment(contents, index);
+            continue;
+        }
+
+        if character == '\'' || character == '"' {
+            index = skip_quoted_string(contents, index, character);
+            continue;
+        }
+
+        if character == '/' && is_regex_literal_start(contents, index) {
+            if let Some(next_index) = skip_regex_literal(contents, index) {
+                index = next_index;
+                continue;
+            }
+        }
+
+        if character == '`' {
+            index = skip_template_string(contents, index);
+            continue;
+        }
+
+        if matches!(character, '{' | '(' | '[') {
+            stack.push((character, index));
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if matches!(character, '}' | ')' | ']') {
+            let (expected_open, expected_close) = match character {
+                '}' => ('{', '}'),
+                ')' => ('(', ')'),
+                _ => ('[', ']'),
+            };
+            let (actual_open, open_index) = stack.pop()?;
+            if actual_open != expected_open {
+                return None;
+            }
+            if index == close_index
+                && actual_open == open_character
+                && expected_close == close_character
+            {
+                return Some(open_index);
+            }
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    None
+}
+
+fn skip_regex_literal(contents: &str, start_index: usize) -> Option<usize> {
     let mut index = advance_one(contents, start_index);
     let mut in_character_class = false;
 
@@ -1219,7 +1668,7 @@ fn skip_regex_literal(contents: &str, start_index: usize) -> usize {
         if character == '\\' {
             let next_index = advance_one(contents, index);
             if next_index >= contents.len() {
-                return contents.len();
+                return None;
             }
             index = advance_one(contents, next_index);
             continue;
@@ -1239,21 +1688,32 @@ fn skip_regex_literal(contents: &str, start_index: usize) -> usize {
 
         if character == '/' && !in_character_class {
             index = advance_one(contents, index);
+            let mut seen_flags = Vec::new();
             while matches!(current_char(contents, index), Some(flag) if is_identifier_character(flag))
             {
+                let Some(flag) = current_char(contents, index) else {
+                    break;
+                };
+                if !is_regex_flag(flag) || seen_flags.contains(&flag) {
+                    return None;
+                }
+                seen_flags.push(flag);
                 index = advance_one(contents, index);
             }
-            return index;
+            if !regex_literal_has_valid_follow(contents, index) {
+                return None;
+            }
+            return Some(index);
         }
 
         if character == '\n' || character == '\r' {
-            return index;
+            return None;
         }
 
         index = advance_one(contents, index);
     }
 
-    index
+    None
 }
 
 fn get_closing_character(open_character: char) -> char {
@@ -1262,6 +1722,69 @@ fn get_closing_character(open_character: char) -> char {
         '(' => ')',
         _ => ']',
     }
+}
+
+fn is_regex_flag(character: char) -> bool {
+    matches!(character, 'd' | 'g' | 'i' | 'm' | 's' | 'u' | 'v' | 'y')
+}
+
+fn regex_literal_has_valid_follow(contents: &str, start_index: usize) -> bool {
+    let mut index = start_index;
+
+    while index < contents.len() {
+        let Some(character) = current_char(contents, index) else {
+            return true;
+        };
+
+        if matches!(character, '\n' | '\r') {
+            return true;
+        }
+
+        if character.is_whitespace() {
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if regex_literal_can_be_followed_by_character(character) {
+            return true;
+        }
+
+        if is_identifier_start(character) {
+            let token = read_identifier(contents, index);
+            return matches!(token, "as" | "in" | "instanceof" | "satisfies");
+        }
+
+        return false;
+    }
+
+    true
+}
+
+fn regex_literal_can_be_followed_by_character(character: char) -> bool {
+    matches!(
+        character,
+        '.' | '['
+            | ';'
+            | ','
+            | ')'
+            | '}'
+            | ']'
+            | ':'
+            | '?'
+            | '+'
+            | '-'
+            | '*'
+            | '%'
+            | '&'
+            | '|'
+            | '^'
+            | '<'
+            | '>'
+            | '='
+            | '!'
+            | '~'
+            | '/'
+    )
 }
 
 fn has_token_boundary(contents: &str, start_index: usize, token: &str) -> bool {
@@ -1334,6 +1857,152 @@ fn find_previous_non_whitespace(contents: &str, start_index: usize) -> Option<us
         .find_map(|(index, character)| (!character.is_whitespace()).then_some(index))
 }
 
+fn find_previous_significant_index(contents: &str, start_index: usize) -> Option<usize> {
+    let mut search_end = start_index;
+
+    loop {
+        let candidate_index = find_previous_non_whitespace(contents, search_end)?;
+
+        if let Some(comment_start) = find_trailing_comment_start(contents, candidate_index) {
+            search_end = comment_start;
+            continue;
+        }
+
+        return Some(candidate_index);
+    }
+}
+
+fn find_trailing_comment_start(contents: &str, candidate_index: usize) -> Option<usize> {
+    if current_char(contents, candidate_index) == Some('/')
+        && previous_char(contents, candidate_index) == Some('*')
+    {
+        return contents[..candidate_index.saturating_sub(1)].rfind("/*");
+    }
+
+    find_line_comment_start(contents, candidate_index)
+}
+
+fn line_start_index(contents: &str, index: usize) -> usize {
+    contents[..index]
+        .char_indices()
+        .rev()
+        .find_map(|(character_index, character)| {
+            matches!(character, '\n' | '\r').then_some(character_index + character.len_utf8())
+        })
+        .unwrap_or(0)
+}
+
+fn find_line_comment_start(contents: &str, candidate_index: usize) -> Option<usize> {
+    let line_start = line_start_index(contents, candidate_index);
+    let mut index = line_start;
+
+    while index <= candidate_index {
+        let character = current_char(contents, index)?;
+
+        if character == '\'' || character == '"' {
+            index = skip_quoted_string(contents, index, character);
+            continue;
+        }
+
+        if character == '`' {
+            index = skip_template_string_for_comment_scan(contents, index);
+            continue;
+        }
+
+        if character == '/' && peek_char(contents, index + 1) == Some('*') {
+            index = skip_block_comment(contents, index);
+            continue;
+        }
+
+        if character == '/' && peek_char(contents, index + 1) == Some('/') {
+            return Some(index);
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    None
+}
+
+fn skip_template_string_for_comment_scan(contents: &str, start_index: usize) -> usize {
+    let mut index = start_index + 1;
+
+    while index < contents.len() {
+        let Some(character) = current_char(contents, index) else {
+            break;
+        };
+
+        if character == '\\' {
+            let next_index = advance_one(contents, index);
+            if next_index >= contents.len() {
+                return contents.len();
+            }
+            index = advance_one(contents, next_index);
+            continue;
+        }
+
+        if character == '`' {
+            return index + 1;
+        }
+
+        if character == '$' && peek_char(contents, index + 1) == Some('{') {
+            index = skip_balanced_expression_for_comment_scan(contents, index + 2);
+            continue;
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    contents.len()
+}
+
+fn skip_balanced_expression_for_comment_scan(contents: &str, start_index: usize) -> usize {
+    let mut stack = vec!['}'];
+    let mut index = start_index;
+
+    while index < contents.len() && !stack.is_empty() {
+        let Some(character) = current_char(contents, index) else {
+            break;
+        };
+
+        if character == '/' && peek_char(contents, index + 1) == Some('/') {
+            index = skip_line_comment(contents, index);
+            continue;
+        }
+
+        if character == '/' && peek_char(contents, index + 1) == Some('*') {
+            index = skip_block_comment(contents, index);
+            continue;
+        }
+
+        if character == '\'' || character == '"' {
+            index = skip_quoted_string(contents, index, character);
+            continue;
+        }
+
+        if character == '`' {
+            index = skip_template_string_for_comment_scan(contents, index);
+            continue;
+        }
+
+        if matches!(character, '{' | '(' | '[') {
+            stack.push(get_closing_character(character));
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        if Some(character) == stack.last().copied() {
+            stack.pop();
+            index = advance_one(contents, index);
+            continue;
+        }
+
+        index = advance_one(contents, index);
+    }
+
+    index
+}
+
 fn is_likely_jsx_tag(tag_text: &str) -> bool {
     if tag_text == "<>" || tag_text == "</>" {
         return true;
@@ -1369,6 +2038,10 @@ fn read_identifier(contents: &str, start_index: usize) -> &str {
 }
 
 fn previous_identifier_token(contents: &str, end_index: usize) -> Option<&str> {
+    previous_identifier_span(contents, end_index).map(|(_, token)| token)
+}
+
+fn previous_identifier_span(contents: &str, end_index: usize) -> Option<(usize, &str)> {
     let current = current_char(contents, end_index)?;
     if !is_identifier_character(current) {
         return None;
@@ -1382,7 +2055,7 @@ fn previous_identifier_token(contents: &str, end_index: usize) -> Option<&str> {
         start = index;
     }
 
-    Some(&contents[start..advance_one(contents, end_index)])
+    Some((start, &contents[start..advance_one(contents, end_index)]))
 }
 
 fn is_identifier_start(character: char) -> bool {
@@ -1395,6 +2068,36 @@ fn is_identifier_character(character: char) -> bool {
 
 fn normalize_whitespace(value: &str) -> String {
     value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn head_ends_with_tokens(head: &str, suffix: &[&str]) -> bool {
+    let tokens = head.split_whitespace().collect::<Vec<_>>();
+    tokens.ends_with(suffix)
+}
+
+fn contains_assignment_operator(head: &str) -> bool {
+    let mut characters = head.char_indices().peekable();
+
+    while let Some((index, character)) = characters.next() {
+        if character != '=' {
+            continue;
+        }
+
+        let previous = head[..index].chars().next_back();
+        let next = characters.peek().map(|(_, next_character)| *next_character);
+
+        if matches!(previous, Some('=' | '!' | '<' | '>')) {
+            continue;
+        }
+
+        if matches!(next, Some('=' | '>')) {
+            continue;
+        }
+
+        return true;
+    }
+
+    false
 }
 
 fn current_char(contents: &str, index: usize) -> Option<char> {

--- a/crates/legolas-core/tests/import_scanner.rs
+++ b/crates/legolas-core/tests/import_scanner.rs
@@ -72,18 +72,24 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
         to_posix_paths(&root, &files),
         vec![
             "basic/Dashboard.tsx",
+            "comments/Commented.tsx",
             "dynamic/Dashboard.tsx",
             "false-positives/docs.ts",
             "jsx/View.jsx",
+            "nested-dynamic/App.tsx",
+            "reexport/index.ts",
             "svelte/Panel.svelte",
+            "svelte-context/Panel.svelte",
+            "templates/Template.tsx",
             "type-only/types.ts",
             "vue/Widget.vue",
+            "vue-multiscript/Widget.vue",
         ]
     );
 
     let analysis = scan_imports(&root, &files).expect("scan fixture imports");
 
-    assert_eq!(analysis.dynamic_import_count, 4);
+    assert_eq!(analysis.dynamic_import_count, 6);
     assert_eq!(
         analysis.by_package.keys().cloned().collect::<Vec<_>>(),
         vec![
@@ -117,8 +123,16 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
         analysis.by_package.get("@scope/runtime"),
         Some(&ImportedPackageRecord {
             name: "@scope/runtime".to_string(),
-            files: vec!["type-only/types.ts".to_string()],
-            static_files: vec!["type-only/types.ts".to_string()],
+            files: vec![
+                "reexport/index.ts".to_string(),
+                "type-only/types.ts".to_string(),
+                "vue-multiscript/Widget.vue".to_string(),
+            ],
+            static_files: vec![
+                "reexport/index.ts".to_string(),
+                "type-only/types.ts".to_string(),
+                "vue-multiscript/Widget.vue".to_string(),
+            ],
             dynamic_files: Vec::new(),
         })
     );
@@ -128,22 +142,34 @@ fn scan_imports_matches_manual_scanner_parity_expectations() {
             name: "chart.js".to_string(),
             files: vec![
                 "basic/Dashboard.tsx".to_string(),
+                "nested-dynamic/App.tsx".to_string(),
+                "reexport/index.ts".to_string(),
                 "vue/Widget.vue".to_string()
             ],
             static_files: vec![
                 "basic/Dashboard.tsx".to_string(),
+                "reexport/index.ts".to_string(),
                 "vue/Widget.vue".to_string()
             ],
-            dynamic_files: vec!["vue/Widget.vue".to_string()],
+            dynamic_files: vec![
+                "nested-dynamic/App.tsx".to_string(),
+                "vue/Widget.vue".to_string()
+            ],
         })
     );
     assert_eq!(
         analysis.by_package.get("mapbox-gl"),
         Some(&ImportedPackageRecord {
             name: "mapbox-gl".to_string(),
-            files: vec!["dynamic/Dashboard.tsx".to_string()],
+            files: vec![
+                "dynamic/Dashboard.tsx".to_string(),
+                "nested-dynamic/App.tsx".to_string()
+            ],
             static_files: Vec::new(),
-            dynamic_files: vec!["dynamic/Dashboard.tsx".to_string()],
+            dynamic_files: vec![
+                "dynamic/Dashboard.tsx".to_string(),
+                "nested-dynamic/App.tsx".to_string()
+            ],
         })
     );
     assert_eq!(

--- a/crates/legolas-core/tests/import_scanner_regressions.rs
+++ b/crates/legolas-core/tests/import_scanner_regressions.rs
@@ -1,8 +1,12 @@
 mod support;
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use legolas_core::import_scanner::{collect_source_files, scan_imports, ImportedPackageRecord};
+use tempfile::tempdir;
 
 #[test]
 fn scan_imports_ignores_import_like_text_in_comments() {
@@ -30,6 +34,108 @@ fn scan_imports_ignores_import_like_text_in_raw_template_strings() {
     assert!(analysis.by_package.is_empty());
     assert_eq!(analysis.dynamic_import_count, 0);
     assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_counts_dynamic_imports_inside_template_interpolations() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const rendered = `${true ? import(\"chart.js/auto\") : \"\"}`;\n",
+    );
+
+    let files = collect_source_files(root).expect("collect interpolation regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan interpolation regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["chart.js"]
+    );
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_counts_dynamic_imports_inside_template_interpolations_with_regex_literals() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const rendered = `${/}/.test(value) ? import(\"chart.js/auto\") : \"\"}`;\n",
+    );
+
+    let files = collect_source_files(root).expect("collect interpolation regex regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan interpolation regex regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["chart.js"]
+    );
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_counts_dynamic_imports_inside_template_interpolations_with_returned_regex_literals()
+{
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const rendered = `${(() => { return /}/.test(value) ? import(\"chart.js/auto\") : \"\"; })()}`;\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect interpolation return regex regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan interpolation return regex regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["chart.js"]
+    );
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
 }
 
 #[test]
@@ -190,4 +296,11 @@ fn to_posix_paths(root: &Path, files: &[PathBuf]) -> Vec<String> {
         .collect::<Vec<_>>();
     relative_paths.sort();
     relative_paths
+}
+
+fn write_file(root: &Path, relative_path: &str, contents: &str) {
+    let path = root.join(relative_path);
+    let parent = path.parent().expect("fixture file parent");
+    fs::create_dir_all(parent).expect("create fixture directory");
+    fs::write(path, contents).expect("write fixture file");
 }

--- a/crates/legolas-core/tests/import_scanner_regressions.rs
+++ b/crates/legolas-core/tests/import_scanner_regressions.rs
@@ -5,7 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use legolas_core::import_scanner::{collect_source_files, scan_imports, ImportedPackageRecord};
+use legolas_core::{
+    import_scanner::{collect_source_files, scan_imports, ImportedPackageRecord},
+    FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata, TreeShakingWarning,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -139,6 +142,655 @@ fn scan_imports_counts_dynamic_imports_inside_template_interpolations_with_retur
 }
 
 #[test]
+fn scan_imports_ignores_import_like_text_inside_template_interpolation_regex_literals() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const rendered = `${/import(\"chart.js\\/auto\")/.test(value) ? \"hit\" : \"miss\"}`;\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect interpolation regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan interpolation regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_imports_inside_unterminated_template_interpolations() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const broken = `${(() => import(\"chart.js/auto\"))()\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect unterminated template interpolation files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan unterminated template interpolation fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_statement_regex_after_control_headers() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "export const ok = true;\n",
+            "if (ok) /import(\"chart.js\\/auto\")/.test(value);\n",
+            "if (ok) /=import(\"chart.js\\/auto\")/.test(value);\n",
+            "do /import(\"chart.js\\/auto\")/.test(value); while (false);\n",
+            "if (ok) { safe(); } else /import(\"chart.js\\/auto\")/.test(value);\n",
+        ),
+    );
+
+    let files =
+        collect_source_files(root).expect("collect control-header regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan control-header regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_statement_regex_after_control_headers_with_comments(
+) {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const ok = true;\nif (ok) /**//import(\"chart.js\\/auto\")/.test(value);\n",
+    );
+
+    let files = collect_source_files(root)
+        .expect("collect control-header comment regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files)
+        .expect("scan control-header comment regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_statement_regex_after_block_boundaries() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "if (flag) { doThing(); }\n/import(\"chart.js\\/auto\")/.test(value);\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect block-boundary regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan block-boundary regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_statement_regex_after_function_declarations() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "function foo() {}\n/import(\"chart.js\\/auto\")/.test(value);\n",
+    );
+
+    let files = collect_source_files(root)
+        .expect("collect function-declaration regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan function-declaration regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_statement_regex_after_class_declarations() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "class Foo {}\n/import(\"chart.js\\/auto\")/.test(value);\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect class-declaration regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan class-declaration regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_statement_regex_after_declaration_adornments() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "class Foo extends Bar {}\n",
+            "/import(\"chart.js\\/auto\")/.test(value);\n",
+            "function foo<T>() {}\n",
+            "/import(\"chart.js\\/auto\")/.test(value);\n",
+            "function* bar() {}\n",
+            "/import(\"chart.js\\/auto\")/.test(value);\n",
+        ),
+    );
+
+    let files = collect_source_files(root)
+        .expect("collect declaration adornment regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files)
+        .expect("scan declaration adornment regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_statement_regex_after_catch_blocks() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "try { risky(); } catch {}\n/import(\"chart.js\\/auto\")/.test(value);\n",
+    );
+
+    let files = collect_source_files(root).expect("collect catch-block regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan catch-block regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_statement_regex_after_for_await_headers() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "async function main() {\n",
+            "  for await (const item of items) {}\n",
+            "  /import(\"chart.js\\/auto\")/.test(item);\n",
+            "}\n",
+        ),
+    );
+
+    let files = collect_source_files(root).expect("collect for-await regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan for-await regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_inside_for_of_headers() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "for (const item of /import(\"chart.js\\/auto\")/.exec(value) ?? []) {\n",
+            "  console.log(item);\n",
+            "}\n",
+        ),
+    );
+
+    let files = collect_source_files(root).expect("collect for-of regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan for-of regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_preserves_dynamic_imports_after_object_literal_statements_followed_by_division() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "const objectLiteral = {}\n/import(\"chart\") / 2;\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect object-literal division regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan object-literal division fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert!(analysis.by_package.contains_key("chart"));
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_after_arrow_function_statements() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "const render = () => {}\n",
+            "/import(\"chart.js\\/auto\")/.test(render);\n",
+        ),
+    );
+
+    let files =
+        collect_source_files(root).expect("collect arrow-function regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan arrow-function regex fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_after_arrow_function_assignments() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "exports.loader = () => {}\n",
+            "/import(\"chart.js\\/auto\")/.test(exports.loader);\n",
+        ),
+    );
+
+    let files =
+        collect_source_files(root).expect("collect arrow-assignment regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan arrow-assignment regex false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_preserves_dynamic_imports_after_function_expression_assignments_followed_by_division(
+) {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "exports.fallback = function () {}\n/import(\"chart\") / 2;\n",
+    );
+
+    let files = collect_source_files(root)
+        .expect("collect function-expression assignment division regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files)
+        .expect("scan function-expression assignment division regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert!(analysis.by_package.contains_key("chart"));
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_after_labeled_block_statements() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "label: {}\n",
+            "/import(\"chart.js\\/auto\")/.test(label);\n",
+        ),
+    );
+
+    let files =
+        collect_source_files(root).expect("collect labeled-block regex false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan labeled-block regex fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_preserves_dynamic_imports_after_function_bodies_followed_by_division() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const value = (() => { return 1; }) / import(\"chart.js/auto\") / 2;\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect function-body division regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan function-body division regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_preserves_dynamic_imports_after_url_strings_followed_by_division() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const value = \"https://cdn.example.com\" / import(\"chart.js/auto\") / 2;\n",
+    );
+
+    let files = collect_source_files(root).expect("collect url-string division regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan url-string division regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_preserves_dynamic_imports_after_url_template_strings_followed_by_division() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const value = `https://cdn.example.com` / import(\"chart.js/auto\") / 2;\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect url-template-string division regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan url-template-string division regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_preserves_dynamic_imports_after_object_literal_exports_followed_by_division() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const value = {}\n/import(\"chart.js/auto\") / 2;\n",
+    );
+
+    let files = collect_source_files(root)
+        .expect("collect object-literal export division regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan object-literal export division regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_preserves_dynamic_imports_after_semicolon_less_object_literal_returns_and_exports_followed_by_division(
+) {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "function demo() {\n",
+            "  return {}\n",
+            "  / import(\"chart\") / 2;\n",
+            "}\n",
+            "function regexChainDemo() {\n",
+            "  return {}\n",
+            "  / import(\"chart\") / /2/.test(value);\n",
+            "}\n",
+            "export default {}\n",
+            "/ import(\"chart\") / /2/.test(value);\n",
+        ),
+    );
+
+    let files = collect_source_files(root)
+        .expect("collect semicolon-less object literal division regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files)
+        .expect("scan semicolon-less object literal division regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 3);
+    assert!(analysis.by_package.contains_key("chart"));
+}
+
+#[test]
+fn scan_imports_preserves_dynamic_imports_after_postfix_increment_and_decrement() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "let count = 0;\n",
+            "export const plus = count++ / import(\"chart.js/auto\") / 2;\n",
+            "export const minus = count-- / import(\"chart.js/auto\") / 2;\n",
+        ),
+    );
+
+    let files =
+        collect_source_files(root).expect("collect postfix increment division regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan postfix increment division regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 2);
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_emits_tree_shaking_warnings_for_export_from_root_packages() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/index.ts",
+        "export { default as fp } from \"lodash\";\n",
+    );
+
+    let files = collect_source_files(root).expect("collect export tree-shaking regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/index.ts"]);
+
+    let analysis = scan_imports(root, &files).expect("scan export tree-shaking regression fixture");
+
+    assert_eq!(
+        analysis.by_package.get("lodash"),
+        Some(&ImportedPackageRecord {
+            name: "lodash".to_string(),
+            files: vec!["src/index.ts".to_string()],
+            static_files: vec!["src/index.ts".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert_eq!(
+        analysis.tree_shaking_warnings,
+        vec![TreeShakingWarning {
+            key: "lodash-root-import".to_string(),
+            package_name: "lodash".to_string(),
+            message: "Root lodash imports often keep more code than expected in client bundles."
+                .to_string(),
+            recommendation: "Prefer per-method imports or lodash-es.".to_string(),
+            estimated_kb: 26,
+            files: vec!["src/index.ts".to_string()],
+            finding: FindingMetadata::new(
+                "tree-shaking:lodash-root-import",
+                FindingAnalysisSource::SourceImport,
+            )
+            .with_confidence(FindingConfidence::High)
+            .with_evidence([FindingEvidence::new("source-file")
+                .with_file("src/index.ts")
+                .with_specifier("lodash")
+                .with_detail("root package import")]),
+        }]
+    );
+}
+
+#[test]
 fn scan_imports_tracks_export_from_reexports_without_type_only_exports() {
     let root = support::fixture_path("tests/fixtures/scanner/reexport");
     let files = collect_source_files(&root).expect("collect reexport regression files");
@@ -212,6 +864,66 @@ fn scan_imports_counts_nested_dynamic_imports() {
             files: vec!["App.tsx".to_string()],
             static_files: Vec::new(),
             dynamic_files: vec!["App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_reads_script_blocks_with_embedded_closing_tags_in_strings_and_comments() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/Widget.vue",
+        concat!(
+            "<script>\n",
+            "const html = \"</script>\";\n",
+            "import { reactive } from \"vue\";\n",
+            "</script>\n",
+        ),
+    );
+    write_file(
+        root,
+        "src/Panel.svelte",
+        concat!(
+            "<script>\n",
+            "// </script>\n",
+            "import dayjs from \"dayjs\";\n",
+            "</script>\n",
+        ),
+    );
+
+    let files = collect_source_files(root).expect("collect embedded closing-tag regression files");
+
+    assert_eq!(
+        to_posix_paths(root, &files),
+        vec!["src/Panel.svelte", "src/Widget.vue"]
+    );
+
+    let analysis = scan_imports(root, &files).expect("scan embedded closing-tag regression files");
+
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["dayjs", "vue"]
+    );
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert_eq!(
+        analysis.by_package.get("dayjs"),
+        Some(&ImportedPackageRecord {
+            name: "dayjs".to_string(),
+            files: vec!["src/Panel.svelte".to_string()],
+            static_files: vec!["src/Panel.svelte".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+    assert_eq!(
+        analysis.by_package.get("vue"),
+        Some(&ImportedPackageRecord {
+            name: "vue".to_string(),
+            files: vec!["src/Widget.vue".to_string()],
+            static_files: vec!["src/Widget.vue".to_string()],
+            dynamic_files: Vec::new(),
         })
     );
 }

--- a/crates/legolas-core/tests/import_scanner_regressions.rs
+++ b/crates/legolas-core/tests/import_scanner_regressions.rs
@@ -1,0 +1,193 @@
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use legolas_core::import_scanner::{collect_source_files, scan_imports, ImportedPackageRecord};
+
+#[test]
+fn scan_imports_ignores_import_like_text_in_comments() {
+    let root = support::fixture_path("tests/fixtures/scanner/comments");
+    let files = collect_source_files(&root).expect("collect comment regression files");
+
+    assert_eq!(to_posix_paths(&root, &files), vec!["Commented.tsx"]);
+
+    let analysis = scan_imports(&root, &files).expect("scan comment regression fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_text_in_template_strings() {
+    let root = support::fixture_path("tests/fixtures/scanner/templates");
+    let files = collect_source_files(&root).expect("collect template regression files");
+
+    assert_eq!(to_posix_paths(&root, &files), vec!["Template.tsx"]);
+
+    let analysis = scan_imports(&root, &files).expect("scan template regression fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_tracks_export_from_reexports_without_type_only_exports() {
+    let root = support::fixture_path("tests/fixtures/scanner/reexport");
+    let files = collect_source_files(&root).expect("collect reexport regression files");
+
+    assert_eq!(to_posix_paths(&root, &files), vec!["index.ts"]);
+
+    let analysis = scan_imports(&root, &files).expect("scan reexport regression fixture");
+
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["@scope/runtime", "chart.js", "dayjs"]
+    );
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+    assert_eq!(
+        analysis.by_package.get("@scope/runtime"),
+        Some(&ImportedPackageRecord {
+            name: "@scope/runtime".to_string(),
+            files: vec!["index.ts".to_string()],
+            static_files: vec!["index.ts".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["index.ts".to_string()],
+            static_files: vec!["index.ts".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+    assert_eq!(
+        analysis.by_package.get("dayjs"),
+        Some(&ImportedPackageRecord {
+            name: "dayjs".to_string(),
+            files: vec!["index.ts".to_string()],
+            static_files: vec!["index.ts".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+}
+
+#[test]
+fn scan_imports_counts_nested_dynamic_imports() {
+    let root = support::fixture_path("tests/fixtures/scanner/nested-dynamic");
+    let files = collect_source_files(&root).expect("collect nested dynamic regression files");
+
+    assert_eq!(to_posix_paths(&root, &files), vec!["App.tsx"]);
+
+    let analysis = scan_imports(&root, &files).expect("scan nested dynamic regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 2);
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["chart.js", "mapbox-gl"]
+    );
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["App.tsx".to_string()],
+        })
+    );
+    assert_eq!(
+        analysis.by_package.get("mapbox-gl"),
+        Some(&ImportedPackageRecord {
+            name: "mapbox-gl".to_string(),
+            files: vec!["App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_reads_both_vue_script_blocks() {
+    let root = support::fixture_path("tests/fixtures/scanner/vue-multiscript");
+    let files = collect_source_files(&root).expect("collect vue multiscript regression files");
+
+    assert_eq!(to_posix_paths(&root, &files), vec!["Widget.vue"]);
+
+    let analysis = scan_imports(&root, &files).expect("scan vue multiscript regression fixture");
+
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["@scope/runtime", "vue"]
+    );
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert_eq!(
+        analysis.by_package.get("@scope/runtime"),
+        Some(&ImportedPackageRecord {
+            name: "@scope/runtime".to_string(),
+            files: vec!["Widget.vue".to_string()],
+            static_files: vec!["Widget.vue".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+    assert_eq!(
+        analysis.by_package.get("vue"),
+        Some(&ImportedPackageRecord {
+            name: "vue".to_string(),
+            files: vec!["Widget.vue".to_string()],
+            static_files: vec!["Widget.vue".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+}
+
+#[test]
+fn scan_imports_reads_svelte_context_and_instance_scripts() {
+    let root = support::fixture_path("tests/fixtures/scanner/svelte-context");
+    let files = collect_source_files(&root).expect("collect svelte context regression files");
+
+    assert_eq!(to_posix_paths(&root, &files), vec!["Panel.svelte"]);
+
+    let analysis = scan_imports(&root, &files).expect("scan svelte context regression fixture");
+
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["@sveltejs/kit", "dayjs"]
+    );
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert_eq!(
+        analysis.by_package.get("@sveltejs/kit"),
+        Some(&ImportedPackageRecord {
+            name: "@sveltejs/kit".to_string(),
+            files: vec!["Panel.svelte".to_string()],
+            static_files: vec!["Panel.svelte".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+    assert_eq!(
+        analysis.by_package.get("dayjs"),
+        Some(&ImportedPackageRecord {
+            name: "dayjs".to_string(),
+            files: vec!["Panel.svelte".to_string()],
+            static_files: vec!["Panel.svelte".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+}
+
+fn to_posix_paths(root: &Path, files: &[PathBuf]) -> Vec<String> {
+    let mut relative_paths = files
+        .iter()
+        .map(|file| {
+            file.strip_prefix(root)
+                .expect("source file should stay under fixture root")
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect::<Vec<_>>();
+    relative_paths.sort();
+    relative_paths
+}

--- a/crates/legolas-core/tests/import_scanner_regressions.rs
+++ b/crates/legolas-core/tests/import_scanner_regressions.rs
@@ -19,7 +19,7 @@ fn scan_imports_ignores_import_like_text_in_comments() {
 }
 
 #[test]
-fn scan_imports_ignores_import_like_text_in_template_strings() {
+fn scan_imports_ignores_import_like_text_in_raw_template_strings() {
     let root = support::fixture_path("tests/fixtures/scanner/templates");
     let files = collect_source_files(&root).expect("collect template regression files");
 

--- a/tests/fixtures/scanner/comments/Commented.tsx
+++ b/tests/fixtures/scanner/comments/Commented.tsx
@@ -1,0 +1,8 @@
+// import maps from "mapbox-gl";
+// const loader = () => import("chart.js/auto");
+/*
+export { fake } from "react-icons";
+require("dayjs/plugin/utc");
+*/
+
+export const Commented = () => null;

--- a/tests/fixtures/scanner/nested-dynamic/App.tsx
+++ b/tests/fixtures/scanner/nested-dynamic/App.tsx
@@ -1,0 +1,8 @@
+export async function loadFeature(flag: boolean) {
+  const loaders = {
+    chart: async () => (await import("chart.js/auto")).Chart,
+    map: () => import("mapbox-gl"),
+  };
+
+  return flag ? loaders.chart() : loaders.map();
+}

--- a/tests/fixtures/scanner/reexport/index.ts
+++ b/tests/fixtures/scanner/reexport/index.ts
@@ -1,0 +1,4 @@
+export { default as UtcPlugin } from "dayjs/plugin/utc";
+export { default as ChartHelper } from "chart.js/helpers";
+export { value as runtimeValue } from "@scope/runtime/utils";
+export type { Config } from "@scope/types";

--- a/tests/fixtures/scanner/svelte-context/Panel.svelte
+++ b/tests/fixtures/scanner/svelte-context/Panel.svelte
@@ -1,0 +1,9 @@
+<script context="module">
+  export { default as UtcPlugin } from "dayjs/plugin/utc";
+</script>
+
+<script>
+  const adapter = require("@sveltejs/kit/node");
+</script>
+
+<div>{adapter ? "ready" : "pending"}</div>

--- a/tests/fixtures/scanner/templates/Template.tsx
+++ b/tests/fixtures/scanner/templates/Template.tsx
@@ -1,0 +1,4 @@
+const fakeLoader = `import("react-icons") ${'require("lodash")'}`;
+const nested = `export { Chart } from "chart.js/helpers"`;
+
+export const Template = `${fakeLoader} ${nested}`;

--- a/tests/fixtures/scanner/templates/Template.tsx
+++ b/tests/fixtures/scanner/templates/Template.tsx
@@ -1,4 +1,4 @@
-const fakeLoader = `import("react-icons") ${'require("lodash")'}`;
+const fakeLoader = `import("react-icons") require("lodash")`;
 const nested = `export { Chart } from "chart.js/helpers"`;
 
 export const Template = `${fakeLoader} ${nested}`;

--- a/tests/fixtures/scanner/templates/Template.tsx
+++ b/tests/fixtures/scanner/templates/Template.tsx
@@ -1,4 +1,4 @@
 const fakeLoader = `import("react-icons") require("lodash")`;
 const nested = `export { Chart } from "chart.js/helpers"`;
 
-export const Template = `${fakeLoader} ${nested}`;
+export const Template = fakeLoader + " " + nested;

--- a/tests/fixtures/scanner/vue-multiscript/Widget.vue
+++ b/tests/fixtures/scanner/vue-multiscript/Widget.vue
@@ -1,0 +1,13 @@
+<template>
+  <section>widget</section>
+</template>
+
+<script setup lang="ts">
+import { reactive } from "vue";
+
+const state = reactive({ ready: true });
+</script>
+
+<script>
+export { value as runtimeValue } from "@scope/runtime/utils";
+</script>


### PR DESCRIPTION
배경

- import scanner regression hardening 작업에서 정규식 리터럴 경계와 template/re-export 경로를 함께 보강했습니다.
- Devils Advocate 리뷰 루프에서 `}` 뒤 정규식 리터럴이 dynamic import 로 오탐되는 케이스가 확인되어, 해당 문맥 판별을 추가로 좁혔습니다.

변경 사항

- source scanner가 정규식 리터럴을 먼저 건너뛰도록 해 comment/string/template 밖의 import-like text 오탐을 줄였습니다.
- `)`/`}` 뒤 문맥을 해석하는 휴리스틱을 추가해 control header, 선언문 종료, 객체 리터럴 문장, 화살표 함수 문장, 라벨드 블록 뒤의 regex statement를 구분합니다.
- `export ... from` 경로도 tree-shaking warning 누적 대상으로 연결했습니다.
- import scanner regression 테스트에 template interpolation regex, control/block/declaration/catch/for-await/object literal/arrow/labeled block, function-body division 케이스를 추가했습니다.

검증

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `target/debug/legolas-cli scan <temp project> --json`
  - object literal 뒤 regex statement: `dynamicImports = 0`
  - function body 뒤 division/dynamic import: `dynamicImports = 1`

브랜치 / 워크트리

- base: `master`
- head: `codex/parser-regression-hardening`
- current worktree: `/Users/pjw/workspace/legolas`
- source branches/worktrees: 없음

이슈 연결

- 없음
