### PR TITLE
feat: route context classifier 추가

### DIFF
--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -25,6 +25,7 @@ use crate::{
     },
     package_intelligence::get_package_intel,
     project_shape::{detect_frameworks, detect_package_manager},
+    route_context::{classify_route_context, RouteContextKind},
     workspace::{find_project_root, load_alias_config, read_json_if_exists},
     LegolasError,
 };
@@ -59,7 +60,12 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
     let mut duplicate_analysis = parse_duplicate_packages(&project_root, &package_manager)?;
     enrich_duplicate_package_findings(&mut duplicate_analysis.duplicates);
     let heavy_dependencies = build_heavy_dependency_report(&manifest, &source_analysis);
-    let lazy_load_candidates = build_lazy_load_candidates(&source_analysis, &heavy_dependencies);
+    let lazy_load_candidates = build_lazy_load_candidates(
+        &project_root,
+        &frameworks,
+        &source_analysis,
+        &heavy_dependencies,
+    );
     let tree_shaking_warnings = build_tree_shaking_warnings(&source_analysis);
     let bundle_artifacts = detect_bundle_artifacts(&project_root)?;
     let impact = estimate_impact(
@@ -187,6 +193,8 @@ fn merged_dependency_entries(manifest: &Value) -> Vec<(String, String)> {
 }
 
 fn build_lazy_load_candidates(
+    project_root: &Path,
+    frameworks: &[String],
     source_analysis: &SourceAnalysis,
     heavy_dependencies: &[HeavyDependency],
 ) -> Vec<LazyLoadCandidate> {
@@ -201,28 +209,72 @@ fn build_lazy_load_candidates(
             continue;
         };
 
-        let split_friendly_files = imported_package
+        let classified_static_files = imported_package
             .static_files
             .iter()
-            .filter(|file| CANDIDATE_FILES_PATTERN.is_match(file))
-            .cloned()
+            .map(|file| {
+                (
+                    file.clone(),
+                    classify_route_context(project_root, frameworks, Path::new(file)),
+                )
+            })
             .collect::<Vec<_>>();
+        let route_context_files = classified_static_files
+            .iter()
+            .filter(|(_, route_kind)| is_lazy_load_route_context(*route_kind))
+            .map(|(file, route_kind)| (file.clone(), *route_kind))
+            .collect::<Vec<_>>();
+        let has_shared_component_import = classified_static_files
+            .iter()
+            .any(|(_, route_kind)| *route_kind == RouteContextKind::SharedComponent);
+        let heuristic_files = classified_static_files
+            .iter()
+            .filter(|(file, route_kind)| {
+                *route_kind != RouteContextKind::SharedComponent
+                    && CANDIDATE_FILES_PATTERN.is_match(file)
+            })
+            .map(|(file, _)| file.clone())
+            .collect::<Vec<_>>();
+
+        if !route_context_files.is_empty() && has_shared_component_import {
+            continue;
+        }
+
+        let split_friendly_files = if route_context_files.is_empty() {
+            heuristic_files.clone()
+        } else {
+            route_context_files
+                .iter()
+                .map(|(file, _)| file.clone())
+                .collect::<Vec<_>>()
+        };
 
         if split_friendly_files.is_empty() || !imported_package.dynamic_files.is_empty() {
             continue;
         }
 
-        let evidence_files = split_friendly_files.clone();
+        let reason = if route_context_files.is_empty() {
+            format!(
+                "{} is statically imported in UI surfaces that usually tolerate lazy loading",
+                imported_package.name
+            )
+        } else {
+            format!(
+                "{} is statically imported in route-aware UI surfaces that usually tolerate lazy loading",
+                imported_package.name
+            )
+        };
         candidates.push(LazyLoadCandidate {
             name: imported_package.name.clone(),
             estimated_savings_kb: (heavy.estimated_kb as f64 * 0.75).round() as usize,
             recommendation: heavy.recommendation.clone(),
             files: split_friendly_files,
-            reason: format!(
-                "{} is statically imported in UI surfaces that usually tolerate lazy loading",
-                imported_package.name
+            reason,
+            finding: build_lazy_load_finding(
+                &imported_package.name,
+                &heuristic_files,
+                &route_context_files,
             ),
-            finding: build_lazy_load_finding(&imported_package.name, &evidence_files),
         });
     }
 
@@ -289,16 +341,32 @@ fn build_heavy_dependency_finding(
         .with_evidence(evidence)
 }
 
-fn build_lazy_load_finding(package_name: &str, files: &[String]) -> FindingMetadata {
-    let evidence = files
-        .iter()
-        .map(|file| {
-            FindingEvidence::new("source-file")
-                .with_file(file.clone())
-                .with_specifier(package_name.to_string())
-                .with_detail(lazy_load_surface_detail(file))
-        })
-        .collect::<Vec<_>>();
+fn build_lazy_load_finding(
+    package_name: &str,
+    heuristic_files: &[String],
+    route_context_files: &[(String, RouteContextKind)],
+) -> FindingMetadata {
+    let evidence = if route_context_files.is_empty() {
+        heuristic_files
+            .iter()
+            .map(|file| {
+                FindingEvidence::new("source-file")
+                    .with_file(file.clone())
+                    .with_specifier(package_name.to_string())
+                    .with_detail(lazy_load_surface_detail(file))
+            })
+            .collect::<Vec<_>>()
+    } else {
+        route_context_files
+            .iter()
+            .map(|(file, route_kind)| {
+                FindingEvidence::new("source-file")
+                    .with_file(file.clone())
+                    .with_specifier(package_name.to_string())
+                    .with_detail(route_context_surface_detail(*route_kind))
+            })
+            .collect::<Vec<_>>()
+    };
 
     FindingMetadata::new(
         format!("lazy-load:{package_name}"),
@@ -320,6 +388,27 @@ fn lazy_load_surface_detail(file: &str) -> String {
             )
         })
         .unwrap_or_else(|| "route-like UI surface heuristic".to_string())
+}
+
+fn route_context_surface_detail(route_kind: RouteContextKind) -> String {
+    let label = match route_kind {
+        RouteContextKind::RoutePage => "route-page",
+        RouteContextKind::RouteLayout => "route-layout",
+        RouteContextKind::AdminSurface => "admin-surface",
+        RouteContextKind::SharedComponent => "shared-component",
+        RouteContextKind::NonRoute => "non-route",
+    };
+
+    format!("route context classified `{label}`")
+}
+
+fn is_lazy_load_route_context(route_kind: RouteContextKind) -> bool {
+    matches!(
+        route_kind,
+        RouteContextKind::RoutePage
+            | RouteContextKind::RouteLayout
+            | RouteContextKind::AdminSurface
+    )
 }
 
 fn build_unused_dependency_candidates(

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod lockfiles;
 pub mod models;
 pub mod package_intelligence;
 pub mod project_shape;
+pub mod route_context;
 pub mod workspace;
 
 pub use action_plan::*;

--- a/crates/legolas-core/src/route_context.rs
+++ b/crates/legolas-core/src/route_context.rs
@@ -1,0 +1,199 @@
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteContextKind {
+    RoutePage,
+    RouteLayout,
+    AdminSurface,
+    SharedComponent,
+    NonRoute,
+}
+
+pub fn classify_route_context(
+    project_root: &Path,
+    frameworks: &[String],
+    path: &Path,
+) -> RouteContextKind {
+    let normalized = normalize_relative_path(project_root, path);
+    let lower = normalized.to_ascii_lowercase();
+
+    if is_shared_component_path(&lower, frameworks) {
+        return RouteContextKind::SharedComponent;
+    }
+
+    if is_next_app_route_path(&lower, frameworks) {
+        if is_admin_surface_path(&lower) {
+            return RouteContextKind::AdminSurface;
+        }
+
+        if file_stem(&lower) == Some("layout") {
+            return RouteContextKind::RouteLayout;
+        }
+
+        return RouteContextKind::RoutePage;
+    }
+
+    if is_generic_route_path(&lower) {
+        if is_admin_surface_path(&lower) {
+            return RouteContextKind::AdminSurface;
+        }
+
+        return RouteContextKind::RoutePage;
+    }
+
+    if is_admin_surface_path(&lower) {
+        return RouteContextKind::AdminSurface;
+    }
+
+    RouteContextKind::NonRoute
+}
+
+fn normalize_relative_path(project_root: &Path, path: &Path) -> String {
+    path.strip_prefix(project_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .to_string()
+}
+
+fn is_next_app_route_path(path: &str, frameworks: &[String]) -> bool {
+    has_framework(frameworks, "Next.js")
+        && is_next_app_root_path(path)
+        && has_supported_source_extension(path)
+        && is_next_app_route_stem(path)
+}
+
+fn is_generic_route_path(path: &str) -> bool {
+    has_supported_source_extension(path)
+        && !is_generic_route_special_case(path)
+        && (path.starts_with("pages/")
+            || path.starts_with("routes/")
+            || path.starts_with("src/pages/")
+            || path.starts_with("src/routes/"))
+}
+
+fn is_shared_component_path(path: &str, frameworks: &[String]) -> bool {
+    has_supported_source_extension(path)
+        && (path.starts_with("components/")
+            || path.starts_with("src/components/")
+            || path.starts_with("shared/")
+            || path.starts_with("src/shared/")
+            || is_nested_collocated_shared_component_path(path, frameworks))
+}
+
+fn is_admin_surface_path(path: &str) -> bool {
+    has_supported_source_extension(path)
+        && (path.starts_with("admin/")
+            || path.starts_with("src/admin/")
+            || path.contains("/admin/")
+            || (is_generic_route_root_path(path) && file_stem(path) == Some("admin")))
+}
+
+fn has_supported_source_extension(path: &str) -> bool {
+    matches!(
+        Path::new(path)
+            .extension()
+            .and_then(|extension| extension.to_str()),
+        Some(
+            "js" | "jsx"
+                | "ts"
+                | "tsx"
+                | "cjs"
+                | "cjsx"
+                | "cts"
+                | "ctsx"
+                | "mjs"
+                | "mjsx"
+                | "mts"
+                | "mtsx"
+                | "vue"
+                | "svelte"
+                | "astro"
+        )
+    )
+}
+
+fn file_stem(path: &str) -> Option<&str> {
+    Path::new(path).file_stem().and_then(|stem| stem.to_str())
+}
+
+fn is_next_app_root_path(path: &str) -> bool {
+    next_app_relative_segments(path).is_some()
+}
+
+fn is_next_app_route_stem(path: &str) -> bool {
+    matches!(
+        file_stem(path),
+        Some("page" | "layout" | "loading" | "error" | "template" | "not-found" | "default")
+    )
+}
+
+fn is_generic_route_special_case(path: &str) -> bool {
+    path.starts_with("pages/api/")
+        || path.starts_with("src/pages/api/")
+        || file_stem(path).is_some_and(|stem| matches!(stem, "_app" | "_document" | "_error"))
+}
+
+fn path_segments(path: &str) -> Vec<&str> {
+    path.split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect()
+}
+
+fn is_generic_route_root_path(path: &str) -> bool {
+    generic_route_relative_segments(path).is_some()
+}
+
+fn is_nested_collocated_shared_component_path(path: &str, frameworks: &[String]) -> bool {
+    if has_framework(frameworks, "Next.js")
+        && next_app_relative_segments(path).is_some_and(|segments| {
+            has_nested_collocated_support_segment(&segments, is_next_app_route_stem(path))
+        })
+    {
+        return true;
+    }
+
+    generic_route_relative_segments(path).is_some_and(|segments| {
+        has_nested_collocated_support_segment(&segments, file_stem(path) == Some("index"))
+    })
+}
+
+fn has_nested_collocated_support_segment(segments: &[&str], is_route_leaf: bool) -> bool {
+    if is_route_leaf || segments.len() < 3 {
+        return false;
+    }
+
+    segments[..segments.len() - 1]
+        .iter()
+        .enumerate()
+        .any(|(index, segment)| index > 0 && matches!(*segment, "components" | "shared"))
+}
+
+fn next_app_relative_segments(path: &str) -> Option<Vec<&str>> {
+    let segments = path_segments(path);
+
+    match segments.as_slice() {
+        ["app", rest @ ..] if !rest.is_empty() => Some(rest.to_vec()),
+        ["src", "app", rest @ ..] if !rest.is_empty() => Some(rest.to_vec()),
+        _ => None,
+    }
+}
+
+fn generic_route_relative_segments(path: &str) -> Option<Vec<&str>> {
+    let segments = path_segments(path);
+
+    match segments.as_slice() {
+        ["pages", rest @ ..] if !rest.is_empty() => Some(rest.to_vec()),
+        ["routes", rest @ ..] if !rest.is_empty() => Some(rest.to_vec()),
+        ["src", "pages", rest @ ..] if !rest.is_empty() => Some(rest.to_vec()),
+        ["src", "routes", rest @ ..] if !rest.is_empty() => Some(rest.to_vec()),
+        _ => None,
+    }
+}
+
+fn has_framework(frameworks: &[String], expected: &str) -> bool {
+    frameworks
+        .iter()
+        .any(|framework| framework.eq_ignore_ascii_case(expected))
+}

--- a/crates/legolas-core/tests/route_aware_lazy_loading.rs
+++ b/crates/legolas-core/tests/route_aware_lazy_loading.rs
@@ -1,0 +1,779 @@
+mod support;
+
+use std::fs;
+
+use legolas_core::{
+    analyze_project,
+    project_shape::detect_frameworks,
+    route_context::{classify_route_context, RouteContextKind},
+};
+use serde_json::Value;
+use tempfile::tempdir;
+
+#[test]
+fn classify_route_context_distinguishes_next_route_pages_from_shared_components() {
+    let project_root = support::fixture_path("tests/fixtures/routes/next-app");
+    let frameworks = load_frameworks(&project_root);
+
+    assert_eq!(
+        classify_route_context(
+            &project_root,
+            &frameworks,
+            &project_root.join("app/dashboard/page.tsx")
+        ),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(
+            &project_root,
+            &frameworks,
+            &project_root.join("components/ChartPanel.tsx"),
+        ),
+        RouteContextKind::SharedComponent
+    );
+}
+
+#[test]
+fn classify_route_context_marks_next_layout_and_admin_surfaces() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "next-admin-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "app/layout.tsx",
+        "export default function Layout() { return null; }\n",
+    );
+    write_file(
+        root,
+        "app/admin/page.tsx",
+        "export default function Page() { return null; }\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("app/layout.tsx")),
+        RouteContextKind::RouteLayout
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("app/admin/page.tsx")),
+        RouteContextKind::AdminSurface
+    );
+}
+
+#[test]
+fn classify_route_context_reads_next_special_route_files() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "next-special-files-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/app/dashboard/loading.tsx",
+        "export default function Loading() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/app/dashboard/error.tsx",
+        "export default function Error() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/app/dashboard/template.tsx",
+        "export default function Template() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/app/dashboard/not-found.tsx",
+        "export default function NotFound() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/app/dashboard/default.tsx",
+        "export default function Default() { return null; }\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/app/dashboard/loading.tsx")
+        ),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/app/dashboard/error.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/app/dashboard/template.tsx")
+        ),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/app/dashboard/not-found.tsx")
+        ),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/app/dashboard/default.tsx")
+        ),
+        RouteContextKind::RoutePage
+    );
+}
+
+#[test]
+fn classify_route_context_reads_generic_pages_and_non_route_files() {
+    let project_root = support::fixture_path("tests/fixtures/routes/vite-pages");
+    let frameworks = load_frameworks(&project_root);
+
+    assert_eq!(
+        classify_route_context(
+            &project_root,
+            &frameworks,
+            &project_root.join("src/pages/Settings.tsx"),
+        ),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(
+            &project_root,
+            &frameworks,
+            &project_root.join("src/lib/date.ts"),
+        ),
+        RouteContextKind::NonRoute
+    );
+}
+
+#[test]
+fn classify_route_context_keeps_generic_route_segments_even_when_names_overlap_support_dirs() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "generic-route-support-app",
+  "dependencies": {
+    "vite": "^6.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/pages/utils/date.ts",
+        "export function formatDate() { return \"2026-04-21\"; }\n",
+    );
+    write_file(
+        root,
+        "routes/lib/helper.ts",
+        "export const routeHelper = true;\n",
+    );
+    write_file(
+        root,
+        "src/pages/dashboard/index.tsx",
+        "export default function DashboardPage() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/routes/lib.tsx",
+        "export default function LibRoute() { return null; }\n",
+    );
+    write_file(
+        root,
+        "pages/components.tsx",
+        "export default function ComponentsRoute() { return null; }\n",
+    );
+    write_file(
+        root,
+        "pages/components/index.tsx",
+        "export default function ComponentsIndexRoute() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/pages/shared/index.tsx",
+        "export default function SharedIndexRoute() { return null; }\n",
+    );
+    write_file(
+        root,
+        "pages/shared/Button.tsx",
+        "export default function SharedButtonRoute() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/pages/components/ChartPanel.tsx",
+        "export default function ComponentsChartRoute() { return null; }\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/pages/utils/date.ts")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("routes/lib/helper.ts")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/pages/dashboard/index.tsx")
+        ),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/routes/lib.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("pages/components.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("pages/components/index.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/pages/shared/index.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("pages/shared/Button.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/pages/components/ChartPanel.tsx")
+        ),
+        RouteContextKind::RoutePage
+    );
+}
+
+#[test]
+fn classify_route_context_reads_src_app_and_root_routes_layouts() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "route-shapes-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "astro": "^5.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/app/reports/page.tsx",
+        "export default function ReportsPage() { return null; }\n",
+    );
+    write_file(
+        root,
+        "pages/index.tsx",
+        "export default function HomePage() { return null; }\n",
+    );
+    write_file(
+        root,
+        "routes/admin.tsx",
+        "export default function AdminPage() { return null; }\n",
+    );
+    write_file(
+        root,
+        "routes/ops.mtsx",
+        "export default function OpsPage() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/pages/blog.astro",
+        "---\nconst title = \"blog\";\n---\n<h1>{title}</h1>\n",
+    );
+    write_file(
+        root,
+        "pages/_app.tsx",
+        "export default function App() { return null; }\n",
+    );
+    write_file(
+        root,
+        "pages/api/health.cts",
+        "export default function handler() { return null; }\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/app/reports/page.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("pages/index.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("routes/admin.tsx")),
+        RouteContextKind::AdminSurface
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("routes/ops.mtsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/pages/blog.astro")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("pages/_app.tsx")),
+        RouteContextKind::NonRoute
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("pages/api/health.cts")),
+        RouteContextKind::NonRoute
+    );
+}
+
+#[test]
+fn classify_route_context_prefers_shared_component_over_admin_filename() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "shared-admin-app",
+  "dependencies": {
+    "vite": "^6.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/components/AdminPanel.tsx",
+        "export function AdminPanel() { return null; }\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/components/AdminPanel.tsx")
+        ),
+        RouteContextKind::SharedComponent
+    );
+}
+
+#[test]
+fn classify_route_context_detects_collocated_shared_components_inside_route_trees() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "collocated-components-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "app/dashboard/components/ChartPanel.tsx",
+        "export function ChartPanel() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/pages/dashboard/components/ChartPanel.tsx",
+        "export function DashboardChartPanel() { return null; }\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("app/dashboard/components/ChartPanel.tsx")
+        ),
+        RouteContextKind::SharedComponent
+    );
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/pages/dashboard/components/ChartPanel.tsx")
+        ),
+        RouteContextKind::SharedComponent
+    );
+}
+
+#[test]
+fn classify_route_context_does_not_treat_partial_admin_names_as_admin_surfaces() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "admin-name-heuristic-app",
+  "dependencies": {
+    "vite": "^6.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/pages/administrator.tsx",
+        "export default function AdministratorPage() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/components/MyAdminPanel.tsx",
+        "export function MyAdminPanel() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/pages/admin.tsx",
+        "export default function AdminPage() { return null; }\n",
+    );
+    write_file(
+        root,
+        "src/lib/admin.tsx",
+        "export const adminHelper = true;\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/pages/administrator.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(
+            root,
+            &frameworks,
+            &root.join("src/components/MyAdminPanel.tsx")
+        ),
+        RouteContextKind::SharedComponent
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/pages/admin.tsx")),
+        RouteContextKind::AdminSurface
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/lib/admin.tsx")),
+        RouteContextKind::NonRoute
+    );
+}
+
+#[test]
+fn classify_route_context_does_not_treat_route_segments_named_components_or_shared_as_shared_components(
+) {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "route-segment-name-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "app/components/page.tsx",
+        "export default function ComponentsPage() { return null; }\n",
+    );
+    write_file(
+        root,
+        "app/shared/page.tsx",
+        "export default function SharedPage() { return null; }\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("app/components/page.tsx")),
+        RouteContextKind::RoutePage
+    );
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("app/shared/page.tsx")),
+        RouteContextKind::RoutePage
+    );
+}
+
+#[test]
+fn analyze_project_uses_route_context_for_lazy_load_candidates_without_keyword_matches() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "route-aware-candidate-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "app/reports/page.tsx",
+        "import { Chart } from \"chart.js\";\nexport default function ReportsPage() { return Chart; }\n",
+    );
+
+    let analysis = analyze_project(root).expect("analyze route-aware candidate project");
+    let candidate = analysis
+        .lazy_load_candidates
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js lazy-load candidate");
+
+    assert_eq!(candidate.files, vec!["app/reports/page.tsx".to_string()]);
+    assert_eq!(
+        candidate.reason,
+        "chart.js is statically imported in route-aware UI surfaces that usually tolerate lazy loading"
+    );
+    let evidence = candidate
+        .finding
+        .evidence
+        .first()
+        .expect("lazy-load evidence");
+    assert_eq!(evidence.file.as_deref(), Some("app/reports/page.tsx"));
+    assert_eq!(evidence.specifier.as_deref(), Some("chart.js"));
+    assert_eq!(
+        evidence.detail.as_deref(),
+        Some("route context classified `route-page`")
+    );
+}
+
+#[test]
+fn analyze_project_skips_candidates_when_shared_component_keeps_static_import_alive() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "shared-import-route-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "app/reports/page.tsx",
+        "import { Chart } from \"chart.js\";\nexport default function ReportsPage() { return Chart; }\n",
+    );
+    write_file(
+        root,
+        "src/components/ChartPanel.tsx",
+        "import { Chart } from \"chart.js\";\nexport function ChartPanel() { return Chart; }\n",
+    );
+
+    let analysis = analyze_project(root).expect("analyze shared-import route project");
+
+    assert!(
+        analysis
+            .lazy_load_candidates
+            .iter()
+            .all(|item| item.name != "chart.js"),
+        "shared component static import should suppress route-aware chart.js candidate"
+    );
+}
+
+#[test]
+fn analyze_project_keeps_index_routes_inside_support_named_segments_as_candidates() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "support-named-route-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "vite": "^6.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "pages/components/index.tsx",
+        "import { Chart } from \"chart.js\";\nexport default function ComponentsPage() { return Chart; }\n",
+    );
+
+    let analysis = analyze_project(root).expect("analyze support-named route project");
+    let candidate = analysis
+        .lazy_load_candidates
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js lazy-load candidate");
+
+    assert_eq!(
+        candidate.files,
+        vec!["pages/components/index.tsx".to_string()]
+    );
+    let evidence = candidate
+        .finding
+        .evidence
+        .first()
+        .expect("lazy-load evidence");
+    assert_eq!(evidence.file.as_deref(), Some("pages/components/index.tsx"));
+    assert_eq!(
+        evidence.detail.as_deref(),
+        Some("route context classified `route-page`")
+    );
+}
+
+#[test]
+fn analyze_project_keeps_direct_route_files_inside_support_named_segments_as_candidates() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "support-named-direct-route-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "vite": "^6.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "pages/shared/Button.tsx",
+        "import { Chart } from \"chart.js\";\nexport default function SharedButtonPage() { return Chart; }\n",
+    );
+
+    let analysis = analyze_project(root).expect("analyze direct support-named route project");
+    let candidate = analysis
+        .lazy_load_candidates
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js lazy-load candidate");
+
+    assert_eq!(candidate.files, vec!["pages/shared/Button.tsx".to_string()]);
+    assert_eq!(
+        candidate.reason,
+        "chart.js is statically imported in route-aware UI surfaces that usually tolerate lazy loading"
+    );
+    let evidence = candidate
+        .finding
+        .evidence
+        .first()
+        .expect("lazy-load evidence");
+    assert_eq!(evidence.file.as_deref(), Some("pages/shared/Button.tsx"));
+    assert_eq!(
+        evidence.detail.as_deref(),
+        Some("route context classified `route-page`")
+    );
+}
+
+#[test]
+fn classify_route_context_does_not_treat_next_non_entry_admin_named_file_as_admin_surface() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "next-non-entry-admin-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    );
+    write_file(
+        root,
+        "src/app/admin.tsx",
+        "export const adminHelper = true;\n",
+    );
+
+    let frameworks = load_frameworks(root);
+
+    assert_eq!(
+        classify_route_context(root, &frameworks, &root.join("src/app/admin.tsx")),
+        RouteContextKind::NonRoute
+    );
+}
+
+fn load_frameworks(project_root: &std::path::Path) -> Vec<String> {
+    let manifest =
+        fs::read_to_string(project_root.join("package.json")).expect("read package.json");
+    let manifest: Value = serde_json::from_str(&manifest).expect("parse package.json");
+    detect_frameworks(project_root, &manifest).expect("detect frameworks")
+}
+
+fn write_file(root: &std::path::Path, relative_path: &str, contents: &str) {
+    let target = root.join(relative_path);
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).expect("create parent dir");
+    }
+    fs::write(target, contents).expect("write file");
+}

--- a/tests/fixtures/routes/next-app/app/dashboard/page.tsx
+++ b/tests/fixtures/routes/next-app/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return null;
+}

--- a/tests/fixtures/routes/next-app/components/ChartPanel.tsx
+++ b/tests/fixtures/routes/next-app/components/ChartPanel.tsx
@@ -1,0 +1,3 @@
+export function ChartPanel() {
+  return null;
+}

--- a/tests/fixtures/routes/next-app/package.json
+++ b/tests/fixtures/routes/next-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "route-context-next-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}

--- a/tests/fixtures/routes/vite-pages/package.json
+++ b/tests/fixtures/routes/vite-pages/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "route-context-vite-pages",
+  "dependencies": {
+    "vite": "^6.0.0",
+    "react": "^19.0.0"
+  }
+}

--- a/tests/fixtures/routes/vite-pages/src/pages/Settings.tsx
+++ b/tests/fixtures/routes/vite-pages/src/pages/Settings.tsx
@@ -1,0 +1,3 @@
+export default function SettingsPage() {
+  return null;
+}


### PR DESCRIPTION
## 배경
- Phase 5 artifact parser wave가 merge된 뒤, local execution board를 `Phase 6 Artifact Adoption` 기준으로 다시 맞췄습니다.
- 이번 PR은 그 다음 smallest unlocked slice인 `PR-FIT-009A`를 route classifier seam만으로 먼저 여는 작업입니다.

## 변경 사항
- `crates/legolas-core/src/route_context.rs`에 route context classifier를 추가했습니다.
  - `RoutePage`
  - `RouteLayout`
  - `AdminSurface`
  - `SharedComponent`
  - `NonRoute`
- `crates/legolas-core/src/lib.rs`에 module export를 연결했습니다.
- `crates/legolas-core/tests/route_aware_lazy_loading.rs`에 Next app router / generic pages / shared component / admin surface 회귀 테스트를 추가했습니다.
- route fixture를 추가했습니다.
  - `tests/fixtures/routes/next-app/*`
  - `tests/fixtures/routes/vite-pages/*`

## 검증
- `cargo test -p legolas-core --test route_aware_lazy_loading`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/route-context-classifier`
- 기준 브랜치: `master`
- 현재 워크트리: `/Users/pjw/workspace/legolas`
- 포함 source worktree: 없음

