### PR TITLE
feat: artifact source merge helper 추가

### DIFF
--- a/crates/legolas-core/src/artifacts/merge.rs
+++ b/crates/legolas-core/src/artifacts/merge.rs
@@ -1,0 +1,228 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    artifacts::ArtifactSummary, findings::FindingEvidence, import_scanner::SourceAnalysis,
+    models::HeavyDependency,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactSignalKind {
+    Source,
+    Artifact,
+    ArtifactSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactChunkSignal {
+    pub name: String,
+    pub entrypoints: Vec<String>,
+    pub files: Vec<String>,
+    pub bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactSourceSignal {
+    pub package_name: String,
+    pub kind: ArtifactSignalKind,
+    pub source_files: Vec<String>,
+    pub chunks: Vec<ArtifactChunkSignal>,
+    pub artifact_bytes: usize,
+}
+
+impl ArtifactSourceSignal {
+    pub fn evidence(&self) -> Vec<FindingEvidence> {
+        let mut evidence = self
+            .source_files
+            .iter()
+            .map(|file| {
+                FindingEvidence::new("source-file")
+                    .with_file(file.clone())
+                    .with_specifier(self.package_name.clone())
+                    .with_detail("package imported in source analysis")
+            })
+            .collect::<Vec<_>>();
+
+        evidence.extend(self.chunks.iter().map(|chunk| {
+            let mut item = FindingEvidence::new("artifact-chunk")
+                .with_specifier(self.package_name.clone())
+                .with_detail(chunk_detail(chunk));
+            if let Some(file) = preferred_chunk_file(&chunk.files) {
+                item = item.with_file(file.clone());
+            }
+            item
+        }));
+
+        evidence
+    }
+}
+
+pub fn merge_artifact_source_signals(
+    artifact_summary: &ArtifactSummary,
+    source_analysis: &SourceAnalysis,
+    heavy_dependencies: &[HeavyDependency],
+) -> Vec<ArtifactSourceSignal> {
+    let heavy_packages = heavy_dependencies
+        .iter()
+        .map(|item| item.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let chunk_lookup = artifact_summary
+        .chunks
+        .iter()
+        .map(|chunk| (chunk.name.as_str(), chunk))
+        .collect::<BTreeMap<_, _>>();
+    let mut packages = source_analysis
+        .by_package
+        .iter()
+        .filter(|(package_name, _)| heavy_packages.contains(package_name.as_str()))
+        .map(|(package_name, record)| {
+            (
+                package_name.clone(),
+                PackageAccumulator::new(package_name.clone(), record.files.clone()),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for module in &artifact_summary.modules {
+        let Some(package_name) = module.package_name.as_deref() else {
+            continue;
+        };
+        if !heavy_packages.contains(package_name) {
+            continue;
+        }
+
+        let source_files = source_analysis
+            .by_package
+            .get(package_name)
+            .map(|record| record.files.clone())
+            .unwrap_or_default();
+        let package = packages
+            .entry(package_name.to_string())
+            .or_insert_with(|| PackageAccumulator::new(package_name.to_string(), source_files));
+
+        package.artifact_bytes += module.bytes;
+
+        for chunk_name in &module.chunks {
+            let chunk = chunk_lookup.get(chunk_name.as_str());
+            let entry = package
+                .chunks
+                .entry(chunk_name.clone())
+                .or_insert_with(|| ChunkAccumulator::from_summary(chunk_name, chunk.copied()));
+            entry.bytes += module.bytes;
+        }
+    }
+
+    packages
+        .into_values()
+        .map(PackageAccumulator::into_signal)
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+struct PackageAccumulator {
+    package_name: String,
+    source_files: Vec<String>,
+    chunks: BTreeMap<String, ChunkAccumulator>,
+    artifact_bytes: usize,
+}
+
+impl PackageAccumulator {
+    fn new(package_name: String, mut source_files: Vec<String>) -> Self {
+        sort_and_dedup(&mut source_files);
+        Self {
+            package_name,
+            source_files,
+            chunks: BTreeMap::new(),
+            artifact_bytes: 0,
+        }
+    }
+
+    fn into_signal(self) -> ArtifactSourceSignal {
+        let kind = if self.chunks.is_empty() {
+            ArtifactSignalKind::Source
+        } else if self.source_files.is_empty() {
+            ArtifactSignalKind::Artifact
+        } else {
+            ArtifactSignalKind::ArtifactSource
+        };
+
+        ArtifactSourceSignal {
+            package_name: self.package_name,
+            kind,
+            source_files: self.source_files,
+            chunks: self
+                .chunks
+                .into_values()
+                .map(ChunkAccumulator::into_signal)
+                .collect(),
+            artifact_bytes: self.artifact_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ChunkAccumulator {
+    name: String,
+    entrypoints: Vec<String>,
+    files: Vec<String>,
+    bytes: usize,
+}
+
+impl ChunkAccumulator {
+    fn from_summary(chunk_name: &str, summary: Option<&crate::artifacts::ArtifactChunk>) -> Self {
+        let mut entrypoints = summary
+            .map(|chunk| chunk.entrypoints.clone())
+            .unwrap_or_default();
+        let mut files = summary.map(|chunk| chunk.files.clone()).unwrap_or_default();
+        sort_and_dedup(&mut entrypoints);
+        sort_and_dedup(&mut files);
+
+        Self {
+            name: chunk_name.to_string(),
+            entrypoints,
+            files,
+            bytes: 0,
+        }
+    }
+
+    fn into_signal(self) -> ArtifactChunkSignal {
+        ArtifactChunkSignal {
+            name: self.name,
+            entrypoints: self.entrypoints,
+            files: self.files,
+            bytes: self.bytes,
+        }
+    }
+}
+
+fn sort_and_dedup(values: &mut Vec<String>) {
+    values.sort_unstable();
+    values.dedup();
+}
+
+fn preferred_chunk_file(files: &[String]) -> Option<&String> {
+    files
+        .iter()
+        .find(|file| is_code_asset(file))
+        .or_else(|| files.iter().find(|file| !file.ends_with(".map")))
+        .or_else(|| files.first())
+}
+
+fn is_code_asset(file: &str) -> bool {
+    matches!(file.rsplit('.').next(), Some("js" | "mjs" | "cjs" | "jsx"))
+}
+
+fn chunk_detail(chunk: &ArtifactChunkSignal) -> String {
+    if chunk.entrypoints.is_empty() {
+        format!(
+            "artifact chunk `{}` contributes {} bytes",
+            chunk.name, chunk.bytes
+        )
+    } else {
+        format!(
+            "artifact chunk `{}` contributes {} bytes; entrypoints: {}",
+            chunk.name,
+            chunk.bytes,
+            chunk.entrypoints.join(", ")
+        )
+    }
+}

--- a/crates/legolas-core/src/artifacts/mod.rs
+++ b/crates/legolas-core/src/artifacts/mod.rs
@@ -2,9 +2,13 @@ pub mod models;
 
 pub mod detect;
 pub mod esbuild;
+pub mod merge;
 pub mod rollup;
 pub mod webpack;
 
+pub use merge::{
+    merge_artifact_source_signals, ArtifactChunkSignal, ArtifactSignalKind, ArtifactSourceSignal,
+};
 pub use models::{ArtifactChunk, ArtifactModuleContribution, ArtifactSummary};
 
 pub(crate) fn package_name_from_module_id(module_id: &str) -> Option<String> {

--- a/crates/legolas-core/tests/artifact_source_merge.rs
+++ b/crates/legolas-core/tests/artifact_source_merge.rs
@@ -1,0 +1,160 @@
+mod support;
+
+use legolas_core::{
+    artifacts::{
+        detect::parse_artifact_file, merge_artifact_source_signals, ArtifactChunkSignal,
+        ArtifactSignalKind, ArtifactSourceSignal,
+    },
+    import_scanner::{collect_source_files, scan_imports_with_aliases},
+    FindingEvidence, HeavyDependency,
+};
+
+#[test]
+fn merges_source_and_artifact_signals_for_heavy_packages() {
+    let fixture = support::fixture_path("tests/fixtures/artifacts/merge-app");
+    let source_files = collect_source_files(&fixture).expect("collect source files");
+    let source_analysis =
+        scan_imports_with_aliases(&fixture, &source_files, None).expect("scan imports");
+    let artifact_summary =
+        parse_artifact_file(&fixture.join("stats.json")).expect("parse artifact summary");
+
+    let actual = merge_artifact_source_signals(
+        &artifact_summary,
+        &source_analysis,
+        &[
+            heavy_dependency("chart.js"),
+            heavy_dependency("lodash"),
+            heavy_dependency("react-icons"),
+        ],
+    );
+
+    assert_eq!(
+        actual,
+        vec![
+            ArtifactSourceSignal {
+                package_name: "chart.js".to_string(),
+                kind: ArtifactSignalKind::ArtifactSource,
+                source_files: vec!["src/AdminPage.tsx".to_string()],
+                chunks: vec![chunk(
+                    "admin",
+                    &["dashboard"],
+                    &["dist/admin.css", "dist/admin.js", "dist/admin.js.map"],
+                    6_200,
+                )],
+                artifact_bytes: 6_200,
+            },
+            ArtifactSourceSignal {
+                package_name: "lodash".to_string(),
+                kind: ArtifactSignalKind::Artifact,
+                source_files: vec![],
+                chunks: vec![chunk(
+                    "vendor",
+                    &["dashboard"],
+                    &["dist/vendor.css", "dist/vendor.js", "dist/vendor.js.map"],
+                    5_100,
+                )],
+                artifact_bytes: 5_100,
+            },
+            ArtifactSourceSignal {
+                package_name: "react-icons".to_string(),
+                kind: ArtifactSignalKind::Source,
+                source_files: vec!["src/AdminPage.tsx".to_string()],
+                chunks: vec![],
+                artifact_bytes: 0,
+            },
+        ]
+    );
+}
+
+#[test]
+fn merged_signal_evidence_orders_source_files_before_artifact_chunks() {
+    let fixture = support::fixture_path("tests/fixtures/artifacts/merge-app");
+    let source_files = collect_source_files(&fixture).expect("collect source files");
+    let source_analysis =
+        scan_imports_with_aliases(&fixture, &source_files, None).expect("scan imports");
+    let artifact_summary =
+        parse_artifact_file(&fixture.join("stats.json")).expect("parse artifact summary");
+
+    let actual = merge_artifact_source_signals(
+        &artifact_summary,
+        &source_analysis,
+        &[
+            heavy_dependency("chart.js"),
+            heavy_dependency("lodash"),
+            heavy_dependency("react-icons"),
+        ],
+    );
+
+    assert_eq!(
+        actual[0].evidence(),
+        vec![
+            FindingEvidence::new("source-file")
+                .with_file("src/AdminPage.tsx")
+                .with_specifier("chart.js")
+                .with_detail("package imported in source analysis"),
+            FindingEvidence::new("artifact-chunk")
+                .with_file("dist/admin.js")
+                .with_specifier("chart.js")
+                .with_detail(
+                    "artifact chunk `admin` contributes 6200 bytes; entrypoints: dashboard"
+                ),
+        ]
+    );
+    assert_eq!(
+        actual[1].evidence(),
+        vec![FindingEvidence::new("artifact-chunk")
+            .with_file("dist/vendor.js")
+            .with_specifier("lodash")
+            .with_detail("artifact chunk `vendor` contributes 5100 bytes; entrypoints: dashboard"),]
+    );
+    assert_eq!(
+        actual[2].evidence(),
+        vec![FindingEvidence::new("source-file")
+            .with_file("src/AdminPage.tsx")
+            .with_specifier("react-icons")
+            .with_detail("package imported in source analysis"),]
+    );
+}
+
+#[test]
+fn merged_signal_evidence_prefers_code_assets_over_maps_or_css() {
+    let signal = ArtifactSourceSignal {
+        package_name: "chart.js".to_string(),
+        kind: ArtifactSignalKind::Artifact,
+        source_files: vec![],
+        chunks: vec![chunk(
+            "admin",
+            &["dashboard"],
+            &["dist/admin.css", "dist/admin.js", "dist/admin.js.map"],
+            6_200,
+        )],
+        artifact_bytes: 6_200,
+    };
+
+    assert_eq!(
+        signal.evidence(),
+        vec![FindingEvidence::new("artifact-chunk")
+            .with_file("dist/admin.js")
+            .with_specifier("chart.js")
+            .with_detail("artifact chunk `admin` contributes 6200 bytes; entrypoints: dashboard"),]
+    );
+}
+
+fn heavy_dependency(name: &str) -> HeavyDependency {
+    HeavyDependency {
+        name: name.to_string(),
+        ..HeavyDependency::default()
+    }
+}
+
+fn chunk(name: &str, entrypoints: &[&str], files: &[&str], bytes: usize) -> ArtifactChunkSignal {
+    ArtifactChunkSignal {
+        name: name.to_string(),
+        entrypoints: entrypoints
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        files: files.iter().map(|value| (*value).to_string()).collect(),
+        bytes,
+    }
+}

--- a/tests/fixtures/artifacts/merge-app/package.json
+++ b/tests/fixtures/artifacts/merge-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "artifact-merge-app",
+  "private": true,
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "lodash": "^4.17.21",
+    "react": "^18.3.0",
+    "react-icons": "^5.2.1"
+  }
+}

--- a/tests/fixtures/artifacts/merge-app/src/AdminPage.tsx
+++ b/tests/fixtures/artifacts/merge-app/src/AdminPage.tsx
@@ -1,0 +1,15 @@
+import { Chart } from "chart.js";
+import React from "react";
+import { FiSettings } from "react-icons/fi";
+
+export function AdminPage() {
+  return (
+    <div
+      data-chart={typeof Chart}
+      data-icon={typeof FiSettings}
+      data-react={typeof React}
+    >
+      Admin
+    </div>
+  );
+}

--- a/tests/fixtures/artifacts/merge-app/stats.json
+++ b/tests/fixtures/artifacts/merge-app/stats.json
@@ -1,0 +1,45 @@
+{
+  "entryPoints": {
+    "dashboard": {
+      "assets": [
+        { "name": "dist/admin.js" },
+        { "name": "dist/vendor.js" }
+      ]
+    }
+  },
+  "chunks": [
+    {
+      "id": 1,
+      "names": ["admin"],
+      "files": ["dist/admin.css", "dist/admin.js", "dist/admin.js.map"],
+      "initial": true,
+      "size": 8200,
+      "modules": [
+        {
+          "identifier": "src/AdminPage.tsx",
+          "name": "src/AdminPage.tsx",
+          "size": 1400
+        },
+        {
+          "identifier": "node_modules/chart.js/dist/chart.js",
+          "name": "node_modules/chart.js/dist/chart.js",
+          "size": 6200
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "names": ["vendor"],
+      "files": ["dist/vendor.css", "dist/vendor.js", "dist/vendor.js.map"],
+      "initial": true,
+      "size": 6100,
+      "modules": [
+        {
+          "identifier": "node_modules/lodash/lodash.js",
+          "name": "node_modules/lodash/lodash.js",
+          "size": 5100
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
배경
- artifact parser가 들어왔지만 source signal과 artifact signal을 재사용 가능한 helper seam으로 묶는 레이어는 아직 없었습니다.
- 다음 단계인 PR-FIT-010B에서 finding adoption을 안전하게 붙일 수 있도록 먼저 merge helper를 고정했습니다.

변경 사항
- crates/legolas-core/src/artifacts/merge.rs에 artifact-source merge helper를 추가했습니다.
- heavy package 기준으로 source file signal과 artifact chunk signal을 병합하고, kind를 artifact / artifact-source로 구분하도록 했습니다.
- source-file evidence가 artifact-chunk evidence보다 먼저 나오도록 ordering contract를 고정했습니다.
- crates/legolas-core/tests/artifact_source_merge.rs에 helper contract 회귀 테스트를 추가했습니다.
- tests/fixtures/artifacts/merge-app에 merge 전용 fixture를 추가했습니다.

검증
- cargo test -p legolas-core --test artifact_source_merge
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

브랜치 / 워크트리
- target branch: codex/artifact-source-merge-helper
- current worktree: /Users/pjw/workspace/legolas
- source worktree: 없음

이슈 연결
- 없음