### PR TITLE
feat: merged artifact evidence 반영

### DIFF
--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -284,7 +284,7 @@ struct BarItem {
 struct ActionLine {
     headline: String,
     details: Vec<String>,
-    evidence: Option<String>,
+    evidence: Vec<String>,
 }
 
 fn build_actions(analysis: &Analysis) -> Vec<ActionLine> {
@@ -314,7 +314,9 @@ fn build_ranked_actions(analysis: &Analysis) -> Vec<ActionLine> {
                     action.estimated_savings_kb
                 ),
                 details: recommended_fix_details(action.recommended_fix.as_ref()),
-                evidence: context.and_then(|item| item.evidence.clone()),
+                evidence: context
+                    .map(|item| item.evidence.clone())
+                    .unwrap_or_default(),
             }
         })
         .collect()
@@ -331,7 +333,7 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
                     dependency.name
                 ),
                 details: Vec::new(),
-                evidence: first_evidence_line(&dependency.finding),
+                evidence: display_evidence_lines(&dependency.finding),
             });
             continue;
         }
@@ -339,7 +341,7 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
         actions.push(ActionLine {
             headline: format!("Review {}: {}", dependency.name, dependency.recommendation),
             details: Vec::new(),
-            evidence: first_evidence_line(&dependency.finding),
+            evidence: display_evidence_lines(&dependency.finding),
         });
     }
 
@@ -352,7 +354,7 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
                 duplicate.estimated_extra_kb
             ),
             details: Vec::new(),
-            evidence: first_evidence_line(&duplicate.finding),
+            evidence: display_evidence_lines(&duplicate.finding),
         });
     }
 
@@ -368,7 +370,7 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
                 candidate.name, file, candidate.estimated_savings_kb
             ),
             details: Vec::new(),
-            evidence: first_evidence_line(&candidate.finding),
+            evidence: display_evidence_lines(&candidate.finding),
         });
     }
 
@@ -379,7 +381,7 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
                 warning.package_name, warning.recommendation
             ),
             details: Vec::new(),
-            evidence: first_evidence_line(&warning.finding),
+            evidence: display_evidence_lines(&warning.finding),
         });
     }
 
@@ -483,7 +485,7 @@ fn with_detail_lines(
     let mut lines = vec![summary];
     lines.extend(details.iter().map(|detail| format!("{indent}{detail}")));
 
-    if let Some(evidence) = first_evidence_line(finding) {
+    for evidence in display_evidence_lines(finding) {
         lines.push(format!("{indent}evidence: {evidence}"));
     }
 
@@ -500,7 +502,7 @@ fn confidence_bracket(finding: &FindingMetadata) -> String {
 #[derive(Clone)]
 struct ActionContext {
     headline: String,
-    evidence: Option<String>,
+    evidence: Vec<String>,
 }
 
 fn build_action_contexts(analysis: &Analysis) -> BTreeMap<String, ActionContext> {
@@ -563,7 +565,7 @@ fn insert_action_context(
         finding_id.clone(),
         ActionContext {
             headline,
-            evidence: first_evidence_line(finding),
+            evidence: display_evidence_lines(finding),
         },
     );
 }
@@ -627,15 +629,28 @@ fn render_action_line(item: &ActionLine, index: usize) -> String {
         lines.push(format!("   {detail}"));
     }
 
-    if let Some(evidence) = item.evidence.as_deref() {
+    for evidence in &item.evidence {
         lines.push(format!("   evidence: {evidence}"));
     }
 
     lines.join("\n")
 }
 
-fn first_evidence_line(finding: &FindingMetadata) -> Option<String> {
-    finding.evidence.first().map(format_evidence)
+fn display_evidence_lines(finding: &FindingMetadata) -> Vec<String> {
+    let lines = finding
+        .evidence
+        .iter()
+        .map(format_evidence)
+        .collect::<Vec<_>>();
+    if finding
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "artifact-chunk")
+    {
+        lines
+    } else {
+        lines.into_iter().take(1).collect()
+    }
 }
 
 fn format_evidence(evidence: &FindingEvidence) -> String {

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -1,6 +1,7 @@
 mod support;
 
 use assert_cmd::Command;
+use serde_json::json;
 
 #[test]
 fn prints_version_without_a_command() {
@@ -103,6 +104,71 @@ fn matches_scan_json_oracle() {
         support::normalize_analysis_json_output(&support::read_oracle("basic-app/scan.json"))
     );
     assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
+}
+
+#[test]
+fn merge_app_scan_json_exposes_additive_artifact_contract() {
+    let fixture = support::fixture_path("tests/fixtures/artifacts/merge-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run merge-app scan --json");
+
+    assert!(output.status.success());
+    let analysis =
+        support::normalize_analysis_json_output(&String::from_utf8(output.stdout).expect("stdout"));
+    let heavy_dependencies = analysis["heavyDependencies"]
+        .as_array()
+        .expect("heavy dependencies array");
+
+    let chart_js = heavy_dependencies
+        .iter()
+        .find(|item| item["name"] == "chart.js")
+        .expect("chart.js heavy dependency");
+    assert_eq!(chart_js["analysisSource"], json!("artifact-source"));
+    let chart_js_evidence = chart_js["evidence"].as_array().expect("chart.js evidence");
+    assert_eq!(chart_js_evidence.len(), 2);
+    assert_eq!(chart_js_evidence[0]["kind"], json!("source-file"));
+    assert_eq!(chart_js_evidence[0]["file"], json!("src/AdminPage.tsx"));
+    assert_eq!(chart_js_evidence[0]["specifier"], json!("chart.js"));
+    assert_eq!(chart_js_evidence[1]["kind"], json!("artifact-chunk"));
+    assert_eq!(chart_js_evidence[1]["file"], json!("dist/admin.js"));
+    assert_eq!(chart_js_evidence[1]["specifier"], json!("chart.js"));
+    assert_eq!(
+        chart_js_evidence[1]["detail"],
+        json!("artifact chunk `admin` contributes 6200 bytes; entrypoints: dashboard")
+    );
+
+    let lodash = heavy_dependencies
+        .iter()
+        .find(|item| item["name"] == "lodash")
+        .expect("lodash heavy dependency");
+    assert_eq!(lodash["analysisSource"], json!("artifact"));
+    assert_eq!(
+        lodash["evidence"],
+        json!([
+            {
+                "kind": "artifact-chunk",
+                "file": "dist/vendor.js",
+                "specifier": "lodash",
+                "detail": "artifact chunk `vendor` contributes 5100 bytes; entrypoints: dashboard"
+            }
+        ])
+    );
+
+    let react_icons = heavy_dependencies
+        .iter()
+        .find(|item| item["name"] == "react-icons")
+        .expect("react-icons heavy dependency");
+    assert_eq!(react_icons["analysisSource"], json!("source-import"));
+    let react_icons_evidence = react_icons["evidence"]
+        .as_array()
+        .expect("react-icons evidence");
+    assert_eq!(react_icons_evidence.len(), 1);
+    assert_eq!(react_icons_evidence[0]["kind"], json!("source-file"));
+    assert_eq!(react_icons_evidence[0]["file"], json!("src/AdminPage.tsx"));
+    assert_eq!(react_icons_evidence[0]["specifier"], json!("react-icons"));
 }
 
 #[test]

--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -4,9 +4,9 @@ use legolas_cli::reporters::text::{
     format_optimize_report, format_scan_report, format_visualization_report,
 };
 use legolas_core::{
-    Analysis, DuplicateOrigin, DuplicatePackage, FindingAnalysisSource, FindingEvidence,
-    FindingMetadata, HeavyDependency, Impact, LazyLoadCandidate, Metadata, PackageSummary,
-    SourceSummary,
+    Analysis, DuplicateOrigin, DuplicatePackage, FindingAnalysisSource, FindingConfidence,
+    FindingEvidence, FindingMetadata, HeavyDependency, Impact, LazyLoadCandidate, Metadata,
+    PackageSummary, SourceSummary,
 };
 
 fn load_analysis() -> Analysis {
@@ -102,6 +102,51 @@ fn scan_and_optimize_reports_only_render_the_first_evidence_line_per_finding() {
         )
     );
     assert!(!optimize.contains("second evidence detail"));
+}
+
+#[test]
+fn scan_and_optimize_reports_render_all_evidence_lines_for_artifact_assisted_findings() {
+    let mut analysis = base_analysis("artifact-evidence-app");
+    analysis.heavy_dependencies = vec![HeavyDependency {
+        name: "chart.js".to_string(),
+        estimated_kb: 160,
+        rationale: "Charting code is often only needed on a subset of screens.".to_string(),
+        recommendation:
+            "Register only the chart primitives you use and lazy load dashboard surfaces."
+                .to_string(),
+        imported_by: vec!["src/Admin.tsx".to_string()],
+        finding: FindingMetadata::new(
+            "heavy-dependency:chart.js",
+            FindingAnalysisSource::ArtifactSource,
+        )
+        .with_confidence(FindingConfidence::High)
+        .with_evidence([
+            FindingEvidence::new("source-file")
+                .with_file("src/Admin.tsx")
+                .with_specifier("chart.js")
+                .with_detail("source evidence detail"),
+            FindingEvidence::new("artifact-chunk")
+                .with_file("dist/admin.js")
+                .with_specifier("chart.js")
+                .with_detail("artifact chunk `admin` contributes 6200 bytes"),
+        ]),
+        ..HeavyDependency::default()
+    }];
+
+    let scan = format_scan_report(&analysis);
+    assert!(
+        scan.contains("  evidence: src/Admin.tsx | specifier: chart.js | source evidence detail")
+    );
+    assert!(scan.contains(
+        "  evidence: dist/admin.js | specifier: chart.js | artifact chunk `admin` contributes 6200 bytes"
+    ));
+
+    let optimize = format_optimize_report(&analysis, 1);
+    assert!(optimize
+        .contains("   evidence: src/Admin.tsx | specifier: chart.js | source evidence detail"));
+    assert!(optimize.contains(
+        "   evidence: dist/admin.js | specifier: chart.js | artifact chunk `admin` contributes 6200 bytes"
+    ));
 }
 
 #[test]

--- a/crates/legolas-core/src/analyze.rs
+++ b/crates/legolas-core/src/analyze.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Reverse,
+    collections::BTreeMap,
     fs,
     path::Path,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -11,7 +12,10 @@ use serde_json::Value;
 
 use crate::{
     action_plan::apply_action_plan,
-    artifacts::{detect::parse_artifact_file, detect::KNOWN_ARTIFACT_FILES, ArtifactSummary},
+    artifacts::{
+        detect::parse_artifact_file, detect::KNOWN_ARTIFACT_FILES, merge_artifact_source_signals,
+        ArtifactSummary,
+    },
     confidence::{score_duplicate_package, score_heavy_dependency, score_lazy_load_candidate},
     error::Result,
     findings::{FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata},
@@ -61,6 +65,12 @@ pub fn analyze_project<P: AsRef<Path>>(input_path: P) -> Result<Analysis> {
     );
     let tree_shaking_warnings = build_tree_shaking_warnings(&source_analysis);
     let artifact_assist = collect_artifact_assist(&project_root)?;
+    let mut heavy_dependencies = heavy_dependencies;
+    if let Some(artifact_summary) = artifact_assist.artifact_summary.as_ref() {
+        let merged_signals =
+            merge_artifact_source_signals(artifact_summary, &source_analysis, &heavy_dependencies);
+        apply_merged_artifact_signals(&mut heavy_dependencies, &merged_signals);
+    }
     let impact = estimate_impact(
         &heavy_dependencies,
         &duplicate_analysis.duplicates,
@@ -326,6 +336,38 @@ fn build_heavy_dependency_finding(
     FindingMetadata::new(format!("heavy-dependency:{package_name}"), analysis_source)
         .with_confidence(score_heavy_dependency(import_info))
         .with_evidence(evidence)
+}
+
+fn apply_merged_artifact_signals(
+    heavy_dependencies: &mut [HeavyDependency],
+    merged_signals: &[crate::artifacts::ArtifactSourceSignal],
+) {
+    let signals_by_package = merged_signals
+        .iter()
+        .map(|signal| (signal.package_name.as_str(), signal))
+        .collect::<BTreeMap<_, _>>();
+
+    for dependency in heavy_dependencies {
+        let Some(signal) = signals_by_package.get(dependency.name.as_str()) else {
+            continue;
+        };
+
+        let analysis_source = match signal.kind {
+            crate::artifacts::ArtifactSignalKind::Source => continue,
+            crate::artifacts::ArtifactSignalKind::Artifact => FindingAnalysisSource::Artifact,
+            crate::artifacts::ArtifactSignalKind::ArtifactSource => {
+                FindingAnalysisSource::ArtifactSource
+            }
+        };
+
+        dependency.finding.analysis_source = Some(analysis_source);
+        dependency.finding.evidence.extend(
+            signal
+                .evidence()
+                .into_iter()
+                .skip(signal.source_files.len()),
+        );
+    }
 }
 
 fn build_lazy_load_finding(

--- a/crates/legolas-core/src/findings.rs
+++ b/crates/legolas-core/src/findings.rs
@@ -7,6 +7,8 @@ pub enum FindingAnalysisSource {
     Heuristic,
     SourceImport,
     LockfileTrace,
+    Artifact,
+    ArtifactSource,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]


### PR DESCRIPTION
## 배경
- `PR-FIT-010B` 목표는 merged artifact evidence를 finding metadata와 사람이 읽는 출력까지 연결하는 것입니다.
- 기존에는 artifact summary가 있어도 heavy dependency finding의 `analysisSource`와 evidence가 source 중심으로만 남아 있었습니다.

## 변경 사항
- heavy dependency finding이 merged artifact signal을 받아 `analysisSource`를 `artifact` 또는 `artifact-source`로 승격하도록 반영했습니다.
- merged evidence ordering을 유지한 채 source evidence 뒤에 artifact chunk evidence를 붙이도록 정리했습니다.
- text reporter가 `artifact-chunk` evidence가 포함된 finding에서는 추가 evidence 줄까지 출력하도록 확장했습니다.
- `merge-app` fixture 기준 JSON contract test를 추가해 `chart.js`, `lodash`, `react-icons`의 `analysisSource`와 evidence ordering을 고정했습니다.
- artifact-assisted finding의 text output regression test를 추가해 human-readable 출력 드리프트를 막았습니다.

## 검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- scan tests/fixtures/artifacts/merge-app --json`
- `cargo run -p legolas-cli -- scan tests/fixtures/artifacts/merge-app`
- `cargo test -p legolas-cli --test text_report_parity -- --nocapture`

## 브랜치 / 워크트리
- 대상 브랜치: `codex/pr-fit-010b-artifact-source-adoption`
- 기준 브랜치: `master`
- worktree mode 사용 안 함
- TaskMaestro 상태 파일: `.taskmaestro/session-state.json` (local-only, 미포함)

## 이슈 연결
- 별도 이슈 연결 없음
