### PR TITLE
feat: artifact summary analysis 연결

### DIFF
--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -106,6 +106,62 @@ fn matches_scan_json_oracle() {
 }
 
 #[test]
+fn normalize_analysis_json_output_normalizes_artifact_summary_paths() {
+    let normalized = support::normalize_analysis_json_output(
+        r#"{
+  "projectRoot": "C:\\repo",
+  "bundleArtifacts": ["dist\\stats.json"],
+  "artifactSummary": {
+    "bundler": "webpack",
+    "entrypoints": ["src\\main.ts"],
+    "chunks": [
+      {
+        "name": "main",
+        "entrypoints": ["src\\main.ts"],
+        "files": ["dist\\main.js"],
+        "initial": true,
+        "bytes": 9000
+      }
+    ],
+    "modules": [
+      {
+        "id": "src\\main.ts",
+        "packageName": null,
+        "chunks": ["main"],
+        "bytes": 1400
+      }
+    ],
+    "totalBytes": 9000
+  },
+  "packageSummary": {"name":"demo","dependencyCount":0,"devDependencyCount":0},
+  "sourceSummary": {"filesScanned":0,"importedPackages":0,"dynamicImports":0},
+  "heavyDependencies": [],
+  "duplicatePackages": [],
+  "lazyLoadCandidates": [],
+  "treeShakingWarnings": [],
+  "unusedDependencyCandidates": [],
+  "warnings": [],
+  "impact": {"potentialKbSaved":0,"estimatedLcpImprovementMs":0,"confidence":"directional","summary":"n/a"},
+  "metadata": {"mode":"artifact-assisted","generatedAt":"2026-01-01T00:00:00.000Z"}
+}"#,
+    );
+
+    assert_eq!(normalized["bundleArtifacts"][0], "dist/stats.json");
+    assert_eq!(
+        normalized["artifactSummary"]["entrypoints"][0],
+        "src/main.ts"
+    );
+    assert_eq!(
+        normalized["artifactSummary"]["chunks"][0]["files"][0],
+        "dist/main.js"
+    );
+    assert_eq!(
+        normalized["artifactSummary"]["modules"][0]["id"],
+        "src/main.ts"
+    );
+}
+
+#[test]
 fn matches_validation_error_oracles() {
     let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
     let cases = [

--- a/crates/legolas-cli/tests/support/mod.rs
+++ b/crates/legolas-cli/tests/support/mod.rs
@@ -56,6 +56,7 @@ fn normalize_analysis_value(analysis: &mut Value) {
     replace_string_field(analysis, &["metadata", "generatedAt"], "<GENERATED_AT>");
     normalize_string_array(analysis, &["bundleArtifacts"]);
     normalize_string_array(analysis, &["warnings"]);
+    normalize_artifact_summary(analysis);
     normalize_object_array_string_field(analysis, &["heavyDependencies"], "importedBy");
     normalize_object_array_string_field(analysis, &["heavyDependencies"], "dynamicImportedBy");
     normalize_object_array_object_array_string_field(
@@ -171,4 +172,26 @@ fn get_path_mut<'a>(value: &'a mut Value, path: &[&str]) -> Option<&'a mut Value
 #[allow(dead_code)]
 fn to_posix(value: String) -> String {
     value.replace('\\', "/")
+}
+
+#[allow(dead_code)]
+fn normalize_artifact_summary(analysis: &mut Value) {
+    normalize_string_array(analysis, &["artifactSummary", "entrypoints"]);
+    normalize_object_array_string_field(analysis, &["artifactSummary", "chunks"], "entrypoints");
+    normalize_object_array_string_field(analysis, &["artifactSummary", "chunks"], "files");
+    normalize_object_array_string_scalar_field(analysis, &["artifactSummary", "modules"], "id");
+}
+
+#[allow(dead_code)]
+fn normalize_object_array_string_scalar_field(root: &mut Value, path: &[&str], field: &str) {
+    let Some(Value::Array(items)) = get_path_mut(root, path) else {
+        return;
+    };
+
+    for item in items {
+        let Some(value) = item.get(field).and_then(Value::as_str).map(str::to_string) else {
+            continue;
+        };
+        item[field] = Value::String(to_posix(value));
+    }
 }

--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 
 use crate::{
     action_plan::apply_action_plan,
+    artifacts::{detect::parse_artifact_file, detect::KNOWN_ARTIFACT_FILES, ArtifactSummary},
     confidence::{score_duplicate_package, score_heavy_dependency, score_lazy_load_candidate},
     error::Result,
     findings::{FindingAnalysisSource, FindingEvidence, FindingMetadata},
@@ -34,14 +35,6 @@ static CANDIDATE_FILES_PATTERN: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(?i)(modal|chart|editor|map|viewer|dashboard|settings|admin|page|route|dialog|drawer|popover)")
         .expect("valid candidate files regex")
 });
-
-const KNOWN_BUNDLE_ARTIFACTS: [&str; 5] = [
-    "stats.json",
-    "dist/stats.json",
-    "build/stats.json",
-    "meta.json",
-    "dist/meta.json",
-];
 
 pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
     let project_root = find_project_root(input_path)?;
@@ -67,7 +60,7 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
         &heavy_dependencies,
     );
     let tree_shaking_warnings = build_tree_shaking_warnings(&source_analysis);
-    let bundle_artifacts = detect_bundle_artifacts(&project_root)?;
+    let artifact_assist = collect_artifact_assist(&project_root)?;
     let impact = estimate_impact(
         &heavy_dependencies,
         &duplicate_analysis.duplicates,
@@ -79,7 +72,8 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
         project_root: project_root.to_string_lossy().to_string(),
         package_manager,
         frameworks,
-        bundle_artifacts: bundle_artifacts.clone(),
+        bundle_artifacts: artifact_assist.bundle_artifacts.clone(),
+        artifact_summary: artifact_assist.artifact_summary.clone(),
         package_summary: build_package_summary(&manifest),
         source_summary: SourceSummary {
             files_scanned: source_files.len(),
@@ -94,10 +88,10 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
             &manifest,
             &source_analysis,
         ),
-        warnings: duplicate_analysis.warnings,
+        warnings: merge_warnings(duplicate_analysis.warnings, artifact_assist.warnings),
         impact,
         metadata: Metadata {
-            mode: if bundle_artifacts.is_empty() {
+            mode: if artifact_assist.artifact_summary.is_none() {
                 "heuristic".to_string()
             } else {
                 "artifact-assisted".to_string()
@@ -443,19 +437,72 @@ fn build_unused_dependency_candidates(
     candidates
 }
 
-fn detect_bundle_artifacts(project_root: &Path) -> Result<Vec<String>> {
-    let mut detected = Vec::new();
+#[derive(Debug, Default)]
+struct ArtifactAssist {
+    bundle_artifacts: Vec<String>,
+    artifact_summary: Option<ArtifactSummary>,
+    warnings: Vec<String>,
+}
 
-    for relative_path in KNOWN_BUNDLE_ARTIFACTS {
+#[derive(Debug)]
+struct ParsedArtifactCandidate {
+    relative_path: String,
+    modified_at: SystemTime,
+    summary: ArtifactSummary,
+}
+
+fn collect_artifact_assist(project_root: &Path) -> Result<ArtifactAssist> {
+    let mut assist = ArtifactAssist::default();
+    let mut parsed_candidates = Vec::new();
+
+    for relative_path in KNOWN_ARTIFACT_FILES {
         let absolute_path = project_root.join(relative_path);
-        if let Ok(metadata) = fs::metadata(&absolute_path) {
-            if metadata.is_file() {
-                detected.push(relative_path.to_string());
-            }
+        let Ok(metadata) = fs::metadata(&absolute_path) else {
+            continue;
+        };
+        if !metadata.is_file() {
+            continue;
+        }
+
+        assist.bundle_artifacts.push(relative_path.to_string());
+
+        match parse_artifact_file(&absolute_path) {
+            Ok(summary) => parsed_candidates.push(ParsedArtifactCandidate {
+                relative_path: relative_path.to_string(),
+                modified_at: metadata.modified().unwrap_or(UNIX_EPOCH),
+                summary: summary.normalized(),
+            }),
+            Err(error) => assist.warnings.push(format!(
+                "Bundle artifact `{relative_path}` could not be parsed: {error}"
+            )),
         }
     }
 
-    Ok(detected)
+    if let Some(selected) = select_artifact_summary(&parsed_candidates) {
+        if parsed_candidates.len() > 1 {
+            assist.warnings.push(format!(
+                "Multiple bundle artifacts were parsed; artifactSummary selected `{}` by latest modification time.",
+                selected.relative_path
+            ));
+        }
+        assist.artifact_summary = Some(selected.summary.clone());
+    }
+
+    Ok(assist)
+}
+
+fn select_artifact_summary(
+    candidates: &[ParsedArtifactCandidate],
+) -> Option<&ParsedArtifactCandidate> {
+    candidates.iter().max_by(|left, right| {
+        left.modified_at
+            .cmp(&right.modified_at)
+            .then_with(|| right.relative_path.cmp(&left.relative_path))
+    })
+}
+
+fn merge_warnings(primary: Vec<String>, secondary: Vec<String>) -> Vec<String> {
+    primary.into_iter().chain(secondary).collect()
 }
 
 fn generated_at_string() -> String {

--- a/crates/legolas-core/src/models.rs
+++ b/crates/legolas-core/src/models.rs
@@ -1,4 +1,4 @@
-use crate::findings::FindingMetadata;
+use crate::{artifacts::ArtifactSummary, findings::FindingMetadata};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -8,6 +8,8 @@ pub struct Analysis {
     pub package_manager: String,
     pub frameworks: Vec<String>,
     pub bundle_artifacts: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_summary: Option<ArtifactSummary>,
     pub package_summary: PackageSummary,
     pub source_summary: SourceSummary,
     pub heavy_dependencies: Vec<HeavyDependency>,

--- a/crates/legolas-core/tests/analyze_parity.rs
+++ b/crates/legolas-core/tests/analyze_parity.rs
@@ -1,13 +1,19 @@
 mod support;
 
-use std::{fs, path::Path};
+use std::{fs, path::Path, thread, time::Duration};
 
 #[cfg(unix)]
 use std::os::unix::fs::symlink as create_dir_symlink;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_dir as create_dir_symlink;
 
-use legolas_core::{analyze_project, LegolasError};
+use legolas_core::{
+    analyze_project,
+    artifacts::{
+        detect::parse_artifact_file, ArtifactChunk, ArtifactModuleContribution, ArtifactSummary,
+    },
+    Analysis, LegolasError,
+};
 use regex::Regex;
 use tempfile::tempdir;
 
@@ -71,7 +77,38 @@ fn analyze_project_emits_relative_evidence_blocks_in_parity_fixture() {
 }
 
 #[test]
-fn analyze_project_switches_to_artifact_assisted_mode_only_for_real_files() {
+fn normalize_analysis_for_oracle_normalizes_artifact_summary_paths() {
+    let normalized = support::normalize_analysis_for_oracle(&Analysis {
+        project_root: r"C:\repo".to_string(),
+        bundle_artifacts: vec![r"dist\stats.json".to_string()],
+        artifact_summary: Some(ArtifactSummary {
+            bundler: "webpack".to_string(),
+            entrypoints: vec![r"src\main.ts".to_string()],
+            chunks: vec![ArtifactChunk {
+                name: "main".to_string(),
+                entrypoints: vec![r"src\main.ts".to_string()],
+                files: vec![r"dist\main.js".to_string()],
+                initial: true,
+                bytes: 9_000,
+            }],
+            modules: vec![ArtifactModuleContribution {
+                id: r"src\main.ts".to_string(),
+                package_name: None,
+                chunks: vec!["main".to_string()],
+                bytes: 1_400,
+            }],
+            total_bytes: 9_000,
+        }),
+        ..Analysis::default()
+    });
+
+    assert!(normalized.contains("\"dist/main.js\""));
+    assert!(normalized.contains("\"src/main.ts\""));
+    assert!(!normalized.contains('\\'));
+}
+
+#[test]
+fn analyze_project_uses_parsed_artifact_summary_for_real_bundle_artifacts() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();
 
@@ -86,15 +123,139 @@ fn analyze_project_switches_to_artifact_assisted_mode_only_for_real_files() {
 }"#,
     );
     write_file(root, "src/App.ts", "export const App = () => null;\n");
-    write_file(root, "dist/stats.json", "{}\n");
+    write_file(
+        root,
+        "dist/stats.json",
+        include_str!("../../../tests/fixtures/artifacts/webpack-basic/stats.json"),
+    );
 
     let analysis = analyze_project(root).expect("analyze project");
+    let expected_summary = parse_artifact_file(&support::fixture_path(
+        "tests/fixtures/artifacts/webpack-basic/stats.json",
+    ))
+    .expect("parse artifact fixture")
+    .normalized();
 
     assert_eq!(analysis.metadata.mode, "artifact-assisted");
     assert_eq!(
         analysis.bundle_artifacts,
         vec!["dist/stats.json".to_string()]
     );
+    assert_eq!(analysis.artifact_summary, Some(expected_summary));
+    assert!(analysis.warnings.is_empty());
+}
+
+#[test]
+fn analyze_project_prefers_the_latest_parsed_bundle_artifact_when_multiple_exist() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "multi-artifact-app",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}"#,
+    );
+    write_file(root, "src/App.ts", "export const App = () => null;\n");
+    write_file(
+        root,
+        "dist/stats.json",
+        include_str!("../../../tests/fixtures/artifacts/webpack-basic/stats.json"),
+    );
+    thread::sleep(Duration::from_millis(1100));
+    write_file(
+        root,
+        "dist/meta.json",
+        include_str!("../../../tests/fixtures/artifacts/esbuild-basic/meta.json"),
+    );
+
+    let analysis = analyze_project(root).expect("analyze project");
+    let expected_summary = parse_artifact_file(&support::fixture_path(
+        "tests/fixtures/artifacts/esbuild-basic/meta.json",
+    ))
+    .expect("parse artifact fixture")
+    .normalized();
+
+    assert_eq!(analysis.metadata.mode, "artifact-assisted");
+    assert_eq!(
+        analysis.bundle_artifacts,
+        vec!["dist/stats.json".to_string(), "dist/meta.json".to_string()]
+    );
+    assert_eq!(analysis.artifact_summary, Some(expected_summary));
+    assert_eq!(
+        analysis.warnings,
+        vec![
+            "Multiple bundle artifacts were parsed; artifactSummary selected `dist/meta.json` by latest modification time.".to_string()
+        ]
+    );
+}
+
+#[test]
+fn analyze_project_falls_back_to_heuristic_mode_when_known_artifact_shape_is_unsupported() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "unsupported-artifact-app",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}"#,
+    );
+    write_file(root, "src/App.ts", "export const App = () => null;\n");
+    write_file(root, "dist/stats.json", "{}\n");
+
+    let analysis = analyze_project(root).expect("analyze project");
+
+    assert_eq!(analysis.metadata.mode, "heuristic");
+    assert_eq!(
+        analysis.bundle_artifacts,
+        vec!["dist/stats.json".to_string()]
+    );
+    assert!(analysis.artifact_summary.is_none());
+    assert_eq!(
+        analysis.warnings,
+        vec![
+            "Bundle artifact `dist/stats.json` could not be parsed: not implemented: unsupported artifact file shape".to_string()
+        ]
+    );
+}
+
+#[test]
+fn analyze_project_falls_back_to_heuristic_mode_when_known_artifact_json_is_malformed() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "package.json",
+        r#"{
+  "name": "malformed-artifact-app",
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}"#,
+    );
+    write_file(root, "src/App.ts", "export const App = () => null;\n");
+    write_file(root, "dist/stats.json", "{\n");
+
+    let analysis = analyze_project(root).expect("analyze project");
+
+    assert_eq!(analysis.metadata.mode, "heuristic");
+    assert_eq!(
+        analysis.bundle_artifacts,
+        vec!["dist/stats.json".to_string()]
+    );
+    assert!(analysis.artifact_summary.is_none());
+    assert_eq!(analysis.warnings.len(), 1);
+    assert!(analysis.warnings[0].contains("Bundle artifact `dist/stats.json` could not be parsed:"));
 }
 
 #[test]

--- a/crates/legolas-core/tests/support/mod.rs
+++ b/crates/legolas-core/tests/support/mod.rs
@@ -32,6 +32,7 @@ pub fn normalize_analysis_for_oracle(analysis: &Analysis) -> String {
         .into_iter()
         .map(to_posix)
         .collect();
+    normalized.artifact_summary = normalized.artifact_summary.map(normalize_artifact_summary);
     normalized.heavy_dependencies = normalized
         .heavy_dependencies
         .into_iter()
@@ -103,4 +104,29 @@ fn normalize_recommended_fix_files(finding: &mut legolas_core::FindingMetadata) 
         .drain(..)
         .map(to_posix)
         .collect();
+}
+
+fn normalize_artifact_summary(
+    mut summary: legolas_core::artifacts::ArtifactSummary,
+) -> legolas_core::artifacts::ArtifactSummary {
+    summary.entrypoints = summary.entrypoints.into_iter().map(to_posix).collect();
+    summary.chunks = summary
+        .chunks
+        .into_iter()
+        .map(|mut chunk| {
+            chunk.entrypoints = chunk.entrypoints.into_iter().map(to_posix).collect();
+            chunk.files = chunk.files.into_iter().map(to_posix).collect();
+            chunk
+        })
+        .collect();
+    summary.modules = summary
+        .modules
+        .into_iter()
+        .map(|mut module| {
+            module.id = to_posix(module.id);
+            module
+        })
+        .collect();
+
+    summary
 }


### PR DESCRIPTION
배경
- 현재 analyze는 known artifact 파일 존재만 감지하고 artifact-assisted mode로 표시하고 있었습니다.
- 이번 변경은 실제 parser 결과를 analysis에 연결해 parsed artifact truth를 additive하게 노출합니다.

변경 사항
- Analysis에 optional artifactSummary 필드를 추가했습니다.
- analyze가 known artifact 파일을 실제로 parse하고, 성공 시 artifactSummary와 artifact-assisted mode를 설정합니다.
- parse 실패는 warning으로 surface하고 heuristic mode로 fallback 하도록 정리했습니다.
- analyze parity 테스트에 valid artifact, unsupported shape, malformed JSON fallback 케이스를 추가했습니다.

검증
- cargo test -p legolas-core --test analyze_parity
- cargo run -p legolas-cli -- scan <temp valid artifact fixture> --json
- cargo run -p legolas-cli -- scan <temp invalid artifact fixture> --json
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

브랜치 / 워크트리
- 대상 브랜치: codex/artifact-summary-analysis
- 현재 워크트리: /Users/pjw/workspace/legolas
- 포함된 다른 source worktree: 없음