### PR TITLE
feat: 텍스트 리포트 evidence 블록 추가

### DIFF
--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -1,4 +1,4 @@
-use legolas_core::{budget::BudgetEvaluation, Analysis};
+use legolas_core::{budget::BudgetEvaluation, Analysis, FindingEvidence, FindingMetadata};
 
 pub fn format_scan_report(analysis: &Analysis) -> String {
     let mut lines = Vec::new();
@@ -45,9 +45,13 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
             } else {
                 format!("imported in {} file(s)", item.imported_by.len())
             };
-            format!(
-                "- {} ({} KB): {} {}.",
-                item.name, item.estimated_kb, item.rationale, import_text
+            with_evidence(
+                format!(
+                    "- {} ({} KB): {} {}.",
+                    item.name, item.estimated_kb, item.rationale, import_text
+                ),
+                &item.finding,
+                "  ",
             )
         },
         "- none",
@@ -59,11 +63,15 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
         &mut lines,
         &analysis.duplicate_packages,
         |item, _| {
-            format!(
-                "- {}: {} ({} KB avoidable)",
-                item.name,
-                item.versions.join(", "),
-                item.estimated_extra_kb
+            with_evidence(
+                format!(
+                    "- {}: {} ({} KB avoidable)",
+                    item.name,
+                    item.versions.join(", "),
+                    item.estimated_extra_kb
+                ),
+                &item.finding,
+                "  ",
             )
         },
         "- none",
@@ -75,9 +83,13 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
         &mut lines,
         &analysis.lazy_load_candidates,
         |item, _| {
-            format!(
-                "- {}: {}. Estimated win {} KB.",
-                item.name, item.reason, item.estimated_savings_kb
+            with_evidence(
+                format!(
+                    "- {}: {}. Estimated win {} KB.",
+                    item.name, item.reason, item.estimated_savings_kb
+                ),
+                &item.finding,
+                "  ",
             )
         },
         "- none",
@@ -88,7 +100,13 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
     append_section(
         &mut lines,
         &analysis.tree_shaking_warnings,
-        |item, _| format!("- {}: {}", item.package_name, item.message),
+        |item, _| {
+            with_evidence(
+                format!("- {}: {}", item.package_name, item.message),
+                &item.finding,
+                "  ",
+            )
+        },
         "- none",
     );
 
@@ -183,7 +201,10 @@ pub fn format_optimize_report(analysis: &Analysis, top: usize) -> String {
     append_section(
         &mut lines,
         &actions,
-        |item, index| format!("{}. {}", index + 1, item),
+        |item, index| match item.evidence.as_deref() {
+            Some(evidence) => format!("{}. {}\n   evidence: {}", index + 1, item.summary, evidence),
+            None => format!("{}. {}", index + 1, item.summary),
+        },
         "1. No high-confidence optimization candidates were found.",
     );
     lines.push(String::new());
@@ -256,31 +277,43 @@ struct BarItem {
     value: usize,
 }
 
-fn build_actions(analysis: &Analysis) -> Vec<String> {
+#[derive(Clone)]
+struct ActionLine {
+    summary: String,
+    evidence: Option<String>,
+}
+
+fn build_actions(analysis: &Analysis) -> Vec<ActionLine> {
     let mut actions = Vec::new();
 
     for dependency in analysis.heavy_dependencies.iter().take(3) {
         if dependency.imported_by.is_empty() {
-            actions.push(format!(
-                "Remove or justify {}; it is declared but not imported in scanned source files.",
-                dependency.name
-            ));
+            actions.push(ActionLine {
+                summary: format!(
+                    "Remove or justify {}; it is declared but not imported in scanned source files.",
+                    dependency.name
+                ),
+                evidence: first_evidence_line(&dependency.finding),
+            });
             continue;
         }
 
-        actions.push(format!(
-            "Review {}: {}",
-            dependency.name, dependency.recommendation
-        ));
+        actions.push(ActionLine {
+            summary: format!("Review {}: {}", dependency.name, dependency.recommendation),
+            evidence: first_evidence_line(&dependency.finding),
+        });
     }
 
     for duplicate in analysis.duplicate_packages.iter().take(3) {
-        actions.push(format!(
-            "Deduplicate {} versions ({}) to recover roughly {} KB.",
-            duplicate.name,
-            duplicate.versions.join(", "),
-            duplicate.estimated_extra_kb
-        ));
+        actions.push(ActionLine {
+            summary: format!(
+                "Deduplicate {} versions ({}) to recover roughly {} KB.",
+                duplicate.name,
+                duplicate.versions.join(", "),
+                duplicate.estimated_extra_kb
+            ),
+            evidence: first_evidence_line(&duplicate.finding),
+        });
     }
 
     for candidate in analysis.lazy_load_candidates.iter().take(3) {
@@ -289,20 +322,26 @@ fn build_actions(analysis: &Analysis) -> Vec<String> {
             .first()
             .map(String::as_str)
             .unwrap_or("undefined");
-        actions.push(format!(
-            "Lazy load {} in {} to target roughly {} KB of deferred code.",
-            candidate.name, file, candidate.estimated_savings_kb
-        ));
+        actions.push(ActionLine {
+            summary: format!(
+                "Lazy load {} in {} to target roughly {} KB of deferred code.",
+                candidate.name, file, candidate.estimated_savings_kb
+            ),
+            evidence: first_evidence_line(&candidate.finding),
+        });
     }
 
     for warning in analysis.tree_shaking_warnings.iter().take(2) {
-        actions.push(format!(
-            "Clean up {} imports: {}",
-            warning.package_name, warning.recommendation
-        ));
+        actions.push(ActionLine {
+            summary: format!(
+                "Clean up {} imports: {}",
+                warning.package_name, warning.recommendation
+            ),
+            evidence: first_evidence_line(&warning.finding),
+        });
     }
 
-    dedupe(actions)
+    dedupe_actions(actions)
 }
 
 fn render_bars(items: Vec<BarItem>) -> String {
@@ -342,16 +381,50 @@ where
     }
 }
 
-fn dedupe(items: Vec<String>) -> Vec<String> {
+fn dedupe_actions(items: Vec<ActionLine>) -> Vec<ActionLine> {
     let mut deduped = Vec::new();
 
     for item in items {
-        if !deduped.contains(&item) {
+        if !deduped
+            .iter()
+            .any(|existing: &ActionLine| existing.summary == item.summary)
+        {
             deduped.push(item);
         }
     }
 
     deduped
+}
+
+fn with_evidence(summary: String, finding: &FindingMetadata, indent: &str) -> String {
+    match first_evidence_line(finding) {
+        Some(evidence) => format!("{summary}\n{indent}evidence: {evidence}"),
+        None => summary,
+    }
+}
+
+fn first_evidence_line(finding: &FindingMetadata) -> Option<String> {
+    finding.evidence.first().map(format_evidence)
+}
+
+fn format_evidence(evidence: &FindingEvidence) -> String {
+    let mut parts = Vec::new();
+
+    if let Some(file) = evidence.file.as_deref() {
+        parts.push(file.to_string());
+    }
+    if let Some(specifier) = evidence.specifier.as_deref() {
+        parts.push(format!("specifier: {specifier}"));
+    }
+    if let Some(detail) = evidence.detail.as_deref() {
+        parts.push(detail.to_string());
+    }
+
+    if parts.is_empty() {
+        evidence.kind.clone()
+    } else {
+        parts.join(" | ")
+    }
 }
 
 fn append_warnings(lines: &mut Vec<String>, warnings: &[String]) {

--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -4,8 +4,8 @@ use legolas_cli::reporters::text::{
     format_optimize_report, format_scan_report, format_visualization_report,
 };
 use legolas_core::{
-    Analysis, DuplicatePackage, HeavyDependency, Impact, LazyLoadCandidate, Metadata,
-    PackageSummary, SourceSummary,
+    Analysis, DuplicatePackage, FindingAnalysisSource, FindingEvidence, FindingMetadata,
+    HeavyDependency, Impact, LazyLoadCandidate, Metadata, PackageSummary, SourceSummary,
 };
 
 fn load_analysis() -> Analysis {
@@ -29,6 +29,70 @@ fn matches_scan_visualize_and_optimize_oracles() {
         format_optimize_report(&analysis, 5),
         "basic-app/optimize.txt",
     );
+}
+
+#[test]
+fn scan_and_optimize_reports_render_compact_evidence_lines() {
+    let analysis = load_analysis();
+
+    let scan = format_scan_report(&analysis);
+    assert!(scan.contains(
+        "  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens."
+    ));
+    assert!(
+        scan.contains("  evidence: src/Dashboard.tsx | specifier: lodash | root package import")
+    );
+
+    let optimize = format_optimize_report(&analysis, 5);
+    assert!(optimize.contains(
+        "1. Review chart.js: Register only the chart primitives you use and lazy load dashboard surfaces.\n   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens."
+    ));
+    assert!(optimize.contains(
+        "5. Lazy load chart.js in src/Dashboard.tsx to target roughly 120 KB of deferred code.\n   evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword"
+    ));
+}
+
+#[test]
+fn scan_and_optimize_reports_only_render_the_first_evidence_line_per_finding() {
+    let mut analysis = base_analysis("multi-evidence-app");
+    analysis.heavy_dependencies = vec![HeavyDependency {
+        name: "chart.js".to_string(),
+        estimated_kb: 160,
+        rationale: "Charting code is often only needed on a subset of screens.".to_string(),
+        recommendation:
+            "Register only the chart primitives you use and lazy load dashboard surfaces."
+                .to_string(),
+        imported_by: vec!["src/Admin.tsx".to_string(), "src/Reports.tsx".to_string()],
+        finding: FindingMetadata::new(
+            "heavy-dependency:chart.js",
+            FindingAnalysisSource::SourceImport,
+        )
+        .with_evidence([
+            FindingEvidence::new("source-file")
+                .with_file("src/Admin.tsx")
+                .with_specifier("chart.js")
+                .with_detail("first evidence detail"),
+            FindingEvidence::new("source-file")
+                .with_file("src/Reports.tsx")
+                .with_specifier("chart.js")
+                .with_detail("second evidence detail"),
+        ]),
+        ..HeavyDependency::default()
+    }];
+
+    let scan = format_scan_report(&analysis);
+    assert!(
+        scan.contains("  evidence: src/Admin.tsx | specifier: chart.js | first evidence detail")
+    );
+    assert!(!scan.contains("second evidence detail"));
+
+    let optimize = format_optimize_report(&analysis, 1);
+    assert!(
+        optimize.contains(
+            "1. Review chart.js: Register only the chart primitives you use and lazy load dashboard surfaces.\n   evidence: src/Admin.tsx | specifier: chart.js | first evidence detail"
+        )
+    );
+    assert!(!optimize.contains("second evidence detail"));
 }
 
 #[test]

--- a/crates/legolas-core/tests/analyze_parity.rs
+++ b/crates/legolas-core/tests/analyze_parity.rs
@@ -22,6 +22,55 @@ fn analyze_project_matches_the_parity_oracle() {
 }
 
 #[test]
+fn analyze_project_emits_relative_evidence_blocks_in_parity_fixture() {
+    let analysis = analyze_project(support::fixture_path("tests/fixtures/parity/basic-app"))
+        .expect("analyze parity fixture");
+
+    let heavy = analysis
+        .heavy_dependencies
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js heavy dependency");
+    let heavy_evidence = heavy.finding.evidence.first().expect("heavy evidence");
+    assert_eq!(heavy_evidence.file.as_deref(), Some("src/Dashboard.tsx"));
+    assert_eq!(heavy_evidence.specifier.as_deref(), Some("chart.js"));
+    assert_eq!(
+        heavy_evidence.detail.as_deref(),
+        Some("static import; Charting code is often only needed on a subset of screens.")
+    );
+
+    let lazy = analysis
+        .lazy_load_candidates
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js lazy-load candidate");
+    let lazy_evidence = lazy.finding.evidence.first().expect("lazy-load evidence");
+    assert_eq!(lazy_evidence.file.as_deref(), Some("src/Dashboard.tsx"));
+    assert_eq!(lazy_evidence.specifier.as_deref(), Some("chart.js"));
+    assert_eq!(
+        lazy_evidence.detail.as_deref(),
+        Some("route-like UI surface matched `dashboard` keyword")
+    );
+
+    let warning = analysis
+        .tree_shaking_warnings
+        .iter()
+        .find(|item| item.key == "lodash-root-import")
+        .expect("lodash tree-shaking warning");
+    let warning_evidence = warning
+        .finding
+        .evidence
+        .first()
+        .expect("tree-shaking evidence");
+    assert_eq!(warning_evidence.file.as_deref(), Some("src/Dashboard.tsx"));
+    assert_eq!(warning_evidence.specifier.as_deref(), Some("lodash"));
+    assert_eq!(
+        warning_evidence.detail.as_deref(),
+        Some("root package import")
+    );
+}
+
+#[test]
 fn analyze_project_switches_to_artifact_assisted_mode_only_for_real_files() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();

--- a/tests/oracles/basic-app/optimize.txt
+++ b/tests/oracles/basic-app/optimize.txt
@@ -1,9 +1,13 @@
 Legolas optimize for basic-parity-app
 
 1. Review chart.js: Register only the chart primitives you use and lazy load dashboard surfaces.
+   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
 2. Review react-icons: Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
+   evidence: src/Dashboard.tsx | specifier: react-icons | static import; Wide icon-pack imports can defeat tree shaking.
 3. Review lodash: Use per-method imports or switch to lodash-es when the toolchain supports it.
+   evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
 4. Deduplicate lodash versions (4.17.20, 4.17.21) to recover roughly 18 KB.
 5. Lazy load chart.js in src/Dashboard.tsx to target roughly 120 KB of deferred code.
+   evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
 
 Projected savings: ~366 KB, with directional confidence.

--- a/tests/oracles/basic-app/scan.txt
+++ b/tests/oracles/basic-app/scan.txt
@@ -11,20 +11,28 @@ High impact: the project has clear opportunities to reduce initial payload size.
 
 Heaviest known dependencies:
 - chart.js (160 KB): Charting code is often only needed on a subset of screens. imported in 1 file(s).
+  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
 - react-icons (90 KB): Wide icon-pack imports can defeat tree shaking. imported in 1 file(s).
+  evidence: src/Dashboard.tsx | specifier: react-icons | static import; Wide icon-pack imports can defeat tree shaking.
 - lodash (72 KB): Root lodash imports are a classic source of tree-shaking misses. imported in 1 file(s).
+  evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
 
 Duplicate package versions:
 - lodash: 4.17.20, 4.17.21 (18 KB avoidable)
 
 Lazy-load candidates:
 - chart.js: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB.
+  evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
 - react-icons: react-icons is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 68 KB.
+  evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
 - lodash: lodash is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 54 KB.
+  evidence: src/Dashboard.tsx | specifier: lodash | route-like UI surface matched `dashboard` keyword
 
 Tree-shaking warnings:
 - lodash: Root lodash imports often keep more code than expected in client bundles.
+  evidence: src/Dashboard.tsx | specifier: lodash | root package import
 - react-icons: Root react-icons imports can make tree shaking unreliable.
+  evidence: src/Dashboard.tsx | specifier: react-icons | root package import
 
 Unused dependency candidates:
 - none


### PR DESCRIPTION
## 요약
- scan/optimize text report에 첫 evidence line을 compact하게 노출합니다
- parity fixture 기준 evidence shape를 추가 회귀 테스트로 고정합니다
- basic-app scan/optimize text oracle을 evidence 포함 형태로 갱신합니다

## 검증
- cargo test -p legolas-cli --test text_report_parity
- cargo test -p legolas-core --test analyze_parity
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app
- cargo run -p legolas-cli -- optimize tests/fixtures/parity/basic-app --top 5