### PR TITLE
feat: route-aware lazy-load confidence 적용

### DIFF
--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -92,19 +92,7 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
     append_section(
         &mut lines,
         &analysis.lazy_load_candidates,
-        |item, _| {
-            with_evidence(
-                format!(
-                    "- {}{}: {}. Estimated win {} KB.",
-                    item.name,
-                    confidence_bracket(&item.finding),
-                    item.reason,
-                    item.estimated_savings_kb
-                ),
-                &item.finding,
-                "  ",
-            )
-        },
+        |item, _| with_evidence(lazy_load_summary(item), &item.finding, "  "),
         "- none",
     );
 
@@ -452,6 +440,38 @@ fn dedupe_actions(items: Vec<ActionLine>) -> Vec<ActionLine> {
 
 fn with_evidence(summary: String, finding: &FindingMetadata, indent: &str) -> String {
     with_detail_lines(summary, &[], finding, indent)
+}
+
+fn lazy_load_summary(item: &legolas_core::LazyLoadCandidate) -> String {
+    if item.reason.contains("route-aware") && !item.files.is_empty() {
+        if item.files.len() == 1 {
+            return format!(
+                "- {}{}: route surface {} statically imports {} and usually tolerates lazy loading. Estimated win {} KB.",
+                item.name,
+                confidence_bracket(&item.finding),
+                item.files[0],
+                item.name,
+                item.estimated_savings_kb
+            );
+        }
+
+        return format!(
+            "- {}{}: route surfaces {} statically import {} and usually tolerate lazy loading. Estimated win {} KB.",
+            item.name,
+            confidence_bracket(&item.finding),
+            item.files.join(", "),
+            item.name,
+            item.estimated_savings_kb
+        );
+    }
+
+    format!(
+        "- {}{}: {}. Estimated win {} KB.",
+        item.name,
+        confidence_bracket(&item.finding),
+        item.reason,
+        item.estimated_savings_kb
+    )
 }
 
 fn with_detail_lines(

--- a/crates/legolas-cli/tests/budget_contract.rs
+++ b/crates/legolas-cli/tests/budget_contract.rs
@@ -53,9 +53,9 @@ fn potential_kb_saved_findings() -> Vec<serde_json::Value> {
         triggered_finding("heavy-dependency:react-icons", "source-import", "high"),
         triggered_finding("heavy-dependency:lodash", "source-import", "high"),
         triggered_finding("duplicate-package:lodash", "lockfile-trace", "high"),
-        triggered_finding("lazy-load:chart.js", "heuristic", "medium"),
-        triggered_finding("lazy-load:react-icons", "heuristic", "medium"),
-        triggered_finding("lazy-load:lodash", "heuristic", "medium"),
+        triggered_finding("lazy-load:chart.js", "heuristic", "low"),
+        triggered_finding("lazy-load:react-icons", "heuristic", "low"),
+        triggered_finding("lazy-load:lodash", "heuristic", "low"),
         triggered_finding("tree-shaking:lodash-root-import", "source-import", "high"),
         triggered_finding(
             "tree-shaking:react-icons-root-import",
@@ -75,9 +75,9 @@ fn duplicate_findings() -> Vec<serde_json::Value> {
 
 fn dynamic_import_findings() -> Vec<serde_json::Value> {
     vec![
-        triggered_finding("lazy-load:chart.js", "heuristic", "medium"),
-        triggered_finding("lazy-load:react-icons", "heuristic", "medium"),
-        triggered_finding("lazy-load:lodash", "heuristic", "medium"),
+        triggered_finding("lazy-load:chart.js", "heuristic", "low"),
+        triggered_finding("lazy-load:react-icons", "heuristic", "low"),
+        triggered_finding("lazy-load:lodash", "heuristic", "low"),
     ]
 }
 

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -53,9 +53,9 @@ fn potential_kb_saved_findings() -> Vec<serde_json::Value> {
         triggered_finding("heavy-dependency:react-icons", "source-import", "high"),
         triggered_finding("heavy-dependency:lodash", "source-import", "high"),
         triggered_finding("duplicate-package:lodash", "lockfile-trace", "high"),
-        triggered_finding("lazy-load:chart.js", "heuristic", "medium"),
-        triggered_finding("lazy-load:react-icons", "heuristic", "medium"),
-        triggered_finding("lazy-load:lodash", "heuristic", "medium"),
+        triggered_finding("lazy-load:chart.js", "heuristic", "low"),
+        triggered_finding("lazy-load:react-icons", "heuristic", "low"),
+        triggered_finding("lazy-load:lodash", "heuristic", "low"),
         triggered_finding("tree-shaking:lodash-root-import", "source-import", "high"),
         triggered_finding(
             "tree-shaking:react-icons-root-import",
@@ -67,9 +67,9 @@ fn potential_kb_saved_findings() -> Vec<serde_json::Value> {
 
 fn dynamic_import_findings() -> Vec<serde_json::Value> {
     vec![
-        triggered_finding("lazy-load:chart.js", "heuristic", "medium"),
-        triggered_finding("lazy-load:react-icons", "heuristic", "medium"),
-        triggered_finding("lazy-load:lodash", "heuristic", "medium"),
+        triggered_finding("lazy-load:chart.js", "heuristic", "low"),
+        triggered_finding("lazy-load:react-icons", "heuristic", "low"),
+        triggered_finding("lazy-load:lodash", "heuristic", "low"),
     ]
 }
 

--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -41,7 +41,7 @@ fn scan_and_optimize_reports_render_compact_evidence_lines() {
         "- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s)."
     ));
     assert!(scan.contains(
-        "- chart.js [medium confidence]: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB."
+        "- chart.js [low confidence]: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB."
     ));
     assert!(scan.contains(
         "  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens."
@@ -132,6 +132,72 @@ fn scan_report_renders_all_duplicate_origin_lines() {
     assert!(scan.contains("  origin: 4.17.19 via shell -> shared"));
     assert!(scan.contains("  origin: 4.17.20 via admin"));
     assert!(scan.contains("  origin: 4.17.21 via docs -> shared"));
+}
+
+#[test]
+fn scan_report_renders_route_aware_lazy_load_file_in_summary() {
+    let mut analysis = base_analysis("route-aware-report");
+    analysis.lazy_load_candidates = vec![LazyLoadCandidate {
+        name: "chart.js".to_string(),
+        estimated_savings_kb: 128,
+        recommendation: "Load it lazily.".to_string(),
+        files: vec!["app/reports/page.tsx".to_string()],
+        reason:
+            "chart.js is statically imported in route-aware UI surfaces that usually tolerate lazy loading"
+                .to_string(),
+        finding: FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic)
+            .with_confidence(legolas_core::FindingConfidence::Medium)
+            .with_evidence([FindingEvidence::new("route-file")
+                .with_file("app/reports/page.tsx")
+                .with_specifier("chart.js")
+                .with_detail("route context classified `route-page`")]),
+    }];
+
+    let scan = format_scan_report(&analysis);
+    assert!(scan.contains(
+        "- chart.js [medium confidence]: route surface app/reports/page.tsx statically imports chart.js and usually tolerates lazy loading. Estimated win 128 KB."
+    ));
+    assert!(scan.contains(
+        "  evidence: app/reports/page.tsx | specifier: chart.js | route context classified `route-page`"
+    ));
+}
+
+#[test]
+fn scan_report_renders_all_route_aware_lazy_load_files_in_summary() {
+    let mut analysis = base_analysis("route-aware-multi-report");
+    analysis.lazy_load_candidates = vec![LazyLoadCandidate {
+        name: "chart.js".to_string(),
+        estimated_savings_kb: 128,
+        recommendation: "Load it lazily.".to_string(),
+        files: vec![
+            "app/reports/page.tsx".to_string(),
+            "app/settings/page.tsx".to_string(),
+        ],
+        reason:
+            "chart.js is statically imported in route-aware UI surfaces that usually tolerate lazy loading"
+                .to_string(),
+        finding: FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic)
+            .with_confidence(legolas_core::FindingConfidence::Medium)
+            .with_evidence([
+                FindingEvidence::new("route-file")
+                    .with_file("app/reports/page.tsx")
+                    .with_specifier("chart.js")
+                    .with_detail("route context classified `route-page`"),
+                FindingEvidence::new("route-file")
+                    .with_file("app/settings/page.tsx")
+                    .with_specifier("chart.js")
+                    .with_detail("route context classified `route-page`"),
+            ]),
+    }];
+
+    let scan = format_scan_report(&analysis);
+    assert!(scan.contains(
+        "- chart.js [medium confidence]: route surfaces app/reports/page.tsx, app/settings/page.tsx statically import chart.js and usually tolerate lazy loading. Estimated win 128 KB."
+    ));
+    assert!(scan.contains(
+        "  evidence: app/reports/page.tsx | specifier: chart.js | route context classified `route-page`"
+    ));
+    assert!(!scan.contains("app/settings/page.tsx | specifier: chart.js"));
 }
 
 #[test]

--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -14,7 +14,7 @@ use crate::{
     artifacts::{detect::parse_artifact_file, detect::KNOWN_ARTIFACT_FILES, ArtifactSummary},
     confidence::{score_duplicate_package, score_heavy_dependency, score_lazy_load_candidate},
     error::Result,
-    findings::{FindingAnalysisSource, FindingEvidence, FindingMetadata},
+    findings::{FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata},
     impact::estimate_impact,
     import_scanner::{
         collect_source_files, scan_imports_with_aliases, ImportedPackageRecord, SourceAnalysis,
@@ -247,20 +247,13 @@ fn build_lazy_load_candidates(
             continue;
         }
 
-        let reason = if route_context_files.is_empty() {
-            format!(
-                "{} is statically imported in UI surfaces that usually tolerate lazy loading",
-                imported_package.name
-            )
-        } else {
-            format!(
-                "{} is statically imported in route-aware UI surfaces that usually tolerate lazy loading",
-                imported_package.name
-            )
-        };
+        let reason = lazy_load_reason(&imported_package.name, &route_context_files);
         candidates.push(LazyLoadCandidate {
             name: imported_package.name.clone(),
-            estimated_savings_kb: (heavy.estimated_kb as f64 * 0.75).round() as usize,
+            estimated_savings_kb: lazy_load_estimated_savings_kb(
+                heavy.estimated_kb,
+                &route_context_files,
+            ),
             recommendation: heavy.recommendation.clone(),
             files: split_friendly_files,
             reason,
@@ -366,8 +359,48 @@ fn build_lazy_load_finding(
         format!("lazy-load:{package_name}"),
         FindingAnalysisSource::Heuristic,
     )
-    .with_confidence(score_lazy_load_candidate())
+    .with_confidence(lazy_load_candidate_confidence(route_context_files))
     .with_evidence(evidence)
+}
+
+fn lazy_load_reason(
+    package_name: &str,
+    route_context_files: &[(String, RouteContextKind)],
+) -> String {
+    if route_context_files.is_empty() {
+        format!(
+            "{} is statically imported in UI surfaces that usually tolerate lazy loading",
+            package_name
+        )
+    } else {
+        format!(
+            "{} is statically imported in route-aware UI surfaces that usually tolerate lazy loading",
+            package_name
+        )
+    }
+}
+
+fn lazy_load_estimated_savings_kb(
+    estimated_kb: usize,
+    route_context_files: &[(String, RouteContextKind)],
+) -> usize {
+    let multiplier = if route_context_files.is_empty() {
+        0.75
+    } else {
+        0.80
+    };
+
+    (estimated_kb as f64 * multiplier).round() as usize
+}
+
+fn lazy_load_candidate_confidence(
+    route_context_files: &[(String, RouteContextKind)],
+) -> FindingConfidence {
+    if route_context_files.is_empty() {
+        FindingConfidence::Low
+    } else {
+        score_lazy_load_candidate()
+    }
 }
 
 fn lazy_load_surface_detail(file: &str) -> String {

--- a/crates/legolas-core/tests/confidence_labels.rs
+++ b/crates/legolas-core/tests/confidence_labels.rs
@@ -1,6 +1,9 @@
 mod support;
 
+use std::fs;
+
 use legolas_core::{analyze_project, FindingConfidence};
+use tempfile::tempdir;
 
 #[test]
 fn analyze_project_marks_direct_import_findings_as_high_confidence() {
@@ -31,11 +34,45 @@ fn analyze_project_marks_direct_import_findings_as_high_confidence() {
 }
 
 #[test]
-fn analyze_project_marks_lazy_load_candidates_as_medium_confidence() {
+fn analyze_project_marks_filename_heuristic_lazy_load_candidates_as_low_confidence() {
     let analysis = analyze_project(support::fixture_path(
         "tests/fixtures/confidence/high-confidence",
     ))
     .expect("analyze high confidence fixture");
+    let candidate = analysis
+        .lazy_load_candidates
+        .iter()
+        .find(|item| item.name == "chart.js")
+        .expect("chart.js lazy-load candidate");
+
+    assert_eq!(candidate.finding.confidence, Some(FindingConfidence::Low));
+}
+
+#[test]
+fn analyze_project_marks_route_aware_lazy_load_candidates_as_medium_confidence() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "route-aware-confidence-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}"#,
+    )
+    .expect("write package.json");
+    fs::create_dir_all(root.join("app/reports")).expect("create route dir");
+    fs::write(
+        root.join("app/reports/page.tsx"),
+        "import { Chart } from \"chart.js\";\nexport default function ReportsPage() { return Chart; }\n",
+    )
+    .expect("write route page");
+
+    let analysis = analyze_project(root).expect("analyze route-aware confidence fixture");
     let candidate = analysis
         .lazy_load_candidates
         .iter()

--- a/crates/legolas-core/tests/finding_evidence.rs
+++ b/crates/legolas-core/tests/finding_evidence.rs
@@ -58,7 +58,7 @@ fn analyze_project_populates_lazy_load_candidate_evidence() {
     assert_finding_metadata(
         &candidate.finding,
         FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic)
-            .with_confidence(FindingConfidence::Medium)
+            .with_confidence(FindingConfidence::Low)
             .with_evidence([FindingEvidence::new("source-file")
                 .with_file("src/AdminDashboard.tsx")
                 .with_specifier("chart.js")
@@ -143,7 +143,7 @@ fn analyze_project_limits_lazy_load_evidence_to_candidate_files() {
     assert_finding_metadata(
         &candidate.finding,
         FindingMetadata::new("lazy-load:chart.js", FindingAnalysisSource::Heuristic)
-            .with_confidence(FindingConfidence::Medium)
+            .with_confidence(FindingConfidence::Low)
             .with_evidence([FindingEvidence::new("source-file")
                 .with_file("src/Dashboard.tsx")
                 .with_specifier("chart.js")

--- a/crates/legolas-core/tests/route_aware_lazy_loading.rs
+++ b/crates/legolas-core/tests/route_aware_lazy_loading.rs
@@ -6,6 +6,7 @@ use legolas_core::{
     analyze_project,
     project_shape::detect_frameworks,
     route_context::{classify_route_context, RouteContextKind},
+    FindingConfidence,
 };
 use serde_json::Value;
 use tempfile::tempdir;
@@ -588,6 +589,11 @@ fn analyze_project_uses_route_context_for_lazy_load_candidates_without_keyword_m
         candidate.reason,
         "chart.js is statically imported in route-aware UI surfaces that usually tolerate lazy loading"
     );
+    assert_eq!(candidate.estimated_savings_kb, 128);
+    assert_eq!(
+        candidate.finding.confidence,
+        Some(FindingConfidence::Medium)
+    );
     let evidence = candidate
         .finding
         .evidence
@@ -721,6 +727,7 @@ fn analyze_project_keeps_direct_route_files_inside_support_named_segments_as_can
         candidate.reason,
         "chart.js is statically imported in route-aware UI surfaces that usually tolerate lazy loading"
     );
+    assert_eq!(candidate.estimated_savings_kb, 128);
     let evidence = candidate
         .finding
         .evidence

--- a/tests/oracles/basic-app/optimize-ranked.txt
+++ b/tests/oracles/basic-app/optimize-ranked.txt
@@ -4,7 +4,7 @@ Legolas optimize for basic-parity-app
    recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
    targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
-2. Lazy load chart.js [medium | medium confidence | ~120 KB]
+2. Lazy load chart.js [medium | low confidence | ~120 KB]
    recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
    targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
@@ -17,7 +17,7 @@ Legolas optimize for basic-parity-app
    targets: src/Dashboard.tsx
    replacement: lodash-es
    evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
-5. Lazy load react-icons [medium | medium confidence | ~68 KB]
+5. Lazy load react-icons [medium | low confidence | ~68 KB]
    recommended fix: lazy-load - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
    targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword

--- a/tests/oracles/basic-app/optimize.txt
+++ b/tests/oracles/basic-app/optimize.txt
@@ -4,7 +4,7 @@ Legolas optimize for basic-parity-app
    recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
    targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
-2. Lazy load chart.js [medium | medium confidence | ~120 KB]
+2. Lazy load chart.js [medium | low confidence | ~120 KB]
    recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
    targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
@@ -17,7 +17,7 @@ Legolas optimize for basic-parity-app
    targets: src/Dashboard.tsx
    replacement: lodash-es
    evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
-5. Lazy load react-icons [medium | medium confidence | ~68 KB]
+5. Lazy load react-icons [medium | low confidence | ~68 KB]
    recommended fix: lazy-load - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
    targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword

--- a/tests/oracles/basic-app/scan.json
+++ b/tests/oracles/basic-app/scan.json
@@ -162,7 +162,7 @@
       "reason": "chart.js is statically imported in UI surfaces that usually tolerate lazy loading",
       "findingId": "lazy-load:chart.js",
       "analysisSource": "heuristic",
-      "confidence": "medium",
+      "confidence": "low",
       "actionPriority": 2,
       "recommendedFix": {
         "kind": "lazy-load",
@@ -190,7 +190,7 @@
       "reason": "react-icons is statically imported in UI surfaces that usually tolerate lazy loading",
       "findingId": "lazy-load:react-icons",
       "analysisSource": "heuristic",
-      "confidence": "medium",
+      "confidence": "low",
       "actionPriority": 5,
       "recommendedFix": {
         "kind": "lazy-load",
@@ -218,7 +218,7 @@
       "reason": "lodash is statically imported in UI surfaces that usually tolerate lazy loading",
       "findingId": "lazy-load:lodash",
       "analysisSource": "heuristic",
-      "confidence": "medium",
+      "confidence": "low",
       "actionPriority": 6,
       "recommendedFix": {
         "kind": "lazy-load",

--- a/tests/oracles/basic-app/scan.txt
+++ b/tests/oracles/basic-app/scan.txt
@@ -23,11 +23,11 @@ Duplicate package versions:
   origin: 4.17.21 via lodash
 
 Lazy-load candidates:
-- chart.js [medium confidence]: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB.
+- chart.js [low confidence]: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB.
   evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
-- react-icons [medium confidence]: react-icons is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 68 KB.
+- react-icons [low confidence]: react-icons is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 68 KB.
   evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
-- lodash [medium confidence]: lodash is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 54 KB.
+- lodash [low confidence]: lodash is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 54 KB.
   evidence: src/Dashboard.tsx | specifier: lodash | route-like UI surface matched `dashboard` keyword
 
 Tree-shaking warnings:


### PR DESCRIPTION
배경
- `PR-FIT-009B` 범위에서 route context를 lazy-load confidence와 reporter wording에 실제 반영했습니다.
- heuristic filename 후보와 route-aware 후보를 같은 confidence로 다루던 부분을 분리해 false positive를 줄이려는 변경입니다.

변경 사항
- heuristic filename 기반 lazy-load candidate를 `low confidence`로 내렸습니다.
- route context를 실제로 잡은 candidate만 `medium confidence`를 유지하도록 정리했습니다.
- route-aware candidate는 estimated savings를 약간 높이고, text report summary line에 첫 route file을 직접 노출하도록 바꿨습니다.
- `budget`/`ci` contract와 parity oracle을 새 confidence 계약에 맞게 갱신했습니다.

검증
- `cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

브랜치 / 워크트리
- 대상 브랜치: `codex/route-aware-lazy-load-confidence`
- 현재 워크트리: `/Users/pjw/workspace/legolas`
- source worktree/source branch: 없음