### PR TITLE
feat: artifact parser truth layer 추가

### DIFF
--- a/crates/legolas-core/src/artifacts/detect.rs
+++ b/crates/legolas-core/src/artifacts/detect.rs
@@ -1,1 +1,124 @@
-//! Placeholder parser namespace for upcoming generic artifact detection work.
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value;
+
+use crate::{
+    artifacts::{
+        esbuild::parse_esbuild_metafile, rollup::parse_rollup_metadata,
+        webpack::parse_webpack_stats, ArtifactSummary,
+    },
+    LegolasError, Result,
+};
+
+pub const KNOWN_ARTIFACT_FILES: [&str; 5] = [
+    "stats.json",
+    "dist/stats.json",
+    "build/stats.json",
+    "meta.json",
+    "dist/meta.json",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactParserKind {
+    Esbuild,
+    Rollup,
+    Webpack,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectedArtifact {
+    pub relative_path: String,
+    pub parser: ArtifactParserKind,
+}
+
+pub fn detect_known_artifacts(project_root: &Path) -> Result<Vec<DetectedArtifact>> {
+    let mut detected = Vec::new();
+
+    for relative_path in KNOWN_ARTIFACT_FILES {
+        let absolute_path = project_root.join(relative_path);
+        if !is_file(&absolute_path) {
+            continue;
+        }
+
+        let value = match read_json(&absolute_path) {
+            Ok(value) => value,
+            Err(LegolasError::JsonParse(_)) => continue,
+            Err(error) => return Err(error),
+        };
+        let Some(parser) = detect_parser_kind(&absolute_path, &value) else {
+            continue;
+        };
+
+        detected.push(DetectedArtifact {
+            relative_path: relative_path.to_string(),
+            parser,
+        });
+    }
+
+    Ok(detected)
+}
+
+pub fn parse_artifact_file(path: &Path) -> Result<ArtifactSummary> {
+    let value = read_json(path)?;
+    parse_artifact_value(path, &value)
+}
+
+pub fn parse_artifact_value(path: &Path, value: &Value) -> Result<ArtifactSummary> {
+    match detect_parser_kind(path, value) {
+        Some(ArtifactParserKind::Esbuild) => parse_esbuild_metafile(value),
+        Some(ArtifactParserKind::Rollup) => parse_rollup_metadata(value),
+        Some(ArtifactParserKind::Webpack) => parse_webpack_stats(value),
+        None => Err(LegolasError::NotImplemented(
+            "unsupported artifact file shape",
+        )),
+    }
+}
+
+pub fn detect_parser_kind(path: &Path, value: &Value) -> Option<ArtifactParserKind> {
+    let file_name = path.file_name()?.to_str()?;
+
+    if file_name.eq_ignore_ascii_case("stats.json") && looks_like_webpack_stats(value) {
+        return Some(ArtifactParserKind::Webpack);
+    }
+
+    if !file_name.eq_ignore_ascii_case("meta.json") {
+        return None;
+    }
+
+    if value.get("inputs").is_some() && value.get("outputs").is_some() {
+        return Some(ArtifactParserKind::Esbuild);
+    }
+
+    if value
+        .get("outputs")
+        .is_some_and(|outputs| outputs.is_array())
+    {
+        return Some(ArtifactParserKind::Rollup);
+    }
+
+    None
+}
+
+fn looks_like_webpack_stats(value: &Value) -> bool {
+    webpack_entrypoints(value).is_some() && value.get("chunks").is_some_and(Value::is_array)
+}
+
+fn webpack_entrypoints(value: &Value) -> Option<&serde_json::Map<String, Value>> {
+    value
+        .get("entryPoints")
+        .or_else(|| value.get("entrypoints"))
+        .and_then(Value::as_object)
+}
+
+fn is_file(path: &PathBuf) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file())
+        .unwrap_or(false)
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+}

--- a/crates/legolas-core/src/artifacts/esbuild.rs
+++ b/crates/legolas-core/src/artifacts/esbuild.rs
@@ -1,1 +1,101 @@
-//! Placeholder parser namespace for upcoming esbuild artifact parsing work.
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::{
+    artifacts::{
+        package_name_from_module_id, ArtifactChunk, ArtifactModuleContribution, ArtifactSummary,
+    },
+    LegolasError, Result,
+};
+
+pub fn parse_esbuild_metafile(value: &Value) -> Result<ArtifactSummary> {
+    let outputs =
+        value
+            .get("outputs")
+            .and_then(Value::as_object)
+            .ok_or(LegolasError::NotImplemented(
+                "unsupported artifact file shape",
+            ))?;
+
+    let mut summary = ArtifactSummary {
+        bundler: "esbuild".to_string(),
+        entrypoints: Vec::new(),
+        chunks: Vec::new(),
+        modules: Vec::new(),
+        total_bytes: 0,
+    };
+    let mut modules = BTreeMap::new();
+
+    for (output_path, output) in outputs {
+        if !is_supported_chunk_output(output_path, output) {
+            continue;
+        }
+
+        let bytes = output.get("bytes").and_then(Value::as_u64).unwrap_or(0) as usize;
+        let entry_point = output
+            .get("entryPoint")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        if let Some(entry_point) = entry_point.clone() {
+            summary.entrypoints.push(entry_point);
+        }
+
+        summary.total_bytes += bytes;
+        summary.chunks.push(ArtifactChunk {
+            name: chunk_name(output_path),
+            entrypoints: entry_point.into_iter().collect(),
+            files: vec![output_path.clone()],
+            initial: output.get("entryPoint").is_some(),
+            bytes,
+        });
+
+        let Some(inputs) = output.get("inputs").and_then(Value::as_object) else {
+            continue;
+        };
+
+        for (module_id, contribution) in inputs {
+            let bytes = contribution
+                .get("bytesInOutput")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as usize;
+            if bytes == 0 {
+                continue;
+            }
+
+            let entry =
+                modules
+                    .entry(module_id.clone())
+                    .or_insert_with(|| ArtifactModuleContribution {
+                        id: module_id.clone(),
+                        package_name: package_name_from_module_id(module_id),
+                        chunks: Vec::new(),
+                        bytes: 0,
+                    });
+            entry.chunks.push(chunk_name(output_path));
+            entry.bytes += bytes;
+        }
+    }
+
+    summary.modules = modules.into_values().collect();
+
+    Ok(summary.normalized())
+}
+
+fn chunk_name(output_path: &str) -> String {
+    std::path::Path::new(output_path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or(output_path)
+        .to_string()
+}
+
+fn is_supported_chunk_output(output_path: &str, output: &Value) -> bool {
+    output.get("inputs").is_some_and(Value::is_object)
+        && matches!(
+            std::path::Path::new(output_path)
+                .extension()
+                .and_then(|extension| extension.to_str()),
+            Some("js" | "mjs" | "cjs")
+        )
+}

--- a/crates/legolas-core/src/artifacts/mod.rs
+++ b/crates/legolas-core/src/artifacts/mod.rs
@@ -6,3 +6,17 @@ pub mod rollup;
 pub mod webpack;
 
 pub use models::{ArtifactChunk, ArtifactModuleContribution, ArtifactSummary};
+
+pub(crate) fn package_name_from_module_id(module_id: &str) -> Option<String> {
+    let normalized = module_id.replace('\\', "/");
+    let (_, package_path) = normalized.rsplit_once("node_modules/")?;
+    let mut segments = package_path
+        .split('/')
+        .filter(|segment| !segment.is_empty());
+    let first = segments.next()?;
+    if first.starts_with('@') {
+        Some(format!("{}/{}", first, segments.next()?))
+    } else {
+        Some(first.to_string())
+    }
+}

--- a/crates/legolas-core/src/artifacts/rollup.rs
+++ b/crates/legolas-core/src/artifacts/rollup.rs
@@ -1,1 +1,106 @@
-//! Placeholder parser namespace for upcoming Rollup/Vite artifact parsing work.
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::{
+    artifacts::{
+        package_name_from_module_id, ArtifactChunk, ArtifactModuleContribution, ArtifactSummary,
+    },
+    LegolasError, Result,
+};
+
+pub fn parse_rollup_metadata(value: &Value) -> Result<ArtifactSummary> {
+    let outputs =
+        value
+            .get("outputs")
+            .and_then(Value::as_array)
+            .ok_or(LegolasError::NotImplemented(
+                "unsupported artifact file shape",
+            ))?;
+
+    let mut summary = ArtifactSummary {
+        bundler: "rollup".to_string(),
+        entrypoints: Vec::new(),
+        chunks: Vec::new(),
+        modules: Vec::new(),
+        total_bytes: 0,
+    };
+    let mut modules_by_id = BTreeMap::new();
+
+    for output in outputs {
+        if output.get("type").and_then(Value::as_str) != Some("chunk") {
+            continue;
+        }
+
+        let name = output
+            .get("name")
+            .and_then(Value::as_str)
+            .or_else(|| output.get("file").and_then(Value::as_str))
+            .unwrap_or("chunk")
+            .to_string();
+        let file = output
+            .get("file")
+            .and_then(Value::as_str)
+            .unwrap_or("dist/chunk.js")
+            .to_string();
+        let is_entry = output
+            .get("isEntry")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if is_entry {
+            summary.entrypoints.push(name.clone());
+        }
+
+        let modules = output
+            .get("modules")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        let chunk_bytes = modules
+            .values()
+            .map(|module| {
+                module
+                    .get("renderedLength")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0)
+            })
+            .sum::<u64>() as usize;
+        summary.total_bytes += chunk_bytes;
+        summary.chunks.push(ArtifactChunk {
+            name: name.clone(),
+            entrypoints: is_entry.then_some(name.clone()).into_iter().collect(),
+            files: vec![file],
+            initial: output
+                .get("isDynamicEntry")
+                .and_then(Value::as_bool)
+                .map(|value| !value)
+                .unwrap_or(true),
+            bytes: chunk_bytes,
+        });
+
+        for (module_id, module) in modules {
+            let bytes = module
+                .get("renderedLength")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as usize;
+            if bytes == 0 {
+                continue;
+            }
+
+            let entry = modules_by_id.entry(module_id.clone()).or_insert_with(|| {
+                ArtifactModuleContribution {
+                    id: module_id.clone(),
+                    package_name: package_name_from_module_id(&module_id),
+                    chunks: Vec::new(),
+                    bytes: 0,
+                }
+            });
+            entry.chunks.push(name.clone());
+            entry.bytes += bytes;
+        }
+    }
+
+    summary.modules = modules_by_id.into_values().collect();
+
+    Ok(summary.normalized())
+}

--- a/crates/legolas-core/src/artifacts/webpack.rs
+++ b/crates/legolas-core/src/artifacts/webpack.rs
@@ -1,1 +1,130 @@
-//! Placeholder parser namespace for upcoming webpack artifact parsing work.
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::{
+    artifacts::{
+        package_name_from_module_id, ArtifactChunk, ArtifactModuleContribution, ArtifactSummary,
+    },
+    LegolasError, Result,
+};
+
+pub fn parse_webpack_stats(value: &Value) -> Result<ArtifactSummary> {
+    let entrypoints = value
+        .get("entryPoints")
+        .or_else(|| value.get("entrypoints"))
+        .and_then(Value::as_object)
+        .ok_or(LegolasError::NotImplemented(
+            "unsupported artifact file shape",
+        ))?;
+    let chunks =
+        value
+            .get("chunks")
+            .and_then(Value::as_array)
+            .ok_or(LegolasError::NotImplemented(
+                "unsupported artifact file shape",
+            ))?;
+
+    let mut entrypoint_assets = BTreeMap::new();
+    for (entry_name, entry_value) in entrypoints {
+        let assets = entry_value
+            .get("assets")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|asset| asset.get("name").and_then(Value::as_str))
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        entrypoint_assets.insert(entry_name.clone(), assets);
+    }
+
+    let mut summary = ArtifactSummary {
+        bundler: "webpack".to_string(),
+        entrypoints: entrypoint_assets.keys().cloned().collect(),
+        chunks: Vec::new(),
+        modules: Vec::new(),
+        total_bytes: 0,
+    };
+    let mut modules_by_id = BTreeMap::new();
+
+    for chunk in chunks {
+        let files = chunk
+            .get("files")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        let chunk_entrypoints = entrypoint_assets
+            .iter()
+            .filter(|(_, assets)| {
+                assets
+                    .iter()
+                    .any(|asset| files.iter().any(|file| file == asset))
+            })
+            .map(|(entry_name, _)| entry_name.clone())
+            .collect::<Vec<_>>();
+        let name = chunk
+            .get("names")
+            .and_then(Value::as_array)
+            .and_then(|names| names.first())
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| {
+                chunk
+                    .get("id")
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "chunk".to_string())
+            });
+        let bytes = chunk.get("size").and_then(Value::as_u64).unwrap_or(0) as usize;
+        summary.total_bytes += bytes;
+        summary.chunks.push(ArtifactChunk {
+            name: name.clone(),
+            entrypoints: chunk_entrypoints,
+            files,
+            initial: chunk
+                .get("initial")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            bytes,
+        });
+
+        let Some(modules) = chunk.get("modules").and_then(Value::as_array) else {
+            continue;
+        };
+
+        for module in modules {
+            let id = module
+                .get("identifier")
+                .or_else(|| module.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if id.is_empty() {
+                continue;
+            }
+
+            let bytes = module.get("size").and_then(Value::as_u64).unwrap_or(0) as usize;
+            if bytes == 0 {
+                continue;
+            }
+
+            let entry =
+                modules_by_id
+                    .entry(id.clone())
+                    .or_insert_with(|| ArtifactModuleContribution {
+                        id: id.clone(),
+                        package_name: package_name_from_module_id(&id),
+                        chunks: Vec::new(),
+                        bytes: 0,
+                    });
+            entry.chunks.push(name.clone());
+            entry.bytes += bytes;
+        }
+    }
+
+    summary.modules = modules_by_id.into_values().collect();
+
+    Ok(summary.normalized())
+}

--- a/crates/legolas-core/tests/artifact_parsers.rs
+++ b/crates/legolas-core/tests/artifact_parsers.rs
@@ -1,0 +1,413 @@
+mod support;
+
+use legolas_core::artifacts::detect::{
+    detect_known_artifacts, detect_parser_kind, parse_artifact_file, ArtifactParserKind,
+};
+use legolas_core::artifacts::{
+    esbuild::parse_esbuild_metafile, rollup::parse_rollup_metadata, webpack::parse_webpack_stats,
+};
+use serde_json::json;
+use tempfile::tempdir;
+
+#[test]
+fn detect_known_artifacts_routes_each_fixture_to_the_expected_parser() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root.join("dist/stats.json"),
+        support::fixture_path("tests/fixtures/artifacts/webpack-basic/stats.json"),
+    );
+    write_file(
+        root.join("dist/meta.json"),
+        support::fixture_path("tests/fixtures/artifacts/esbuild-basic/meta.json"),
+    );
+    write_file(
+        root.join("meta.json"),
+        support::fixture_path("tests/fixtures/artifacts/vite-basic/meta.json"),
+    );
+
+    let actual = detect_known_artifacts(root).expect("detect artifacts");
+
+    assert_eq!(
+        actual,
+        vec![
+            legolas_core::artifacts::detect::DetectedArtifact {
+                relative_path: "dist/stats.json".to_string(),
+                parser: ArtifactParserKind::Webpack,
+            },
+            legolas_core::artifacts::detect::DetectedArtifact {
+                relative_path: "meta.json".to_string(),
+                parser: ArtifactParserKind::Rollup,
+            },
+            legolas_core::artifacts::detect::DetectedArtifact {
+                relative_path: "dist/meta.json".to_string(),
+                parser: ArtifactParserKind::Esbuild,
+            },
+        ]
+    );
+}
+
+#[test]
+fn parse_artifact_file_reads_esbuild_fixture() {
+    let summary = parse_artifact_file(&support::fixture_path(
+        "tests/fixtures/artifacts/esbuild-basic/meta.json",
+    ))
+    .expect("parse esbuild artifact");
+
+    assert_eq!(summary.bundler, "esbuild");
+    assert_eq!(summary.entrypoints, vec!["src/main.ts".to_string()]);
+    assert_eq!(summary.total_bytes, 13_200);
+    assert_eq!(summary.chunks.len(), 2);
+    assert_eq!(
+        summary.modules,
+        vec![
+            module(
+                "node_modules/react/index.js",
+                Some("react"),
+                &["main", "vendor"],
+                5_400
+            ),
+            module("src/main.ts", None, &["main"], 1_200),
+        ]
+    );
+}
+
+#[test]
+fn parse_esbuild_metafile_ignores_sourcemaps_and_non_js_assets() {
+    let summary = parse_esbuild_metafile(&json!({
+        "outputs": {
+            "dist/main.js": {
+                "bytes": 8_200,
+                "entryPoint": "src/main.ts",
+                "inputs": {
+                    "src/main.ts": {
+                        "bytesInOutput": 1_200
+                    },
+                    "node_modules/react/index.js": {
+                        "bytesInOutput": 3_200
+                    }
+                }
+            },
+            "dist/main.js.map": {
+                "bytes": 4_000,
+                "inputs": {
+                    "src/main.ts": {
+                        "bytesInOutput": 1_200
+                    }
+                }
+            },
+            "dist/styles.css": {
+                "bytes": 1_500,
+                "inputs": {
+                    "src/styles.css": {
+                        "bytesInOutput": 1_500
+                    }
+                }
+            },
+            "dist/logo.svg": {
+                "bytes": 700,
+                "inputs": {
+                    "src/logo.svg": {
+                        "bytesInOutput": 700
+                    }
+                }
+            }
+        }
+    }))
+    .expect("parse esbuild metafile");
+
+    assert_eq!(summary.total_bytes, 8_200);
+    assert_eq!(summary.chunks.len(), 1);
+    assert_eq!(
+        summary.modules,
+        vec![
+            module(
+                "node_modules/react/index.js",
+                Some("react"),
+                &["main"],
+                3_200
+            ),
+            module("src/main.ts", None, &["main"], 1_200),
+        ]
+    );
+}
+
+#[test]
+fn parse_artifact_file_reads_webpack_fixture() {
+    let summary = parse_artifact_file(&support::fixture_path(
+        "tests/fixtures/artifacts/webpack-basic/stats.json",
+    ))
+    .expect("parse webpack artifact");
+
+    assert_eq!(summary.bundler, "webpack");
+    assert_eq!(summary.entrypoints, vec!["main".to_string()]);
+    assert_eq!(summary.total_bytes, 14_000);
+    assert_eq!(summary.chunks.len(), 2);
+    assert_eq!(
+        summary.modules,
+        vec![
+            module(
+                "node_modules/react/index.js",
+                Some("react"),
+                &["vendors"],
+                4_500
+            ),
+            module("src/index.tsx", None, &["main"], 1_400),
+        ]
+    );
+}
+
+#[test]
+fn parse_artifact_file_reads_rollup_fixture() {
+    let summary = parse_artifact_file(&support::fixture_path(
+        "tests/fixtures/artifacts/vite-basic/meta.json",
+    ))
+    .expect("parse rollup artifact");
+
+    assert_eq!(summary.bundler, "rollup");
+    assert_eq!(summary.entrypoints, vec!["main".to_string()]);
+    assert_eq!(summary.total_bytes, 6_400);
+    assert_eq!(summary.chunks.len(), 2);
+    assert_eq!(
+        summary.modules,
+        vec![
+            module(
+                "/workspace/node_modules/vue/dist/vue.runtime.esm-bundler.js",
+                Some("vue"),
+                &["main", "vendor"],
+                5_300,
+            ),
+            module("/workspace/src/main.ts", None, &["main"], 1_100),
+        ]
+    );
+}
+
+#[test]
+fn detect_parser_kind_distinguishes_esbuild_and_rollup_meta_files_by_root_shape() {
+    let webpack = json!({
+        "entryPoints": {},
+        "chunks": []
+    });
+    let esbuild = json!({
+        "inputs": {},
+        "outputs": {}
+    });
+    let rollup = json!({
+        "outputs": []
+    });
+    let invalid_stats = json!({});
+
+    assert_eq!(
+        detect_parser_kind(std::path::Path::new("dist/stats.json"), &webpack),
+        Some(ArtifactParserKind::Webpack)
+    );
+    assert_eq!(
+        detect_parser_kind(std::path::Path::new("dist/stats.json"), &invalid_stats),
+        None
+    );
+    assert_eq!(
+        detect_parser_kind(std::path::Path::new("dist/meta.json"), &esbuild),
+        Some(ArtifactParserKind::Esbuild)
+    );
+    assert_eq!(
+        detect_parser_kind(std::path::Path::new("meta.json"), &rollup),
+        Some(ArtifactParserKind::Rollup)
+    );
+}
+
+#[test]
+fn detect_known_artifacts_ignores_stats_json_without_webpack_shape() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    std::fs::create_dir_all(root.join("dist")).expect("create dist dir");
+    std::fs::write(root.join("dist/stats.json"), "{}\n").expect("write invalid stats");
+
+    let actual = detect_known_artifacts(root).expect("detect artifacts");
+
+    assert!(actual.is_empty());
+}
+
+#[test]
+fn detect_known_artifacts_skips_malformed_json_and_keeps_valid_artifacts() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    std::fs::create_dir_all(root.join("dist")).expect("create dist dir");
+    std::fs::write(root.join("dist/stats.json"), "{\n").expect("write malformed stats");
+    write_file(
+        root.join("dist/meta.json"),
+        support::fixture_path("tests/fixtures/artifacts/esbuild-basic/meta.json"),
+    );
+
+    let actual = detect_known_artifacts(root).expect("detect artifacts");
+
+    assert_eq!(
+        actual,
+        vec![legolas_core::artifacts::detect::DetectedArtifact {
+            relative_path: "dist/meta.json".to_string(),
+            parser: ArtifactParserKind::Esbuild,
+        }]
+    );
+}
+
+#[test]
+fn parse_webpack_stats_merges_same_module_across_chunks() {
+    let summary = parse_webpack_stats(&json!({
+        "entryPoints": {
+            "main": {
+                "assets": [
+                    { "name": "main.js" },
+                    { "name": "vendors.js" }
+                ]
+            }
+        },
+        "chunks": [
+            {
+                "id": 1,
+                "names": ["main"],
+                "files": ["main.js"],
+                "initial": true,
+                "size": 3_000,
+                "modules": [
+                    {
+                        "identifier": "node_modules/react/index.js",
+                        "size": 1_000
+                    }
+                ]
+            },
+            {
+                "id": 2,
+                "names": ["vendors"],
+                "files": ["vendors.js"],
+                "initial": true,
+                "size": 4_000,
+                "modules": [
+                    {
+                        "identifier": "node_modules/react/index.js",
+                        "size": 2_500
+                    }
+                ]
+            }
+        ]
+    }))
+    .expect("parse webpack stats");
+
+    assert_eq!(
+        summary.modules,
+        vec![module(
+            "node_modules/react/index.js",
+            Some("react"),
+            &["main", "vendors"],
+            3_500,
+        )]
+    );
+}
+
+#[test]
+fn nested_node_modules_paths_use_the_deepest_package_name() {
+    let esbuild = parse_esbuild_metafile(&json!({
+        "outputs": {
+            "dist/main.js": {
+                "bytes": 1_000,
+                "entryPoint": "src/main.ts",
+                "inputs": {
+                    "/repo/node_modules/pkg/node_modules/dep/index.js": {
+                        "bytesInOutput": 500
+                    }
+                }
+            }
+        }
+    }))
+    .expect("parse esbuild metafile");
+    assert_eq!(
+        esbuild.modules,
+        vec![module(
+            "/repo/node_modules/pkg/node_modules/dep/index.js",
+            Some("dep"),
+            &["main"],
+            500,
+        )]
+    );
+
+    let rollup = parse_rollup_metadata(&json!({
+        "outputs": [
+            {
+                "type": "chunk",
+                "name": "main",
+                "file": "dist/main.js",
+                "isEntry": true,
+                "modules": {
+                    "/repo/node_modules/pkg/node_modules/@scope/dep/index.js": {
+                        "renderedLength": 700
+                    }
+                }
+            }
+        ]
+    }))
+    .expect("parse rollup metadata");
+    assert_eq!(
+        rollup.modules,
+        vec![module(
+            "/repo/node_modules/pkg/node_modules/@scope/dep/index.js",
+            Some("@scope/dep"),
+            &["main"],
+            700,
+        )]
+    );
+
+    let webpack = parse_webpack_stats(&json!({
+        "entryPoints": {
+            "main": {
+                "assets": [{ "name": "main.js" }]
+            }
+        },
+        "chunks": [
+            {
+                "id": 1,
+                "names": ["main"],
+                "files": ["main.js"],
+                "initial": true,
+                "size": 1_000,
+                "modules": [
+                    {
+                        "identifier": "C:\\repo\\node_modules\\pkg\\node_modules\\dep\\index.js",
+                        "size": 600
+                    }
+                ]
+            }
+        ]
+    }))
+    .expect("parse webpack stats");
+    assert_eq!(
+        webpack.modules,
+        vec![module(
+            "C:\\repo\\node_modules\\pkg\\node_modules\\dep\\index.js",
+            Some("dep"),
+            &["main"],
+            600,
+        )]
+    );
+}
+
+fn module(
+    id: &str,
+    package_name: Option<&str>,
+    chunks: &[&str],
+    bytes: usize,
+) -> legolas_core::artifacts::ArtifactModuleContribution {
+    legolas_core::artifacts::ArtifactModuleContribution {
+        id: id.to_string(),
+        package_name: package_name.map(ToOwned::to_owned),
+        chunks: chunks.iter().map(|chunk| chunk.to_string()).collect(),
+        bytes,
+    }
+}
+
+fn write_file(target: std::path::PathBuf, source: std::path::PathBuf) {
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::copy(source, target).expect("copy fixture");
+}

--- a/tests/fixtures/artifacts/esbuild-basic/meta.json
+++ b/tests/fixtures/artifacts/esbuild-basic/meta.json
@@ -1,0 +1,32 @@
+{
+  "inputs": {
+    "src/main.ts": {
+      "bytes": 1200
+    },
+    "node_modules/react/index.js": {
+      "bytes": 5400
+    }
+  },
+  "outputs": {
+    "dist/main.js": {
+      "bytes": 8200,
+      "entryPoint": "src/main.ts",
+      "inputs": {
+        "src/main.ts": {
+          "bytesInOutput": 1200
+        },
+        "node_modules/react/index.js": {
+          "bytesInOutput": 3200
+        }
+      }
+    },
+    "dist/vendor.js": {
+      "bytes": 5000,
+      "inputs": {
+        "node_modules/react/index.js": {
+          "bytesInOutput": 2200
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/artifacts/vite-basic/meta.json
+++ b/tests/fixtures/artifacts/vite-basic/meta.json
@@ -1,0 +1,31 @@
+{
+  "outputs": [
+    {
+      "file": "dist/assets/main.js",
+      "name": "main",
+      "type": "chunk",
+      "isEntry": true,
+      "isDynamicEntry": false,
+      "modules": {
+        "/workspace/src/main.ts": {
+          "renderedLength": 1100
+        },
+        "/workspace/node_modules/vue/dist/vue.runtime.esm-bundler.js": {
+          "renderedLength": 2800
+        }
+      }
+    },
+    {
+      "file": "dist/assets/vendor.js",
+      "name": "vendor",
+      "type": "chunk",
+      "isEntry": false,
+      "isDynamicEntry": false,
+      "modules": {
+        "/workspace/node_modules/vue/dist/vue.runtime.esm-bundler.js": {
+          "renderedLength": 2500
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/artifacts/webpack-basic/stats.json
+++ b/tests/fixtures/artifacts/webpack-basic/stats.json
@@ -1,0 +1,38 @@
+{
+  "entryPoints": {
+    "main": {
+      "assets": [
+        { "name": "main.js" },
+        { "name": "vendors.js" }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "id": 1,
+      "names": ["main"],
+      "files": ["main.js"],
+      "initial": true,
+      "size": 9000,
+      "modules": [
+        {
+          "identifier": "src/index.tsx",
+          "size": 1400
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "names": ["vendors"],
+      "files": ["vendors.js"],
+      "initial": true,
+      "size": 5000,
+      "modules": [
+        {
+          "identifier": "node_modules/react/index.js",
+          "size": 4500
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
배경
- Phase 5 `PR-FIT-007B` ~ `PR-FIT-007E`의 artifact truth parser layer를 병렬 lane로 준비했습니다.
- source scan 위에 실제 artifact 파일을 normalized `ArtifactSummary`로 읽는 기반을 먼저 고정합니다.

변경 사항
- known artifact file 탐지와 parser kind 라우팅을 추가했습니다.
- esbuild metafile parser를 추가했습니다.
- webpack stats parser를 추가했습니다.
- Rollup/Vite metadata parser를 추가했습니다.
- parser contract 테스트와 fixture를 추가했습니다.

검증
- `cargo test -p legolas-core --test artifact_parsers`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

브랜치 / 워크트리
- branch: `codex/artifact-truth-parsers`
- worktree: `/Users/pjw/workspace/legolas`
- source worktree: 없음

비고
- 글로벌 병렬 우선 규칙은 로컬 `~/.codex/AGENTS.md`에만 반영했고, 이 PR에는 포함하지 않았습니다.
