### PR TITLE
feat: baseline diff engine 추가

### DIFF
--- a/crates/legolas-core/src/baseline.rs
+++ b/crates/legolas-core/src/baseline.rs
@@ -1,0 +1,177 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Analysis;
+
+pub const BASELINE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BaselineSnapshot {
+    pub schema_version: u32,
+    pub project_name: String,
+    pub package_manager: String,
+    pub dependency_count: usize,
+    pub dev_dependency_count: usize,
+    pub source_file_count: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub heavy_dependency_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tree_shaking_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+impl Default for BaselineSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: BASELINE_SCHEMA_VERSION,
+            project_name: String::new(),
+            package_manager: String::new(),
+            dependency_count: 0,
+            dev_dependency_count: 0,
+            source_file_count: 0,
+            heavy_dependency_names: Vec::new(),
+            tree_shaking_warning_keys: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+}
+
+impl BaselineSnapshot {
+    pub fn from_analysis(analysis: &Analysis) -> Self {
+        Self {
+            schema_version: BASELINE_SCHEMA_VERSION,
+            project_name: analysis.package_summary.name.clone(),
+            package_manager: analysis.package_manager.clone(),
+            dependency_count: analysis.package_summary.dependency_count,
+            dev_dependency_count: analysis.package_summary.dev_dependency_count,
+            source_file_count: analysis.source_summary.files_scanned,
+            heavy_dependency_names: unique_sorted(
+                analysis
+                    .heavy_dependencies
+                    .iter()
+                    .map(|item| item.name.clone()),
+            ),
+            tree_shaking_warning_keys: unique_sorted(
+                analysis
+                    .tree_shaking_warnings
+                    .iter()
+                    .map(|item| item.key.clone()),
+            ),
+            warnings: unique_sorted(analysis.warnings.iter().cloned()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BaselineDiff {
+    pub schema_version: u32,
+    pub project_name_previous: String,
+    pub project_name_current: String,
+    pub package_manager_previous: String,
+    pub package_manager_current: String,
+    pub dependency_count_previous: usize,
+    pub dependency_count_current: usize,
+    pub dev_dependency_count_previous: usize,
+    pub dev_dependency_count_current: usize,
+    pub source_file_count_previous: usize,
+    pub source_file_count_current: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_heavy_dependency_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_heavy_dependency_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_tree_shaking_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_tree_shaking_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_warnings: Vec<String>,
+}
+
+impl BaselineDiff {
+    pub fn is_empty(&self) -> bool {
+        self.project_name_previous == self.project_name_current
+            && self.package_manager_previous == self.package_manager_current
+            && self.dependency_count_previous == self.dependency_count_current
+            && self.dev_dependency_count_previous == self.dev_dependency_count_current
+            && self.source_file_count_previous == self.source_file_count_current
+            && self.added_heavy_dependency_names.is_empty()
+            && self.removed_heavy_dependency_names.is_empty()
+            && self.added_tree_shaking_warning_keys.is_empty()
+            && self.removed_tree_shaking_warning_keys.is_empty()
+            && self.added_warnings.is_empty()
+            && self.removed_warnings.is_empty()
+    }
+}
+
+pub fn diff_baselines(previous: &BaselineSnapshot, current: &BaselineSnapshot) -> BaselineDiff {
+    BaselineDiff {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        project_name_previous: previous.project_name.clone(),
+        project_name_current: current.project_name.clone(),
+        package_manager_previous: previous.package_manager.clone(),
+        package_manager_current: current.package_manager.clone(),
+        dependency_count_previous: previous.dependency_count,
+        dependency_count_current: current.dependency_count,
+        dev_dependency_count_previous: previous.dev_dependency_count,
+        dev_dependency_count_current: current.dev_dependency_count,
+        source_file_count_previous: previous.source_file_count,
+        source_file_count_current: current.source_file_count,
+        added_heavy_dependency_names: diff_added(
+            previous.heavy_dependency_names.as_slice(),
+            current.heavy_dependency_names.as_slice(),
+        ),
+        removed_heavy_dependency_names: diff_removed(
+            previous.heavy_dependency_names.as_slice(),
+            current.heavy_dependency_names.as_slice(),
+        ),
+        added_tree_shaking_warning_keys: diff_added(
+            previous.tree_shaking_warning_keys.as_slice(),
+            current.tree_shaking_warning_keys.as_slice(),
+        ),
+        removed_tree_shaking_warning_keys: diff_removed(
+            previous.tree_shaking_warning_keys.as_slice(),
+            current.tree_shaking_warning_keys.as_slice(),
+        ),
+        added_warnings: diff_added(previous.warnings.as_slice(), current.warnings.as_slice()),
+        removed_warnings: diff_removed(previous.warnings.as_slice(), current.warnings.as_slice()),
+    }
+}
+
+pub fn diff_analysis(previous: &BaselineSnapshot, current: &Analysis) -> BaselineDiff {
+    diff_baselines(previous, &BaselineSnapshot::from_analysis(current))
+}
+
+fn unique_sorted<I>(values: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    values
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn diff_added(previous: &[String], current: &[String]) -> Vec<String> {
+    let previous = previous.iter().cloned().collect::<BTreeSet<_>>();
+    current
+        .iter()
+        .filter(|item| !previous.contains(item.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn diff_removed(previous: &[String], current: &[String]) -> Vec<String> {
+    let current = current.iter().cloned().collect::<BTreeSet<_>>();
+    previous
+        .iter()
+        .filter(|item| !current.contains(item.as_str()))
+        .cloned()
+        .collect()
+}

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod action_plan;
 pub mod aliases;
 pub mod analyze;
 pub mod artifacts;
+pub mod baseline;
 pub mod boundaries;
 pub mod budget;
 pub mod confidence;
@@ -20,6 +21,7 @@ pub mod workspaces;
 
 pub use action_plan::*;
 pub use analyze::analyze_project;
+pub use baseline::*;
 pub use boundaries::*;
 pub use confidence::*;
 pub use error::{LegolasError, Result};

--- a/crates/legolas-core/tests/baseline_diff.rs
+++ b/crates/legolas-core/tests/baseline_diff.rs
@@ -1,0 +1,59 @@
+mod support;
+
+use std::fs;
+
+use legolas_core::{analyze_project, diff_analysis, BaselineSnapshot};
+
+#[test]
+fn baseline_diff_detects_new_package_and_tree_shaking_warning() {
+    let previous: BaselineSnapshot = serde_json::from_str(
+        &fs::read_to_string(support::fixture_path(
+            "tests/fixtures/baseline/previous-scan.json",
+        ))
+        .expect("read previous baseline"),
+    )
+    .expect("parse previous baseline");
+    let current_analysis =
+        analyze_project(support::fixture_path("tests/fixtures/baseline/current-app"))
+            .expect("analyze current app");
+    let current = BaselineSnapshot::from_analysis(&current_analysis);
+    let diff = diff_analysis(&previous, &current_analysis);
+
+    assert_eq!(current.project_name, "baseline-app");
+    assert_eq!(current.package_manager, "npm");
+    assert_eq!(
+        diff.added_heavy_dependency_names,
+        vec!["lodash".to_string()]
+    );
+    assert_eq!(diff.removed_heavy_dependency_names, Vec::<String>::new());
+    assert_eq!(
+        diff.added_tree_shaking_warning_keys,
+        vec!["lodash-root-import".to_string()]
+    );
+    assert_eq!(diff.removed_tree_shaking_warning_keys, Vec::<String>::new());
+    assert_eq!(diff.dependency_count_previous, 1);
+    assert_eq!(diff.dependency_count_current, 2);
+    assert_eq!(diff.source_file_count_previous, 1);
+    assert_eq!(diff.source_file_count_current, 1);
+    assert!(!diff.is_empty());
+}
+
+#[test]
+fn baseline_snapshot_round_trips_as_json() {
+    let snapshot = BaselineSnapshot {
+        schema_version: 1,
+        project_name: "baseline-app".to_string(),
+        package_manager: "npm".to_string(),
+        dependency_count: 1,
+        dev_dependency_count: 0,
+        source_file_count: 1,
+        heavy_dependency_names: vec!["chart.js".to_string()],
+        tree_shaking_warning_keys: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    let encoded = serde_json::to_string_pretty(&snapshot).expect("serialize snapshot");
+    let decoded: BaselineSnapshot = serde_json::from_str(&encoded).expect("deserialize snapshot");
+
+    assert_eq!(decoded, snapshot);
+}

--- a/tests/fixtures/baseline/current-app/package.json
+++ b/tests/fixtures/baseline/current-app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "baseline-app",
+  "packageManager": "npm",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "lodash": "^4.17.21"
+  }
+}

--- a/tests/fixtures/baseline/current-app/src/App.tsx
+++ b/tests/fixtures/baseline/current-app/src/App.tsx
@@ -1,0 +1,6 @@
+import { Chart } from "chart.js";
+import _ from "lodash";
+
+export default function App() {
+  return Chart ? <div>{_.chunk([1, 2, 3], 2).length}</div> : null;
+}

--- a/tests/fixtures/baseline/previous-scan.json
+++ b/tests/fixtures/baseline/previous-scan.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "projectName": "baseline-app",
+  "packageManager": "npm",
+  "dependencyCount": 1,
+  "devDependencyCount": 0,
+  "sourceFileCount": 1,
+  "heavyDependencyNames": [
+    "chart.js"
+  ],
+  "treeShakingWarningKeys": [],
+  "warnings": []
+}


### PR DESCRIPTION
## 배경
- base branch는 codex/seed-fit-workspace 입니다.
- PR-FIT-011A는 baseline snapshot 스키마와 diff engine만 다루는 core slice입니다.
- CLI 플래그와 regression-only 출력 채택은 후속 PR-FIT-011B로 남깁니다.

## 변경 사항
- baseline snapshot 스키마를 추가했습니다.
- baseline 간 diff 계산 로직을 추가했습니다.
- fixture 기반 core regression test를 추가했습니다.
- seed seam 위에서 reusable module로 export되도록 정리했습니다.

## 검증
- cargo test -p legolas-core --test baseline_diff
