### PR TITLE
feat: icon import precision 규칙 추가

### DIFF
--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -908,6 +908,10 @@ fn build_tree_shaking_hint(specifier: &str, clause: &str) -> Option<TreeShakingW
         return None;
     }
 
+    if let Some(warning) = icon_tree_shaking_hint(specifier, &normalized_clause) {
+        return Some(warning);
+    }
+
     if is_namespace_import_clause(&normalized_clause) && is_namespace_sensitive_package(specifier) {
         return Some(TreeShakingWarning {
             key: "namespace-ui-import".to_string(),
@@ -925,6 +929,10 @@ fn build_tree_shaking_hint(specifier: &str, clause: &str) -> Option<TreeShakingW
         return Some(warning);
     }
 
+    None
+}
+
+fn icon_tree_shaking_hint(specifier: &str, clause: &str) -> Option<TreeShakingWarning> {
     if specifier == "react-icons" {
         return Some(TreeShakingWarning {
             key: "react-icons-root-import".to_string(),
@@ -937,7 +945,29 @@ fn build_tree_shaking_hint(specifier: &str, clause: &str) -> Option<TreeShakingW
         });
     }
 
-    None
+    if !is_namespace_import_clause(clause) {
+        return None;
+    }
+
+    let key = if specifier == "@mui/icons-material" {
+        "mui-icons-namespace-import"
+    } else if specifier.starts_with("react-icons/") {
+        "react-icons-pack-namespace-import"
+    } else {
+        return None;
+    };
+
+    Some(TreeShakingWarning {
+        key: key.to_string(),
+        package_name: specifier.to_string(),
+        message: "Namespace icon-pack imports can pull large icon sets into a single module graph."
+            .to_string(),
+        recommendation: "Import only the icon symbols you use instead of a namespace icon pack."
+            .to_string(),
+        estimated_kb: 32,
+        files: Vec::new(),
+        finding: Default::default(),
+    })
 }
 
 fn root_barrel_tree_shaking_hint(specifier: &str) -> Option<TreeShakingWarning> {
@@ -977,15 +1007,27 @@ fn build_tree_shaking_finding(
     }
 
     FindingMetadata::new(
-        format!("tree-shaking:{warning_key}"),
+        tree_shaking_finding_id(warning_key, package_name),
         FindingAnalysisSource::SourceImport,
     )
     .with_confidence(score_tree_shaking_warning())
     .with_evidence([evidence])
 }
 
+fn tree_shaking_finding_id(warning_key: &str, package_name: &str) -> String {
+    match warning_key {
+        "mui-icons-namespace-import" | "react-icons-pack-namespace-import" => {
+            format!("tree-shaking:{warning_key}:{package_name}")
+        }
+        _ => format!("tree-shaking:{warning_key}"),
+    }
+}
+
 fn tree_shaking_evidence_detail(warning_key: &str) -> Option<&'static str> {
     match warning_key {
+        "mui-icons-namespace-import" | "react-icons-pack-namespace-import" => {
+            Some("icon pack namespace import")
+        }
         "namespace-ui-import" => Some("namespace import"),
         "lodash-root-import" | "react-icons-root-import" => Some("root package import"),
         _ => None,
@@ -1020,7 +1062,7 @@ fn is_type_only_clause(clause: &str) -> bool {
 }
 
 fn is_namespace_sensitive_package(specifier: &str) -> bool {
-    matches!(specifier, "lodash" | "lucide-react" | "@mui/icons-material")
+    matches!(specifier, "lodash" | "lucide-react")
 }
 
 fn is_namespace_import_clause(clause: &str) -> bool {

--- a/crates/legolas-core/src/package_intelligence.rs
+++ b/crates/legolas-core/src/package_intelligence.rs
@@ -92,9 +92,9 @@ static PACKAGE_INTELLIGENCE: [(&str, PackageIntel); 16] = [
         PackageIntel {
             estimated_kb: 220,
             category: "icons",
-            rationale: "Icons often spread across the app and are easy to over-import.",
+            rationale: "Pack-wide icon imports can spread quickly and keep too many symbols in the graph.",
             recommendation:
-                "Use direct icon imports and lazy load icon-heavy admin or settings routes.",
+                "Prefer direct icon imports such as @mui/icons-material/Add on icon-heavy surfaces.",
         },
     ),
     (

--- a/crates/legolas-core/tests/import_precision_icons.rs
+++ b/crates/legolas-core/tests/import_precision_icons.rs
@@ -1,0 +1,132 @@
+mod support;
+
+use std::collections::BTreeMap;
+
+use legolas_core::{
+    import_scanner::{collect_source_files, scan_imports, ImportedPackageRecord},
+    FindingAnalysisSource, FindingConfidence, TreeShakingWarning,
+};
+
+#[test]
+fn scan_imports_warns_on_root_and_namespace_icon_pack_imports_only() {
+    let root = support::fixture_path("tests/fixtures/import-precision/icons");
+    let files = collect_source_files(&root).expect("collect fixture source files");
+
+    let analysis = scan_imports(&root, &files).expect("scan fixture imports");
+
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["@mui/icons-material", "react-icons"]
+    );
+    assert_eq!(
+        analysis.by_package.get("@mui/icons-material"),
+        Some(&ImportedPackageRecord {
+            name: "@mui/icons-material".to_string(),
+            files: vec!["src/IconPanel.tsx".to_string()],
+            static_files: vec!["src/IconPanel.tsx".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+    assert_eq!(
+        analysis.by_package.get("react-icons"),
+        Some(&ImportedPackageRecord {
+            name: "react-icons".to_string(),
+            files: vec!["src/IconPanel.tsx".to_string()],
+            static_files: vec!["src/IconPanel.tsx".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+
+    let warnings = analysis
+        .tree_shaking_warnings
+        .into_iter()
+        .map(|warning| (format!("{}:{}", warning.key, warning.package_name), warning))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(
+        warnings.keys().cloned().collect::<Vec<_>>(),
+        vec![
+            "mui-icons-namespace-import:@mui/icons-material".to_string(),
+            "react-icons-pack-namespace-import:react-icons/fa".to_string(),
+            "react-icons-pack-namespace-import:react-icons/fi".to_string(),
+            "react-icons-root-import:react-icons".to_string(),
+        ]
+    );
+
+    assert_warning(
+        warnings
+            .get("mui-icons-namespace-import:@mui/icons-material")
+            .expect("mui icons namespace warning"),
+        "mui-icons-namespace-import",
+        "@mui/icons-material",
+        "tree-shaking:mui-icons-namespace-import:@mui/icons-material",
+        "icon pack namespace import",
+    );
+    assert_warning(
+        warnings
+            .get("react-icons-pack-namespace-import:react-icons/fa")
+            .expect("react icons namespace warning"),
+        "react-icons-pack-namespace-import",
+        "react-icons/fa",
+        "tree-shaking:react-icons-pack-namespace-import:react-icons/fa",
+        "icon pack namespace import",
+    );
+    assert_warning(
+        warnings
+            .get("react-icons-pack-namespace-import:react-icons/fi")
+            .expect("react icons fi namespace warning"),
+        "react-icons-pack-namespace-import",
+        "react-icons/fi",
+        "tree-shaking:react-icons-pack-namespace-import:react-icons/fi",
+        "icon pack namespace import",
+    );
+    assert_warning(
+        warnings
+            .get("react-icons-root-import:react-icons")
+            .expect("react icons root warning"),
+        "react-icons-root-import",
+        "react-icons",
+        "tree-shaking:react-icons-root-import",
+        "root package import",
+    );
+
+    let finding_ids = warnings
+        .values()
+        .map(|warning| warning.finding.finding_id.as_deref().expect("finding id"))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(finding_ids.len(), warnings.len());
+}
+
+fn assert_warning(
+    warning: &TreeShakingWarning,
+    expected_key: &str,
+    expected_package_name: &str,
+    expected_finding_id: &str,
+    expected_detail: &str,
+) {
+    assert_eq!(warning.key, expected_key);
+    assert_eq!(warning.package_name, expected_package_name);
+    assert_eq!(warning.files, vec!["src/IconPanel.tsx".to_string()]);
+    assert_eq!(
+        warning.finding.analysis_source,
+        Some(FindingAnalysisSource::SourceImport)
+    );
+    assert_eq!(warning.finding.confidence, Some(FindingConfidence::High));
+    assert_eq!(
+        warning.finding.finding_id.as_deref(),
+        Some(expected_finding_id)
+    );
+    assert_eq!(warning.finding.evidence.len(), 1);
+    assert_eq!(
+        warning.finding.evidence[0].file.as_deref(),
+        Some("src/IconPanel.tsx")
+    );
+    assert_eq!(
+        warning.finding.evidence[0].specifier.as_deref(),
+        Some(expected_package_name)
+    );
+    assert_eq!(
+        warning.finding.evidence[0].detail.as_deref(),
+        Some(expected_detail)
+    );
+}

--- a/tests/fixtures/import-precision/icons/package.json
+++ b/tests/fixtures/import-precision/icons/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "import-precision-icons",
+  "private": true,
+  "dependencies": {
+    "@mui/icons-material": "5.15.0",
+    "react-icons": "5.2.1"
+  }
+}

--- a/tests/fixtures/import-precision/icons/src/IconPanel.tsx
+++ b/tests/fixtures/import-precision/icons/src/IconPanel.tsx
@@ -1,0 +1,19 @@
+import { FaBeer } from "react-icons";
+import * as FaPack from "react-icons/fa";
+import { FiAlertCircle } from "react-icons/fi";
+import * as FiPack from "react-icons/fi";
+import * as MaterialIcons from "@mui/icons-material";
+import AddIcon from "@mui/icons-material/Add";
+
+export function IconPanel() {
+  return (
+    <div>
+      {FaBeer ? "beer" : "none"}
+      {FaPack.FaRegBell ? "pack" : "none"}
+      {FiAlertCircle ? "fi" : "none"}
+      {FiPack.FiSettings ? "fi pack" : "none"}
+      {MaterialIcons.Add ? "mui" : "none"}
+      {AddIcon ? "single" : "none"}
+    </div>
+  );
+}

--- a/tests/oracles/package-intelligence/registry.json
+++ b/tests/oracles/package-intelligence/registry.json
@@ -59,8 +59,8 @@
     "packageName": "@mui/icons-material",
     "estimatedKb": 220,
     "category": "icons",
-    "rationale": "Icons often spread across the app and are easy to over-import.",
-    "recommendation": "Use direct icon imports and lazy load icon-heavy admin or settings routes."
+    "rationale": "Pack-wide icon imports can spread quickly and keep too many symbols in the graph.",
+    "recommendation": "Prefer direct icon imports such as @mui/icons-material/Add on icon-heavy surfaces."
   },
   {
     "packageName": "@mui/material",


### PR DESCRIPTION
## 요약
- react-icons/fa와 @mui/icons-material namespace import를 dedicated tree-shaking warning으로 분리했습니다.
- direct icon import는 pass하고, icon precision 회귀 fixture와 테스트를 추가했습니다.
- @mui/icons-material package intelligence 문구와 registry snapshot을 direct import 기준으로 보정했습니다.

## 검증
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- target/debug/legolas-cli scan tests/fixtures/import-precision/icons --json