### PR TITLE
feat: action ranking 엔진 추가

### DIFF
--- a/crates/legolas-cli/tests/support/mod.rs
+++ b/crates/legolas-cli/tests/support/mod.rs
@@ -58,8 +58,32 @@ fn normalize_analysis_value(analysis: &mut Value) {
     normalize_string_array(analysis, &["warnings"]);
     normalize_object_array_string_field(analysis, &["heavyDependencies"], "importedBy");
     normalize_object_array_string_field(analysis, &["heavyDependencies"], "dynamicImportedBy");
+    normalize_object_array_object_array_string_field(
+        analysis,
+        &["heavyDependencies"],
+        "recommendedFix",
+        "targetFiles",
+    );
     normalize_object_array_string_field(analysis, &["lazyLoadCandidates"], "files");
+    normalize_object_array_object_array_string_field(
+        analysis,
+        &["lazyLoadCandidates"],
+        "recommendedFix",
+        "targetFiles",
+    );
     normalize_object_array_string_field(analysis, &["treeShakingWarnings"], "files");
+    normalize_object_array_object_array_string_field(
+        analysis,
+        &["treeShakingWarnings"],
+        "recommendedFix",
+        "targetFiles",
+    );
+    normalize_object_array_object_array_string_field(
+        analysis,
+        &["duplicatePackages"],
+        "recommendedFix",
+        "targetFiles",
+    );
 }
 
 #[allow(dead_code)]
@@ -94,6 +118,34 @@ fn normalize_object_array_string_field(root: &mut Value, path: &[&str], field: &
 
     for item in items {
         let Some(array) = item.get_mut(field).and_then(Value::as_array_mut) else {
+            continue;
+        };
+
+        for entry in array {
+            if let Some(value) = entry.as_str() {
+                *entry = Value::String(to_posix(value.to_string()));
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn normalize_object_array_object_array_string_field(
+    root: &mut Value,
+    path: &[&str],
+    object_field: &str,
+    array_field: &str,
+) {
+    let Some(Value::Array(items)) = get_path_mut(root, path) else {
+        return;
+    };
+
+    for item in items {
+        let Some(array) = item
+            .get_mut(object_field)
+            .and_then(|value| value.get_mut(array_field))
+            .and_then(Value::as_array_mut)
+        else {
             continue;
         };
 

--- a/crates/legolas-core/src/action_plan.rs
+++ b/crates/legolas-core/src/action_plan.rs
@@ -1,0 +1,219 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    findings::{FindingConfidence, FindingMetadata},
+    models::{ActionDifficulty, ActionPlanItem, Analysis, RecommendedFix},
+};
+
+pub fn rank_actions(analysis: &Analysis) -> Vec<ActionPlanItem> {
+    let mut actions = Vec::new();
+
+    for item in &analysis.heavy_dependencies {
+        push_action(
+            &mut actions,
+            &item.finding,
+            item.estimated_kb,
+            ActionDifficulty::Hard,
+            Some(recommended_fix(
+                recommended_fix_kind(&item.name, &item.recommendation),
+                item.recommendation.clone(),
+                item.imported_by.clone(),
+                &item.name,
+            )),
+        );
+    }
+
+    for item in &analysis.lazy_load_candidates {
+        push_action(
+            &mut actions,
+            &item.finding,
+            item.estimated_savings_kb,
+            ActionDifficulty::Medium,
+            Some(recommended_fix(
+                "lazy-load",
+                item.recommendation.clone(),
+                item.files.clone(),
+                &item.name,
+            )),
+        );
+    }
+
+    for item in &analysis.tree_shaking_warnings {
+        push_action(
+            &mut actions,
+            &item.finding,
+            item.estimated_kb,
+            ActionDifficulty::Easy,
+            Some(recommended_fix(
+                "narrow-import",
+                item.recommendation.clone(),
+                item.files.clone(),
+                &item.package_name,
+            )),
+        );
+    }
+
+    for item in &analysis.duplicate_packages {
+        push_action(
+            &mut actions,
+            &item.finding,
+            item.estimated_extra_kb,
+            ActionDifficulty::Medium,
+            Some(RecommendedFix {
+                kind: "dedupe-package".to_string(),
+                title: format!("Deduplicate {} to one installed version.", item.name),
+                target_files: Vec::new(),
+                replacement: None,
+            }),
+        );
+    }
+
+    actions.sort_by(|left, right| {
+        right
+            .estimated_savings_kb
+            .cmp(&left.estimated_savings_kb)
+            .then(right.confidence.cmp(&left.confidence))
+            .then(left.difficulty.cmp(&right.difficulty))
+            .then(left.finding_id.cmp(&right.finding_id))
+    });
+
+    let mut seen = BTreeSet::new();
+    let mut ranked = actions
+        .into_iter()
+        .filter(|item| seen.insert(item.finding_id.clone()))
+        .collect::<Vec<_>>();
+
+    for (index, item) in ranked.iter_mut().enumerate() {
+        item.action_priority = index + 1;
+    }
+
+    ranked
+}
+
+pub fn apply_action_plan(analysis: &mut Analysis) -> Vec<ActionPlanItem> {
+    let actions = rank_actions(analysis);
+    let action_by_id = actions
+        .iter()
+        .map(|action| (action.finding_id.clone(), action.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    for item in &mut analysis.heavy_dependencies {
+        apply_action_metadata(&mut item.finding, &action_by_id);
+    }
+    for item in &mut analysis.lazy_load_candidates {
+        apply_action_metadata(&mut item.finding, &action_by_id);
+    }
+    for item in &mut analysis.tree_shaking_warnings {
+        apply_action_metadata(&mut item.finding, &action_by_id);
+    }
+    for item in &mut analysis.duplicate_packages {
+        apply_action_metadata(&mut item.finding, &action_by_id);
+    }
+
+    actions
+}
+
+fn push_action(
+    actions: &mut Vec<ActionPlanItem>,
+    finding: &FindingMetadata,
+    estimated_savings_kb: usize,
+    difficulty: ActionDifficulty,
+    recommended_fix: Option<RecommendedFix>,
+) {
+    let Some(finding_id) = finding.finding_id.clone() else {
+        return;
+    };
+
+    actions.push(ActionPlanItem {
+        action_priority: 0,
+        finding_id,
+        estimated_savings_kb,
+        confidence: finding.confidence.unwrap_or(FindingConfidence::Low),
+        difficulty,
+        recommended_fix,
+    });
+}
+
+fn recommended_fix(
+    kind: &str,
+    title: String,
+    target_files: Vec<String>,
+    package_name: &str,
+) -> RecommendedFix {
+    RecommendedFix {
+        kind: kind.to_string(),
+        title,
+        target_files: normalized_files(target_files),
+        replacement: replacement_candidate(kind, package_name),
+    }
+}
+
+fn normalized_files(files: Vec<String>) -> Vec<String> {
+    let mut files = files;
+    files.sort();
+    files.dedup();
+    files
+}
+
+fn apply_action_metadata(
+    finding: &mut FindingMetadata,
+    action_by_id: &BTreeMap<String, ActionPlanItem>,
+) {
+    finding.action_priority = None;
+    finding.recommended_fix = None;
+
+    let Some(action) = finding
+        .finding_id
+        .as_ref()
+        .and_then(|finding_id| action_by_id.get(finding_id))
+    else {
+        return;
+    };
+
+    finding.action_priority = Some(action.action_priority);
+    finding.recommended_fix = action.recommended_fix.clone();
+}
+
+fn recommended_fix_kind(package_name: &str, recommendation: &str) -> &'static str {
+    let normalized = recommendation.to_ascii_lowercase();
+
+    if package_name == "moment" {
+        return "replace-package";
+    }
+
+    if normalized.contains("server boundar") {
+        return "move-boundary";
+    }
+
+    if normalized.contains("lazy load")
+        || normalized.contains("on demand")
+        || normalized.contains("defer")
+    {
+        return "lazy-load";
+    }
+
+    if normalized.contains("route")
+        || normalized.contains("split ")
+        || normalized.contains("split-")
+    {
+        return "split-route";
+    }
+
+    if normalized.contains("import")
+        || normalized.contains("modular")
+        || normalized.contains("register only")
+    {
+        return "narrow-import";
+    }
+
+    "reduce-usage"
+}
+
+fn replacement_candidate(kind: &str, package_name: &str) -> Option<String> {
+    match (kind, package_name) {
+        ("replace-package", "aws-sdk") => Some("AWS SDK v3".to_string()),
+        ("replace-package", "moment") => Some("date-fns or Day.js".to_string()),
+        ("narrow-import", "lodash") => Some("lodash-es".to_string()),
+        _ => None,
+    }
+}

--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -10,6 +10,7 @@ use regex::Regex;
 use serde_json::Value;
 
 use crate::{
+    action_plan::apply_action_plan,
     confidence::{score_duplicate_package, score_heavy_dependency, score_lazy_load_candidate},
     error::Result,
     findings::{FindingAnalysisSource, FindingEvidence, FindingMetadata},
@@ -68,7 +69,7 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
         &tree_shaking_warnings,
     );
 
-    Ok(Analysis {
+    let mut analysis = Analysis {
         project_root: project_root.to_string_lossy().to_string(),
         package_manager,
         frameworks,
@@ -97,7 +98,10 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
             },
             generated_at: generated_at_string(),
         },
-    })
+    };
+    apply_action_plan(&mut analysis);
+
+    Ok(analysis)
 }
 
 fn build_package_summary(manifest: &Value) -> PackageSummary {

--- a/crates/legolas-core/src/findings.rs
+++ b/crates/legolas-core/src/findings.rs
@@ -1,3 +1,4 @@
+use crate::models::RecommendedFix;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -61,6 +62,10 @@ pub struct FindingMetadata {
     pub analysis_source: Option<FindingAnalysisSource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<FindingConfidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_priority: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended_fix: Option<RecommendedFix>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<FindingEvidence>,
 }
@@ -71,6 +76,8 @@ impl FindingMetadata {
             finding_id: Some(finding_id.into()),
             analysis_source: Some(analysis_source),
             confidence: None,
+            action_priority: None,
+            recommended_fix: None,
             evidence: Vec::new(),
         }
     }
@@ -88,6 +95,16 @@ impl FindingMetadata {
         self
     }
 
+    pub fn with_action_priority(mut self, action_priority: usize) -> Self {
+        self.action_priority = Some(action_priority);
+        self
+    }
+
+    pub fn with_recommended_fix(mut self, recommended_fix: RecommendedFix) -> Self {
+        self.recommended_fix = Some(recommended_fix);
+        self
+    }
+
     pub fn push_evidence(&mut self, evidence: FindingEvidence) {
         self.evidence.push(evidence);
     }
@@ -96,6 +113,8 @@ impl FindingMetadata {
         self.finding_id.is_none()
             && self.analysis_source.is_none()
             && self.confidence.is_none()
+            && self.action_priority.is_none()
+            && self.recommended_fix.is_none()
             && self.evidence.is_empty()
     }
 }

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod action_plan;
 pub mod aliases;
 pub mod analyze;
 pub mod artifacts;
@@ -14,6 +15,7 @@ pub mod package_intelligence;
 pub mod project_shape;
 pub mod workspace;
 
+pub use action_plan::*;
 pub use analyze::analyze_project;
 pub use confidence::*;
 pub use error::{LegolasError, Result};

--- a/crates/legolas-core/src/models.rs
+++ b/crates/legolas-core/src/models.rs
@@ -110,3 +110,33 @@ pub struct Metadata {
     pub mode: String,
     pub generated_at: String,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ActionDifficulty {
+    Easy,
+    Medium,
+    Hard,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RecommendedFix {
+    pub kind: String,
+    pub title: String,
+    pub target_files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replacement: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionPlanItem {
+    pub action_priority: usize,
+    pub finding_id: String,
+    pub estimated_savings_kb: usize,
+    pub confidence: crate::FindingConfidence,
+    pub difficulty: ActionDifficulty,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended_fix: Option<RecommendedFix>,
+}

--- a/crates/legolas-core/tests/action_plan.rs
+++ b/crates/legolas-core/tests/action_plan.rs
@@ -1,0 +1,426 @@
+use legolas_core::{
+    apply_action_plan, rank_actions, ActionDifficulty, Analysis, DuplicatePackage,
+    FindingAnalysisSource, FindingConfidence, FindingMetadata, HeavyDependency, LazyLoadCandidate,
+    RecommendedFix, TreeShakingWarning,
+};
+use serde_json::json;
+
+#[test]
+fn rank_actions_sorts_by_savings_confidence_and_difficulty() {
+    let analysis = Analysis {
+        heavy_dependencies: vec![heavy_dependency(
+            "heavy-dependency:medium-hard",
+            "chart.js",
+            100,
+            FindingConfidence::Medium,
+        )],
+        lazy_load_candidates: vec![lazy_load_candidate(
+            "lazy-load:high-medium",
+            "chart.js",
+            100,
+            FindingConfidence::High,
+        )],
+        tree_shaking_warnings: vec![tree_shaking_warning(
+            "tree-shaking:high-easy",
+            "lodash",
+            100,
+            FindingConfidence::High,
+        )],
+        duplicate_packages: vec![duplicate_package(
+            "duplicate-package:low-medium",
+            "react",
+            150,
+            FindingConfidence::Low,
+        )],
+        ..Default::default()
+    };
+
+    let actions = rank_actions(&analysis);
+
+    assert_eq!(
+        actions
+            .iter()
+            .map(|item| (
+                item.action_priority,
+                item.finding_id.as_str(),
+                item.estimated_savings_kb,
+                item.confidence,
+                item.difficulty,
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                1,
+                "duplicate-package:low-medium",
+                150,
+                FindingConfidence::Low,
+                ActionDifficulty::Medium,
+            ),
+            (
+                2,
+                "tree-shaking:high-easy",
+                100,
+                FindingConfidence::High,
+                ActionDifficulty::Easy,
+            ),
+            (
+                3,
+                "lazy-load:high-medium",
+                100,
+                FindingConfidence::High,
+                ActionDifficulty::Medium,
+            ),
+            (
+                4,
+                "heavy-dependency:medium-hard",
+                100,
+                FindingConfidence::Medium,
+                ActionDifficulty::Hard,
+            ),
+        ]
+    );
+}
+
+#[test]
+fn apply_action_plan_writes_priority_and_recommended_fix_to_matching_findings() {
+    let mut analysis = Analysis {
+        heavy_dependencies: vec![heavy_dependency_with_recommendation(
+            "heavy-dependency:lodash",
+            "lodash",
+            72,
+            FindingConfidence::High,
+            "Use per-method imports or switch to lodash-es when the toolchain supports it.",
+        )],
+        tree_shaking_warnings: vec![tree_shaking_warning(
+            "tree-shaking:lodash-root-import",
+            "lodash",
+            26,
+            FindingConfidence::High,
+        )],
+        ..Default::default()
+    };
+
+    let actions = apply_action_plan(&mut analysis);
+
+    assert_eq!(
+        actions
+            .iter()
+            .map(|item| (item.action_priority, item.finding_id.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (1, "heavy-dependency:lodash"),
+            (2, "tree-shaking:lodash-root-import"),
+        ]
+    );
+    assert_eq!(
+        analysis.heavy_dependencies[0].finding.action_priority,
+        Some(1)
+    );
+    assert_eq!(
+        analysis.tree_shaking_warnings[0].finding.action_priority,
+        Some(2)
+    );
+
+    let fix = analysis.heavy_dependencies[0]
+        .finding
+        .recommended_fix
+        .as_ref()
+        .expect("heavy dependency fix");
+    assert_eq!(fix.kind, "narrow-import");
+    assert_eq!(fix.target_files, vec!["src/App.tsx".to_string()]);
+    assert_eq!(fix.replacement.as_deref(), Some("lodash-es"));
+
+    let tree_fix = analysis.tree_shaking_warnings[0]
+        .finding
+        .recommended_fix
+        .as_ref()
+        .expect("tree shaking fix");
+    assert_eq!(tree_fix.kind, "narrow-import");
+    assert_eq!(tree_fix.replacement.as_deref(), Some("lodash-es"));
+}
+
+#[test]
+fn rank_actions_maps_fix_kind_and_replacement_from_recommendation_shape() {
+    let analysis = Analysis {
+        heavy_dependencies: vec![
+            heavy_dependency_with_recommendation(
+                "heavy-dependency:chart.js",
+                "chart.js",
+                160,
+                FindingConfidence::High,
+                "Register only the chart primitives you use and lazy load dashboard surfaces.",
+            ),
+            heavy_dependency_with_recommendation(
+                "heavy-dependency:react-icons",
+                "react-icons",
+                90,
+                FindingConfidence::High,
+                "Import narrowly from specific icon files or migrate to a more tree-shakable icon set.",
+            ),
+            heavy_dependency_with_recommendation(
+                "heavy-dependency:lodash",
+                "lodash",
+                72,
+                FindingConfidence::High,
+                "Use per-method imports or switch to lodash-es when the toolchain supports it.",
+            ),
+            heavy_dependency_with_recommendation(
+                "heavy-dependency:moment",
+                "moment",
+                67,
+                FindingConfidence::High,
+                "Prefer date-fns, Day.js, or the platform Intl APIs where practical.",
+            ),
+        ],
+        ..Default::default()
+    };
+
+    let actions = rank_actions(&analysis);
+
+    let chart = actions
+        .iter()
+        .find(|item| item.finding_id == "heavy-dependency:chart.js")
+        .expect("chart.js action");
+    assert_eq!(
+        chart.recommended_fix.as_ref().map(|fix| fix.kind.as_str()),
+        Some("lazy-load")
+    );
+    assert_eq!(
+        chart
+            .recommended_fix
+            .as_ref()
+            .and_then(|fix| fix.replacement.as_deref()),
+        None
+    );
+
+    let react_icons = actions
+        .iter()
+        .find(|item| item.finding_id == "heavy-dependency:react-icons")
+        .expect("react-icons action");
+    assert_eq!(
+        react_icons
+            .recommended_fix
+            .as_ref()
+            .map(|fix| fix.kind.as_str()),
+        Some("narrow-import")
+    );
+    assert_eq!(
+        react_icons
+            .recommended_fix
+            .as_ref()
+            .and_then(|fix| fix.replacement.as_deref()),
+        None
+    );
+
+    let lodash = actions
+        .iter()
+        .find(|item| item.finding_id == "heavy-dependency:lodash")
+        .expect("lodash action");
+    assert_eq!(
+        lodash.recommended_fix.as_ref().map(|fix| fix.kind.as_str()),
+        Some("narrow-import")
+    );
+    assert_eq!(
+        lodash
+            .recommended_fix
+            .as_ref()
+            .and_then(|fix| fix.replacement.as_deref()),
+        Some("lodash-es")
+    );
+
+    let moment = actions
+        .iter()
+        .find(|item| item.finding_id == "heavy-dependency:moment")
+        .expect("moment action");
+    assert_eq!(
+        moment.recommended_fix.as_ref().map(|fix| fix.kind.as_str()),
+        Some("replace-package")
+    );
+    assert_eq!(
+        moment
+            .recommended_fix
+            .as_ref()
+            .and_then(|fix| fix.replacement.as_deref()),
+        Some("date-fns or Day.js")
+    );
+}
+
+#[test]
+fn rank_actions_dedupes_by_finding_id_not_recommended_fix_text() {
+    let analysis = Analysis {
+        tree_shaking_warnings: vec![
+            tree_shaking_warning(
+                "tree-shaking:lodash-root-import",
+                "lodash",
+                26,
+                FindingConfidence::High,
+            ),
+            tree_shaking_warning(
+                "tree-shaking:lodash-root-import",
+                "lodash",
+                24,
+                FindingConfidence::High,
+            ),
+        ],
+        ..Default::default()
+    };
+
+    let actions = rank_actions(&analysis);
+
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].finding_id, "tree-shaking:lodash-root-import");
+    assert_eq!(actions[0].estimated_savings_kb, 26);
+}
+
+#[test]
+fn apply_action_plan_clears_stale_metadata_before_reapplying() {
+    let mut analysis = Analysis {
+        tree_shaking_warnings: vec![tree_shaking_warning(
+            "tree-shaking:lodash-root-import",
+            "lodash",
+            26,
+            FindingConfidence::High,
+        )],
+        ..Default::default()
+    };
+
+    apply_action_plan(&mut analysis);
+    assert_eq!(
+        analysis.tree_shaking_warnings[0].finding.action_priority,
+        Some(1)
+    );
+    assert!(analysis.tree_shaking_warnings[0]
+        .finding
+        .recommended_fix
+        .is_some());
+
+    analysis.tree_shaking_warnings[0].finding.finding_id = None;
+
+    apply_action_plan(&mut analysis);
+
+    assert_eq!(
+        analysis.tree_shaking_warnings[0].finding.action_priority,
+        None
+    );
+    assert_eq!(
+        analysis.tree_shaking_warnings[0].finding.recommended_fix,
+        None
+    );
+}
+
+#[test]
+fn finding_metadata_serializes_action_priority_and_recommended_fix_additively() {
+    let metadata = FindingMetadata::new(
+        "heavy-dependency:lodash",
+        FindingAnalysisSource::SourceImport,
+    )
+    .with_confidence(FindingConfidence::High)
+    .with_action_priority(1)
+    .with_recommended_fix(RecommendedFix {
+        kind: "replace-package".to_string(),
+        title: "Use per-method imports.".to_string(),
+        target_files: vec!["src/App.tsx".to_string()],
+        replacement: Some("lodash-es".to_string()),
+    });
+
+    let payload = serde_json::to_value(metadata).expect("serialize finding metadata");
+
+    assert_eq!(
+        payload,
+        json!({
+            "findingId": "heavy-dependency:lodash",
+            "analysisSource": "source-import",
+            "confidence": "high",
+            "actionPriority": 1,
+            "recommendedFix": {
+                "kind": "replace-package",
+                "title": "Use per-method imports.",
+                "targetFiles": ["src/App.tsx"],
+                "replacement": "lodash-es"
+            }
+        })
+    );
+}
+
+fn heavy_dependency(
+    finding_id: &str,
+    name: &str,
+    estimated_kb: usize,
+    confidence: FindingConfidence,
+) -> HeavyDependency {
+    heavy_dependency_with_recommendation(
+        finding_id,
+        name,
+        estimated_kb,
+        confidence,
+        &format!("Reduce {name}."),
+    )
+}
+
+fn heavy_dependency_with_recommendation(
+    finding_id: &str,
+    name: &str,
+    estimated_kb: usize,
+    confidence: FindingConfidence,
+    recommendation: &str,
+) -> HeavyDependency {
+    HeavyDependency {
+        name: name.to_string(),
+        estimated_kb,
+        recommendation: recommendation.to_string(),
+        imported_by: vec!["src/App.tsx".to_string()],
+        finding: finding(finding_id, confidence),
+        ..Default::default()
+    }
+}
+
+fn lazy_load_candidate(
+    finding_id: &str,
+    name: &str,
+    estimated_savings_kb: usize,
+    confidence: FindingConfidence,
+) -> LazyLoadCandidate {
+    LazyLoadCandidate {
+        name: name.to_string(),
+        estimated_savings_kb,
+        recommendation: format!("Lazy load {name}."),
+        files: vec!["src/Dashboard.tsx".to_string()],
+        finding: finding(finding_id, confidence),
+        ..Default::default()
+    }
+}
+
+fn tree_shaking_warning(
+    finding_id: &str,
+    package_name: &str,
+    estimated_kb: usize,
+    confidence: FindingConfidence,
+) -> TreeShakingWarning {
+    TreeShakingWarning {
+        package_name: package_name.to_string(),
+        estimated_kb,
+        recommendation: format!("Narrow {package_name} imports."),
+        files: vec!["src/App.tsx".to_string()],
+        finding: finding(finding_id, confidence),
+        ..Default::default()
+    }
+}
+
+fn duplicate_package(
+    finding_id: &str,
+    name: &str,
+    estimated_extra_kb: usize,
+    confidence: FindingConfidence,
+) -> DuplicatePackage {
+    DuplicatePackage {
+        name: name.to_string(),
+        estimated_extra_kb,
+        finding: finding(finding_id, confidence),
+        ..Default::default()
+    }
+}
+
+fn finding(finding_id: &str, confidence: FindingConfidence) -> FindingMetadata {
+    FindingMetadata::new(finding_id, FindingAnalysisSource::SourceImport)
+        .with_confidence(confidence)
+}

--- a/crates/legolas-core/tests/finding_evidence.rs
+++ b/crates/legolas-core/tests/finding_evidence.rs
@@ -4,6 +4,7 @@ use std::fs;
 
 use legolas_core::{
     analyze_project, FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata,
+    RecommendedFix,
 };
 use tempfile::tempdir;
 
@@ -19,8 +20,8 @@ fn analyze_project_populates_heavy_dependency_evidence() {
         .find(|item| item.name == "chart.js")
         .expect("chart.js heavy dependency");
 
-    assert_eq!(
-        heavy_dependency.finding,
+    assert_finding_metadata(
+        &heavy_dependency.finding,
         FindingMetadata::new(
             "heavy-dependency:chart.js",
             FindingAnalysisSource::SourceImport,
@@ -31,7 +32,14 @@ fn analyze_project_populates_heavy_dependency_evidence() {
             .with_specifier("chart.js")
             .with_detail(
                 "static import; Charting code is often only needed on a subset of screens.",
-            )])
+            )]),
+    );
+    assert_eq!(heavy_dependency.finding.action_priority, Some(1));
+    assert_recommended_fix(
+        heavy_dependency.finding.recommended_fix.as_ref(),
+        "lazy-load",
+        &["src/AdminDashboard.tsx"],
+        None,
     );
 }
 
@@ -47,14 +55,21 @@ fn analyze_project_populates_lazy_load_candidate_evidence() {
         .find(|item| item.name == "chart.js")
         .expect("chart.js lazy-load candidate");
 
-    assert_eq!(
-        candidate.finding,
+    assert_finding_metadata(
+        &candidate.finding,
         FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic)
             .with_confidence(FindingConfidence::Medium)
             .with_evidence([FindingEvidence::new("source-file")
                 .with_file("src/AdminDashboard.tsx")
                 .with_specifier("chart.js")
-                .with_detail("route-like UI surface matched `admin` keyword")])
+                .with_detail("route-like UI surface matched `admin` keyword")]),
+    );
+    assert_eq!(candidate.finding.action_priority, Some(2));
+    assert_recommended_fix(
+        candidate.finding.recommended_fix.as_ref(),
+        "lazy-load",
+        &["src/AdminDashboard.tsx"],
+        None,
     );
 }
 
@@ -70,8 +85,8 @@ fn analyze_project_populates_tree_shaking_warning_evidence() {
         .find(|item| item.key == "lodash-root-import")
         .expect("lodash tree-shaking warning");
 
-    assert_eq!(
-        warning.finding,
+    assert_finding_metadata(
+        &warning.finding,
         FindingMetadata::new(
             "tree-shaking:lodash-root-import",
             FindingAnalysisSource::SourceImport,
@@ -80,7 +95,14 @@ fn analyze_project_populates_tree_shaking_warning_evidence() {
         .with_evidence([FindingEvidence::new("source-file")
             .with_file("src/AdminDashboard.tsx")
             .with_specifier("lodash")
-            .with_detail("root package import")])
+            .with_detail("root package import")]),
+    );
+    assert!(warning.finding.action_priority.is_some());
+    assert_recommended_fix(
+        warning.finding.recommended_fix.as_ref(),
+        "narrow-import",
+        &["src/AdminDashboard.tsx"],
+        Some("lodash-es"),
     );
 }
 
@@ -118,14 +140,21 @@ fn analyze_project_limits_lazy_load_evidence_to_candidate_files() {
         .expect("chart.js lazy-load candidate");
 
     assert_eq!(candidate.files, vec!["src/Dashboard.tsx".to_string()]);
-    assert_eq!(
-        candidate.finding,
+    assert_finding_metadata(
+        &candidate.finding,
         FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic)
             .with_confidence(FindingConfidence::Medium)
             .with_evidence([FindingEvidence::new("source-file")
                 .with_file("src/Dashboard.tsx")
                 .with_specifier("chart.js")
-                .with_detail("route-like UI surface matched `dashboard` keyword")])
+                .with_detail("route-like UI surface matched `dashboard` keyword")]),
+    );
+    assert_eq!(candidate.finding.action_priority, Some(2));
+    assert_recommended_fix(
+        candidate.finding.recommended_fix.as_ref(),
+        "lazy-load",
+        &["src/Dashboard.tsx"],
+        None,
     );
 }
 
@@ -134,4 +163,29 @@ fn write_file(root: &std::path::Path, relative_path: &str, contents: &str) {
     let parent = path.parent().expect("fixture file parent");
     fs::create_dir_all(parent).expect("create fixture directory");
     fs::write(path, contents).expect("write fixture file");
+}
+
+fn assert_finding_metadata(actual: &FindingMetadata, expected: FindingMetadata) {
+    assert_eq!(actual.finding_id, expected.finding_id);
+    assert_eq!(actual.analysis_source, expected.analysis_source);
+    assert_eq!(actual.confidence, expected.confidence);
+    assert_eq!(actual.evidence, expected.evidence);
+}
+
+fn assert_recommended_fix(
+    actual: Option<&RecommendedFix>,
+    expected_kind: &str,
+    expected_target_files: &[&str],
+    expected_replacement: Option<&str>,
+) {
+    let actual = actual.expect("recommended fix");
+    assert_eq!(actual.kind, expected_kind);
+    assert_eq!(
+        actual.target_files,
+        expected_target_files
+            .iter()
+            .map(|file| (*file).to_string())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(actual.replacement.as_deref(), expected_replacement);
 }

--- a/crates/legolas-core/tests/finding_support.rs
+++ b/crates/legolas-core/tests/finding_support.rs
@@ -102,5 +102,7 @@ where
     assert!(serialized.get("findingId").is_none());
     assert!(serialized.get("analysisSource").is_none());
     assert!(serialized.get("confidence").is_none());
+    assert!(serialized.get("actionPriority").is_none());
+    assert!(serialized.get("recommendedFix").is_none());
     assert!(serialized.get("evidence").is_none());
 }

--- a/crates/legolas-core/tests/support/mod.rs
+++ b/crates/legolas-core/tests/support/mod.rs
@@ -39,6 +39,7 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
             item.imported_by = item.imported_by.into_iter().map(to_posix).collect();
             item.dynamic_imported_by = item.dynamic_imported_by.into_iter().map(to_posix).collect();
             normalize_finding_files(&mut item.finding);
+            normalize_recommended_fix_files(&mut item.finding);
             item
         })
         .collect();
@@ -48,6 +49,7 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
         .map(|mut item| {
             item.files = item.files.into_iter().map(to_posix).collect();
             normalize_finding_files(&mut item.finding);
+            normalize_recommended_fix_files(&mut item.finding);
             item
         })
         .collect();
@@ -57,6 +59,15 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
         .map(|mut item| {
             item.files = item.files.into_iter().map(to_posix).collect();
             normalize_finding_files(&mut item.finding);
+            normalize_recommended_fix_files(&mut item.finding);
+            item
+        })
+        .collect();
+    normalized.duplicate_packages = normalized
+        .duplicate_packages
+        .into_iter()
+        .map(|mut item| {
+            normalize_recommended_fix_files(&mut item.finding);
             item
         })
         .collect();
@@ -80,4 +91,16 @@ fn normalize_finding_files(finding: &mut legolas_core::FindingMetadata) {
             evidence.file = Some(to_posix(file));
         }
     }
+}
+
+fn normalize_recommended_fix_files(finding: &mut legolas_core::FindingMetadata) {
+    let Some(recommended_fix) = finding.recommended_fix.as_mut() else {
+        return;
+    };
+
+    recommended_fix.target_files = recommended_fix
+        .target_files
+        .drain(..)
+        .map(to_posix)
+        .collect();
 }

--- a/tests/oracles/basic-app/scan.json
+++ b/tests/oracles/basic-app/scan.json
@@ -32,6 +32,14 @@
       "findingId": "heavy-dependency:chart.js",
       "analysisSource": "source-import",
       "confidence": "high",
+      "actionPriority": 1,
+      "recommendedFix": {
+        "kind": "lazy-load",
+        "title": "Register only the chart primitives you use and lazy load dashboard surfaces.",
+        "targetFiles": [
+          "src/Dashboard.tsx"
+        ]
+      },
       "evidence": [
         {
           "kind": "source-file",
@@ -56,6 +64,14 @@
       "findingId": "heavy-dependency:react-icons",
       "analysisSource": "source-import",
       "confidence": "high",
+      "actionPriority": 3,
+      "recommendedFix": {
+        "kind": "narrow-import",
+        "title": "Import narrowly from specific icon files or migrate to a more tree-shakable icon set.",
+        "targetFiles": [
+          "src/Dashboard.tsx"
+        ]
+      },
       "evidence": [
         {
           "kind": "source-file",
@@ -80,6 +96,15 @@
       "findingId": "heavy-dependency:lodash",
       "analysisSource": "source-import",
       "confidence": "high",
+      "actionPriority": 4,
+      "recommendedFix": {
+        "kind": "narrow-import",
+        "title": "Use per-method imports or switch to lodash-es when the toolchain supports it.",
+        "targetFiles": [
+          "src/Dashboard.tsx"
+        ],
+        "replacement": "lodash-es"
+      },
       "evidence": [
         {
           "kind": "source-file",
@@ -101,7 +126,13 @@
       "estimatedExtraKb": 18,
       "findingId": "duplicate-package:lodash",
       "analysisSource": "lockfile-trace",
-      "confidence": "high"
+      "confidence": "high",
+      "actionPriority": 9,
+      "recommendedFix": {
+        "kind": "dedupe-package",
+        "title": "Deduplicate lodash to one installed version.",
+        "targetFiles": []
+      }
     }
   ],
   "lazyLoadCandidates": [
@@ -116,6 +147,14 @@
       "findingId": "lazy-load:chart.js",
       "analysisSource": "heuristic",
       "confidence": "medium",
+      "actionPriority": 2,
+      "recommendedFix": {
+        "kind": "lazy-load",
+        "title": "Register only the chart primitives you use and lazy load dashboard surfaces.",
+        "targetFiles": [
+          "src/Dashboard.tsx"
+        ]
+      },
       "evidence": [
         {
           "kind": "source-file",
@@ -136,6 +175,14 @@
       "findingId": "lazy-load:react-icons",
       "analysisSource": "heuristic",
       "confidence": "medium",
+      "actionPriority": 5,
+      "recommendedFix": {
+        "kind": "lazy-load",
+        "title": "Import narrowly from specific icon files or migrate to a more tree-shakable icon set.",
+        "targetFiles": [
+          "src/Dashboard.tsx"
+        ]
+      },
       "evidence": [
         {
           "kind": "source-file",
@@ -156,6 +203,14 @@
       "findingId": "lazy-load:lodash",
       "analysisSource": "heuristic",
       "confidence": "medium",
+      "actionPriority": 6,
+      "recommendedFix": {
+        "kind": "lazy-load",
+        "title": "Use per-method imports or switch to lodash-es when the toolchain supports it.",
+        "targetFiles": [
+          "src/Dashboard.tsx"
+        ]
+      },
       "evidence": [
         {
           "kind": "source-file",
@@ -179,6 +234,15 @@
       "findingId": "tree-shaking:lodash-root-import",
       "analysisSource": "source-import",
       "confidence": "high",
+      "actionPriority": 7,
+      "recommendedFix": {
+        "kind": "narrow-import",
+        "title": "Prefer per-method imports or lodash-es.",
+        "targetFiles": [
+          "src/Dashboard.tsx"
+        ],
+        "replacement": "lodash-es"
+      },
       "evidence": [
         {
           "kind": "source-file",
@@ -200,6 +264,14 @@
       "findingId": "tree-shaking:react-icons-root-import",
       "analysisSource": "source-import",
       "confidence": "high",
+      "actionPriority": 8,
+      "recommendedFix": {
+        "kind": "narrow-import",
+        "title": "Import from the specific icon pack path instead.",
+        "targetFiles": [
+          "src/Dashboard.tsx"
+        ]
+      },
       "evidence": [
         {
           "kind": "source-file",


### PR DESCRIPTION
## 배경
- Phase 3의 남은 core slice인 PR-FIT-006A를 구현했습니다.
- optimize reporter 채택 전에 재사용 가능한 action ranking engine과 additive finding metadata를 먼저 고정하는 단계입니다.

## 변경 사항
- legolas-core에 action ranking helper를 추가했습니다.
- savings > confidence > difficulty 순서의 tie-break 규칙을 테스트로 잠갔습니다.
- finding metadata에 optional actionPriority, recommendedFix 필드를 추가했습니다.
- findingId 기준 dedupe와 exact package intelligence replacement 연결을 검증하는 테스트를 추가했습니다.

## 검증
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p legolas-core --test action_plan
- cargo test --workspace

## 브랜치 / 워크트리
- branch: codex/action-ranking-engine
- worktree: /Users/pjw/workspace/legolas