### PR TITLE
feat: budget/ci confidence contract 적용

### DIFF
--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -51,8 +51,12 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
             };
             with_evidence(
                 format!(
-                    "- {} ({} KB): {} {}.",
-                    item.name, item.estimated_kb, item.rationale, import_text
+                    "- {} ({} KB){}: {} {}.",
+                    item.name,
+                    item.estimated_kb,
+                    confidence_bracket(&item.finding),
+                    item.rationale,
+                    import_text
                 ),
                 &item.finding,
                 "  ",
@@ -69,8 +73,9 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
         |item, _| {
             with_evidence(
                 format!(
-                    "- {}: {} ({} KB avoidable)",
+                    "- {}{}: {} ({} KB avoidable)",
                     item.name,
+                    confidence_bracket(&item.finding),
                     item.versions.join(", "),
                     item.estimated_extra_kb
                 ),
@@ -89,8 +94,11 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
         |item, _| {
             with_evidence(
                 format!(
-                    "- {}: {}. Estimated win {} KB.",
-                    item.name, item.reason, item.estimated_savings_kb
+                    "- {}{}: {}. Estimated win {} KB.",
+                    item.name,
+                    confidence_bracket(&item.finding),
+                    item.reason,
+                    item.estimated_savings_kb
                 ),
                 &item.finding,
                 "  ",
@@ -106,7 +114,12 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
         &analysis.tree_shaking_warnings,
         |item, _| {
             with_evidence(
-                format!("- {}: {}", item.package_name, item.message),
+                format!(
+                    "- {}{}: {}",
+                    item.package_name,
+                    confidence_bracket(&item.finding),
+                    item.message
+                ),
                 &item.finding,
                 "  ",
             )
@@ -443,6 +456,13 @@ fn with_evidence(summary: String, finding: &FindingMetadata, indent: &str) -> St
     }
 }
 
+fn confidence_bracket(finding: &FindingMetadata) -> String {
+    finding
+        .confidence
+        .map(|confidence| format!(" [{}]", confidence_phrase(confidence)))
+        .unwrap_or_default()
+}
+
 #[derive(Clone)]
 struct ActionContext {
     headline: String,
@@ -523,6 +543,18 @@ fn difficulty_label(difficulty: ActionDifficulty) -> &'static str {
 }
 
 fn confidence_label(confidence: FindingConfidence) -> &'static str {
+    confidence_display(confidence)
+}
+
+fn confidence_phrase(confidence: FindingConfidence) -> &'static str {
+    match confidence {
+        FindingConfidence::Low => "low confidence",
+        FindingConfidence::Medium => "medium confidence",
+        FindingConfidence::High => "high confidence",
+    }
+}
+
+fn confidence_display(confidence: FindingConfidence) -> &'static str {
     match confidence {
         FindingConfidence::Low => "low",
         FindingConfidence::Medium => "medium",

--- a/crates/legolas-cli/tests/budget_contract.rs
+++ b/crates/legolas-cli/tests/budget_contract.rs
@@ -35,6 +35,52 @@ fn normalize(value: &str) -> String {
     value.replace('\\', "/")
 }
 
+fn triggered_finding(
+    finding_id: &str,
+    analysis_source: &str,
+    confidence: &str,
+) -> serde_json::Value {
+    json!({
+        "findingId": finding_id,
+        "analysisSource": analysis_source,
+        "confidence": confidence
+    })
+}
+
+fn potential_kb_saved_findings() -> Vec<serde_json::Value> {
+    vec![
+        triggered_finding("heavy-dependency:chart.js", "source-import", "high"),
+        triggered_finding("heavy-dependency:react-icons", "source-import", "high"),
+        triggered_finding("heavy-dependency:lodash", "source-import", "high"),
+        triggered_finding("duplicate-package:lodash", "lockfile-trace", "high"),
+        triggered_finding("lazy-load:chart.js", "heuristic", "medium"),
+        triggered_finding("lazy-load:react-icons", "heuristic", "medium"),
+        triggered_finding("lazy-load:lodash", "heuristic", "medium"),
+        triggered_finding("tree-shaking:lodash-root-import", "source-import", "high"),
+        triggered_finding(
+            "tree-shaking:react-icons-root-import",
+            "source-import",
+            "high",
+        ),
+    ]
+}
+
+fn duplicate_findings() -> Vec<serde_json::Value> {
+    vec![triggered_finding(
+        "duplicate-package:lodash",
+        "lockfile-trace",
+        "high",
+    )]
+}
+
+fn dynamic_import_findings() -> Vec<serde_json::Value> {
+    vec![
+        triggered_finding("lazy-load:chart.js", "heuristic", "medium"),
+        triggered_finding("lazy-load:react-icons", "heuristic", "medium"),
+        triggered_finding("lazy-load:lodash", "heuristic", "medium"),
+    ]
+}
+
 #[test]
 fn budget_text_output_uses_built_in_starter_thresholds() {
     let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
@@ -73,21 +119,24 @@ fn budget_json_output_has_a_stable_shape() {
                     "actual": 366,
                     "warnAt": 40,
                     "failAt": 80,
-                    "status": "Fail"
+                    "status": "Fail",
+                    "triggeredFindings": potential_kb_saved_findings()
                 },
                 {
                     "key": "duplicatePackageCount",
                     "actual": 1,
                     "warnAt": 2,
                     "failAt": 4,
-                    "status": "Pass"
+                    "status": "Pass",
+                    "triggeredFindings": []
                 },
                 {
                     "key": "dynamicImportCount",
                     "actual": 0,
                     "warnAt": 1,
                     "failAt": 0,
-                    "status": "Fail"
+                    "status": "Fail",
+                    "triggeredFindings": dynamic_import_findings()
                 }
             ]
         })
@@ -136,21 +185,24 @@ fn budget_uses_config_threshold_overrides_and_starter_fallbacks_together() {
                     "actual": 366,
                     "warnAt": 400,
                     "failAt": 500,
-                    "status": "Pass"
+                    "status": "Pass",
+                    "triggeredFindings": []
                 },
                 {
                     "key": "duplicatePackageCount",
                     "actual": 1,
                     "warnAt": 1,
                     "failAt": 2,
-                    "status": "Warn"
+                    "status": "Warn",
+                    "triggeredFindings": duplicate_findings()
                 },
                 {
                     "key": "dynamicImportCount",
                     "actual": 0,
                     "warnAt": 1,
                     "failAt": 0,
-                    "status": "Fail"
+                    "status": "Fail",
+                    "triggeredFindings": dynamic_import_findings()
                 }
             ]
         })
@@ -199,21 +251,24 @@ fn budget_uses_discovered_config_from_project_root() {
                     "actual": 366,
                     "warnAt": 40,
                     "failAt": 80,
-                    "status": "Fail"
+                    "status": "Fail",
+                    "triggeredFindings": potential_kb_saved_findings()
                 },
                 {
                     "key": "duplicatePackageCount",
                     "actual": 1,
                     "warnAt": 2,
                     "failAt": 4,
-                    "status": "Pass"
+                    "status": "Pass",
+                    "triggeredFindings": []
                 },
                 {
                     "key": "dynamicImportCount",
                     "actual": 0,
                     "warnAt": 1,
                     "failAt": 0,
-                    "status": "Fail"
+                    "status": "Fail",
+                    "triggeredFindings": dynamic_import_findings()
                 }
             ]
         })

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -35,6 +35,44 @@ fn normalize(value: &str) -> String {
     value.replace('\\', "/")
 }
 
+fn triggered_finding(
+    finding_id: &str,
+    analysis_source: &str,
+    confidence: &str,
+) -> serde_json::Value {
+    json!({
+        "findingId": finding_id,
+        "analysisSource": analysis_source,
+        "confidence": confidence
+    })
+}
+
+fn potential_kb_saved_findings() -> Vec<serde_json::Value> {
+    vec![
+        triggered_finding("heavy-dependency:chart.js", "source-import", "high"),
+        triggered_finding("heavy-dependency:react-icons", "source-import", "high"),
+        triggered_finding("heavy-dependency:lodash", "source-import", "high"),
+        triggered_finding("duplicate-package:lodash", "lockfile-trace", "high"),
+        triggered_finding("lazy-load:chart.js", "heuristic", "medium"),
+        triggered_finding("lazy-load:react-icons", "heuristic", "medium"),
+        triggered_finding("lazy-load:lodash", "heuristic", "medium"),
+        triggered_finding("tree-shaking:lodash-root-import", "source-import", "high"),
+        triggered_finding(
+            "tree-shaking:react-icons-root-import",
+            "source-import",
+            "high",
+        ),
+    ]
+}
+
+fn dynamic_import_findings() -> Vec<serde_json::Value> {
+    vec![
+        triggered_finding("lazy-load:chart.js", "heuristic", "medium"),
+        triggered_finding("lazy-load:react-icons", "heuristic", "medium"),
+        triggered_finding("lazy-load:lodash", "heuristic", "medium"),
+    ]
+}
+
 #[test]
 fn ci_fail_returns_exit_code_one_and_fixed_failure_prefix() {
     let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
@@ -114,21 +152,24 @@ fn ci_json_output_uses_machine_readable_gate_shape() {
                     "actual": 366,
                     "warnAt": 40,
                     "failAt": 80,
-                    "status": "Fail"
+                    "status": "Fail",
+                    "triggeredFindings": potential_kb_saved_findings()
                 },
                 {
                     "key": "duplicatePackageCount",
                     "actual": 1,
                     "warnAt": 2,
                     "failAt": 4,
-                    "status": "Pass"
+                    "status": "Pass",
+                    "triggeredFindings": []
                 },
                 {
                     "key": "dynamicImportCount",
                     "actual": 0,
                     "warnAt": 1,
                     "failAt": 0,
-                    "status": "Fail"
+                    "status": "Fail",
+                    "triggeredFindings": dynamic_import_findings()
                 }
             ]
         })

--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -37,6 +37,12 @@ fn scan_and_optimize_reports_render_compact_evidence_lines() {
 
     let scan = format_scan_report(&analysis);
     assert!(scan.contains(
+        "- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s)."
+    ));
+    assert!(scan.contains(
+        "- chart.js [medium confidence]: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB."
+    ));
+    assert!(scan.contains(
         "  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens."
     ));
     assert!(

--- a/crates/legolas-core/src/budget.rs
+++ b/crates/legolas-core/src/budget.rs
@@ -1,7 +1,10 @@
+use std::collections::BTreeSet;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
     config::{BudgetRules, BudgetThresholds},
+    findings::{FindingAnalysisSource, FindingConfidence, FindingMetadata},
     models::Analysis,
 };
 
@@ -25,6 +28,7 @@ pub struct BudgetRuleResult {
     pub warn_at: usize,
     pub fail_at: usize,
     pub status: BudgetStatus,
+    pub triggered_findings: Vec<TriggeredFinding>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -32,6 +36,14 @@ pub struct BudgetRuleResult {
 pub struct BudgetEvaluation {
     pub overall_status: BudgetStatus,
     pub rules: Vec<BudgetRuleResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TriggeredFinding {
+    pub finding_id: String,
+    pub analysis_source: FindingAnalysisSource,
+    pub confidence: FindingConfidence,
 }
 
 impl BudgetEvaluation {
@@ -50,6 +62,25 @@ pub fn evaluate_budget(analysis: &Analysis, overrides: Option<&BudgetRules>) -> 
                 .potential_kb_saved
                 .as_ref()
                 .expect("starter rule exists"),
+            collect_triggered_findings(
+                analysis
+                    .heavy_dependencies
+                    .iter()
+                    .map(|item| &item.finding)
+                    .chain(analysis.duplicate_packages.iter().map(|item| &item.finding))
+                    .chain(
+                        analysis
+                            .lazy_load_candidates
+                            .iter()
+                            .map(|item| &item.finding),
+                    )
+                    .chain(
+                        analysis
+                            .tree_shaking_warnings
+                            .iter()
+                            .map(|item| &item.finding),
+                    ),
+            ),
         ),
         evaluate_max_rule(
             DUPLICATE_PACKAGE_COUNT_KEY,
@@ -58,6 +89,9 @@ pub fn evaluate_budget(analysis: &Analysis, overrides: Option<&BudgetRules>) -> 
                 .duplicate_package_count
                 .as_ref()
                 .expect("starter rule exists"),
+            collect_triggered_findings(
+                analysis.duplicate_packages.iter().map(|item| &item.finding),
+            ),
         ),
         evaluate_min_rule(
             DYNAMIC_IMPORT_COUNT_KEY,
@@ -66,6 +100,12 @@ pub fn evaluate_budget(analysis: &Analysis, overrides: Option<&BudgetRules>) -> 
                 .dynamic_import_count
                 .as_ref()
                 .expect("starter rule exists"),
+            collect_triggered_findings(
+                analysis
+                    .lazy_load_candidates
+                    .iter()
+                    .map(|item| &item.finding),
+            ),
         ),
     ];
     let overall_status = results
@@ -86,24 +126,78 @@ fn resolved_rules(overrides: Option<&BudgetRules>) -> BudgetRules {
         .unwrap_or_else(BudgetRules::starter_defaults)
 }
 
-fn evaluate_max_rule(key: &str, actual: usize, thresholds: &BudgetThresholds) -> BudgetRuleResult {
+fn evaluate_max_rule(
+    key: &str,
+    actual: usize,
+    thresholds: &BudgetThresholds,
+    triggered_findings: Vec<TriggeredFinding>,
+) -> BudgetRuleResult {
+    let status = evaluate_max_status(actual, thresholds);
+
     BudgetRuleResult {
         key: key.to_string(),
         actual,
         warn_at: thresholds.warn_at,
         fail_at: thresholds.fail_at,
-        status: evaluate_max_status(actual, thresholds),
+        triggered_findings: triggered_findings_for_status(status, triggered_findings),
+        status,
     }
 }
 
-fn evaluate_min_rule(key: &str, actual: usize, thresholds: &BudgetThresholds) -> BudgetRuleResult {
+fn evaluate_min_rule(
+    key: &str,
+    actual: usize,
+    thresholds: &BudgetThresholds,
+    triggered_findings: Vec<TriggeredFinding>,
+) -> BudgetRuleResult {
+    let status = evaluate_min_status(actual, thresholds);
+
     BudgetRuleResult {
         key: key.to_string(),
         actual,
         warn_at: thresholds.warn_at,
         fail_at: thresholds.fail_at,
-        status: evaluate_min_status(actual, thresholds),
+        triggered_findings: triggered_findings_for_status(status, triggered_findings),
+        status,
     }
+}
+
+fn triggered_findings_for_status(
+    status: BudgetStatus,
+    triggered_findings: Vec<TriggeredFinding>,
+) -> Vec<TriggeredFinding> {
+    match status {
+        BudgetStatus::Pass => Vec::new(),
+        BudgetStatus::Warn | BudgetStatus::Fail => triggered_findings,
+    }
+}
+
+fn collect_triggered_findings<'a, I>(findings: I) -> Vec<TriggeredFinding>
+where
+    I: IntoIterator<Item = &'a FindingMetadata>,
+{
+    let mut seen = BTreeSet::new();
+    let mut collected = Vec::new();
+
+    for finding in findings {
+        let Some(triggered_finding) = triggered_finding_from_metadata(finding) else {
+            continue;
+        };
+
+        if seen.insert(triggered_finding.finding_id.clone()) {
+            collected.push(triggered_finding);
+        }
+    }
+
+    collected
+}
+
+fn triggered_finding_from_metadata(finding: &FindingMetadata) -> Option<TriggeredFinding> {
+    Some(TriggeredFinding {
+        finding_id: finding.finding_id.clone()?,
+        analysis_source: finding.analysis_source?,
+        confidence: finding.confidence?,
+    })
 }
 
 fn evaluate_max_status(actual: usize, thresholds: &BudgetThresholds) -> BudgetStatus {

--- a/tests/oracles/basic-app/scan.txt
+++ b/tests/oracles/basic-app/scan.txt
@@ -10,28 +10,28 @@ Estimated LCP improvement: ~769 ms
 High impact: the project has clear opportunities to reduce initial payload size.
 
 Heaviest known dependencies:
-- chart.js (160 KB): Charting code is often only needed on a subset of screens. imported in 1 file(s).
+- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s).
   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
-- react-icons (90 KB): Wide icon-pack imports can defeat tree shaking. imported in 1 file(s).
+- react-icons (90 KB) [high confidence]: Wide icon-pack imports can defeat tree shaking. imported in 1 file(s).
   evidence: src/Dashboard.tsx | specifier: react-icons | static import; Wide icon-pack imports can defeat tree shaking.
-- lodash (72 KB): Root lodash imports are a classic source of tree-shaking misses. imported in 1 file(s).
+- lodash (72 KB) [high confidence]: Root lodash imports are a classic source of tree-shaking misses. imported in 1 file(s).
   evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
 
 Duplicate package versions:
-- lodash: 4.17.20, 4.17.21 (18 KB avoidable)
+- lodash [high confidence]: 4.17.20, 4.17.21 (18 KB avoidable)
 
 Lazy-load candidates:
-- chart.js: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB.
+- chart.js [medium confidence]: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB.
   evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
-- react-icons: react-icons is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 68 KB.
+- react-icons [medium confidence]: react-icons is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 68 KB.
   evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
-- lodash: lodash is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 54 KB.
+- lodash [medium confidence]: lodash is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 54 KB.
   evidence: src/Dashboard.tsx | specifier: lodash | route-like UI surface matched `dashboard` keyword
 
 Tree-shaking warnings:
-- lodash: Root lodash imports often keep more code than expected in client bundles.
+- lodash [high confidence]: Root lodash imports often keep more code than expected in client bundles.
   evidence: src/Dashboard.tsx | specifier: lodash | root package import
-- react-icons: Root react-icons imports can make tree shaking unreliable.
+- react-icons [high confidence]: Root react-icons imports can make tree shaking unreliable.
   evidence: src/Dashboard.tsx | specifier: react-icons | root package import
 
 Unused dependency candidates:


### PR DESCRIPTION
배경
- Phase 4 PR-FIT-002B를 진행했습니다.
- budget, ci, scan surface에서 finding confidence vocabulary를 같은 계약으로 노출합니다.

변경 사항
- budget rule 결과에 additive triggeredFindings 배열을 추가했습니다.
- ci --json도 동일한 rule payload를 재사용하도록 맞췄습니다.
- scan 텍스트 finding line에 high confidence, medium confidence 문구를 직접 노출합니다.
- 관련 CLI 계약 테스트와 scan oracle을 갱신했습니다.

검증
- cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app
- cargo run -p legolas-cli -- budget tests/fixtures/parity/basic-app --json
- cargo run -p legolas-cli -- ci tests/fixtures/parity/basic-app --json
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

브랜치 / 워크트리
- branch: codex/confidence-contract-adoption
- worktree: /Users/pjw/workspace/legolas