### PR TITLE
feat: locale import precision 규칙 추가

### DIFF
--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -128,6 +128,12 @@ struct WarningAccumulator {
     finding: FindingMetadata,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct LocaleImportAccumulator {
+    specifiers: BTreeSet<String>,
+    files: BTreeSet<String>,
+}
+
 pub fn collect_source_files<P: AsRef<Path>>(project_root: P) -> Result<Vec<PathBuf>> {
     let project_root = project_root.as_ref();
     ensure_directory_exists(project_root)?;
@@ -158,6 +164,7 @@ pub fn scan_imports_with_aliases<P: AsRef<Path>>(
 
     let mut by_package: BTreeMap<String, PackageAccumulator> = BTreeMap::new();
     let mut tree_shaking_observations = Vec::new();
+    let mut static_locale_imports = BTreeMap::<String, LocaleImportAccumulator>::new();
     let mut dynamic_import_count = 0;
 
     for absolute_path in ordered_files {
@@ -189,6 +196,11 @@ pub fn scan_imports_with_aliases<P: AsRef<Path>>(
                 record.dynamic_files.insert(relative_path.clone());
             } else {
                 record.static_files.insert(relative_path.clone());
+                if let Some(package_name) = locale_subpath_package(&entry.specifier) {
+                    let accumulator = static_locale_imports.entry(package_name).or_default();
+                    accumulator.specifiers.insert(entry.specifier.clone());
+                    accumulator.files.insert(relative_path.clone());
+                }
             }
         }
 
@@ -199,6 +211,8 @@ pub fn scan_imports_with_aliases<P: AsRef<Path>>(
             tree_shaking_observations.push(hint);
         }
     }
+
+    tree_shaking_observations.extend(locale_tree_shaking_hints(static_locale_imports));
 
     let by_package = by_package
         .into_iter()
@@ -993,6 +1007,46 @@ fn root_barrel_tree_shaking_hint(specifier: &str) -> Option<TreeShakingWarning> 
     })
 }
 
+fn locale_subpath_package(specifier: &str) -> Option<String> {
+    for package_name in ["moment", "dayjs", "date-fns"] {
+        let locale_prefix = format!("{package_name}/locale/");
+        if specifier.starts_with(&locale_prefix) && specifier.len() > locale_prefix.len() {
+            return Some(package_name.to_string());
+        }
+    }
+
+    None
+}
+
+fn locale_tree_shaking_hints(
+    locale_imports: BTreeMap<String, LocaleImportAccumulator>,
+) -> Vec<TreeShakingWarning> {
+    let mut hints = Vec::new();
+
+    for (package_name, accumulator) in locale_imports {
+        if accumulator.specifiers.len() < 2 {
+            continue;
+        }
+
+        for file in accumulator.files {
+            hints.push(TreeShakingWarning {
+                key: "import.locale-bundle".to_string(),
+                package_name: package_name.clone(),
+                message: "Multiple static locale imports can pull locale data into the main module graph."
+                    .to_string(),
+                recommendation:
+                    "Load only the active locale or split locale data away from the initial bundle."
+                        .to_string(),
+                estimated_kb: 18,
+                files: vec![file.clone()],
+                finding: build_tree_shaking_finding("import.locale-bundle", &package_name, &file),
+            });
+        }
+    }
+
+    hints
+}
+
 fn build_tree_shaking_finding(
     warning_key: &str,
     package_name: &str,
@@ -1016,7 +1070,9 @@ fn build_tree_shaking_finding(
 
 fn tree_shaking_finding_id(warning_key: &str, package_name: &str) -> String {
     match warning_key {
-        "mui-icons-namespace-import" | "react-icons-pack-namespace-import" => {
+        "import.locale-bundle"
+        | "mui-icons-namespace-import"
+        | "react-icons-pack-namespace-import" => {
             format!("tree-shaking:{warning_key}:{package_name}")
         }
         _ => format!("tree-shaking:{warning_key}"),
@@ -1029,6 +1085,7 @@ fn tree_shaking_evidence_detail(warning_key: &str) -> Option<&'static str> {
             Some("icon pack namespace import")
         }
         "namespace-ui-import" => Some("namespace import"),
+        "import.locale-bundle" => Some("static locale import bundle"),
         "lodash-root-import" | "react-icons-root-import" => Some("root package import"),
         _ => None,
     }

--- a/crates/legolas-core/tests/import_precision_locales.rs
+++ b/crates/legolas-core/tests/import_precision_locales.rs
@@ -1,0 +1,134 @@
+mod support;
+
+use std::{collections::BTreeMap, fs, path::Path};
+
+use legolas_core::{
+    import_scanner::{collect_source_files, scan_imports},
+    FindingAnalysisSource, FindingConfidence, TreeShakingWarning,
+};
+use tempfile::tempdir;
+
+#[test]
+fn scan_imports_warns_on_multiple_static_locale_subpath_imports_per_package() {
+    let root = support::fixture_path("tests/fixtures/import-precision/locales");
+    let files = collect_source_files(&root).expect("collect fixture source files");
+
+    let analysis = scan_imports(&root, &files).expect("scan fixture imports");
+
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["date-fns", "dayjs", "moment"]
+    );
+
+    let warnings = analysis
+        .tree_shaking_warnings
+        .into_iter()
+        .map(|warning| (format!("{}:{}", warning.key, warning.package_name), warning))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(
+        warnings.keys().cloned().collect::<Vec<_>>(),
+        vec![
+            "import.locale-bundle:date-fns".to_string(),
+            "import.locale-bundle:dayjs".to_string(),
+            "import.locale-bundle:moment".to_string(),
+        ]
+    );
+
+    assert_locale_warning(
+        warnings
+            .get("import.locale-bundle:date-fns")
+            .expect("date-fns locale warning"),
+        "date-fns",
+    );
+    assert_locale_warning(
+        warnings
+            .get("import.locale-bundle:dayjs")
+            .expect("dayjs locale warning"),
+        "dayjs",
+    );
+    assert_locale_warning(
+        warnings
+            .get("import.locale-bundle:moment")
+            .expect("moment locale warning"),
+        "moment",
+    );
+}
+
+#[test]
+fn scan_imports_does_not_warn_on_single_or_dynamic_locale_imports() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "single-locale-imports",
+  "private": true,
+  "dependencies": {
+    "dayjs": "1.11.11",
+    "moment": "2.30.1"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/DateView.tsx",
+        r#"import "moment/locale/ko";
+import "dayjs/locale/ko";
+
+export function loadFrenchLocale() {
+  return import("dayjs/locale/fr");
+}
+"#,
+    );
+
+    let files = collect_source_files(root).expect("collect source files");
+    let analysis = scan_imports(root, &files).expect("scan locale imports");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["dayjs", "moment"]
+    );
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+fn assert_locale_warning(warning: &TreeShakingWarning, expected_package_name: &str) {
+    let expected_finding_id = format!("tree-shaking:import.locale-bundle:{expected_package_name}");
+
+    assert_eq!(warning.key, "import.locale-bundle");
+    assert_eq!(warning.package_name, expected_package_name);
+    assert_eq!(warning.files, vec!["src/DateView.tsx".to_string()]);
+    assert_eq!(
+        warning.finding.analysis_source,
+        Some(FindingAnalysisSource::SourceImport)
+    );
+    assert_eq!(warning.finding.confidence, Some(FindingConfidence::High));
+    assert_eq!(
+        warning.finding.finding_id.as_deref(),
+        Some(expected_finding_id.as_str())
+    );
+    assert_eq!(warning.finding.evidence.len(), 1);
+    assert_eq!(
+        warning.finding.evidence[0].file.as_deref(),
+        Some("src/DateView.tsx")
+    );
+    assert_eq!(
+        warning.finding.evidence[0].specifier.as_deref(),
+        Some(expected_package_name)
+    );
+    assert_eq!(
+        warning.finding.evidence[0].detail.as_deref(),
+        Some("static locale import bundle")
+    );
+}
+
+fn write_file(root: &Path, relative_path: &str, contents: &str) {
+    let path = root.join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directories");
+    }
+    fs::write(path, contents).expect("write fixture file");
+}

--- a/tests/fixtures/import-precision/locales/package.json
+++ b/tests/fixtures/import-precision/locales/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "locale-import-precision",
+  "private": true,
+  "dependencies": {
+    "date-fns": "3.6.0",
+    "dayjs": "1.11.11",
+    "moment": "2.30.1"
+  }
+}

--- a/tests/fixtures/import-precision/locales/src/DateView.tsx
+++ b/tests/fixtures/import-precision/locales/src/DateView.tsx
@@ -1,0 +1,22 @@
+import { format } from "date-fns";
+import { fr } from "date-fns/locale/fr";
+import { ko } from "date-fns/locale/ko";
+import dayjs from "dayjs";
+import "dayjs/locale/ja";
+import "dayjs/locale/ko";
+import moment from "moment";
+import "moment/locale/fr";
+import "moment/locale/ko";
+
+export function DateView() {
+  const today = new Date("2026-04-21T00:00:00.000Z");
+
+  return (
+    <time dateTime={today.toISOString()}>
+      {format(today, "PPP", { locale: ko })}
+      {format(today, "PPP", { locale: fr })}
+      {dayjs(today).locale("ko").format("YYYY-MM-DD")}
+      {moment(today).locale("fr").format("YYYY-MM-DD")}
+    </time>
+  );
+}


### PR DESCRIPTION
## 요약
- moment, dayjs, date-fns의 static locale subpath import가 package별 2개 이상이면 dedicated import.locale-bundle warning을 생성합니다.
- single static locale import와 dynamic locale import는 warning에서 제외되도록 regression test를 추가했습니다.
- locale import precision fixture를 추가해 CLI scan 결과까지 재현 가능하게 했습니다.

## 검증
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo run -p legolas-cli -- scan tests/fixtures/import-precision/locales --json