### PR TITLE
feat: general boundary detector 추가

### DIFF
--- a/crates/legolas-core/src/boundaries.rs
+++ b/crates/legolas-core/src/boundaries.rs
@@ -1,8 +1,16 @@
-use std::path::Path;
+use std::{
+    path::{Component, Path},
+    sync::OnceLock,
+};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{findings::FindingMetadata, import_scanner::SourceAnalysis};
+use crate::{
+    findings::{FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata},
+    import_scanner::SourceAnalysis,
+};
+
+static SERVER_ONLY_PACKAGES: OnceLock<Vec<&'static str>> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -25,6 +33,72 @@ pub struct Phase8SeedContext<'a> {
     pub dynamic_import_count: usize,
 }
 
-pub fn collect_boundary_warnings(_context: &Phase8SeedContext<'_>) -> Vec<BoundaryWarning> {
-    Vec::new()
+pub fn collect_boundary_warnings(context: &Phase8SeedContext<'_>) -> Vec<BoundaryWarning> {
+    let mut warnings = Vec::new();
+
+    for (package_name, record) in &context.source_analysis.by_package {
+        if !is_server_only_package(package_name) {
+            continue;
+        }
+
+        let Some(client_file) = record.files.iter().find(|file| is_client_surface(file)) else {
+            continue;
+        };
+
+        warnings.push(build_boundary_warning(package_name, client_file));
+    }
+
+    warnings
+}
+
+fn build_boundary_warning(package_name: &str, client_file: &str) -> BoundaryWarning {
+    BoundaryWarning {
+        message: format!(
+            "Client surface `{client_file}` imports the Node-only `{package_name}` module."
+        ),
+        recommendation: "Keep Node-only work on the server and pass browser-safe data into the client component."
+            .to_string(),
+        finding: FindingMetadata::new(
+            format!("boundary:server-client:{package_name}"),
+            FindingAnalysisSource::SourceImport,
+        )
+        .with_confidence(FindingConfidence::High)
+        .with_action_priority(1)
+        .with_evidence([FindingEvidence::new("source-file")
+            .with_file(client_file)
+            .with_specifier(package_name)
+            .with_detail("client surface imports a Node-only module")]),
+    }
+}
+
+fn is_server_only_package(package_name: &str) -> bool {
+    server_only_packages().contains(&package_name)
+}
+
+fn server_only_packages() -> &'static [&'static str] {
+    SERVER_ONLY_PACKAGES
+        .get_or_init(|| {
+            vec![
+                "child_process",
+                "crypto",
+                "dns",
+                "fs",
+                "module",
+                "net",
+                "os",
+                "path",
+                "readline",
+                "server-only",
+                "stream",
+                "tls",
+                "worker_threads",
+            ]
+        })
+        .as_slice()
+}
+
+fn is_client_surface(relative_path: &str) -> bool {
+    Path::new(relative_path)
+        .components()
+        .any(|component| matches!(component, Component::Normal(segment) if segment == "client"))
 }

--- a/crates/legolas-core/src/boundaries.rs
+++ b/crates/legolas-core/src/boundaries.rs
@@ -1,8 +1,10 @@
 use std::{
+    fs,
     path::{Component, Path},
     sync::OnceLock,
 };
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -11,6 +13,7 @@ use crate::{
 };
 
 static SERVER_ONLY_PACKAGES: OnceLock<Vec<&'static str>> = OnceLock::new();
+static NODE_PREFIX_IMPORT_PATTERN: OnceLock<Regex> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -35,6 +38,7 @@ pub struct Phase8SeedContext<'a> {
 
 pub fn collect_boundary_warnings(context: &Phase8SeedContext<'_>) -> Vec<BoundaryWarning> {
     let mut warnings = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
 
     for (package_name, record) in &context.source_analysis.by_package {
         if !is_server_only_package(package_name) {
@@ -45,16 +49,45 @@ pub fn collect_boundary_warnings(context: &Phase8SeedContext<'_>) -> Vec<Boundar
             continue;
         };
 
-        warnings.push(build_boundary_warning(package_name, client_file));
+        let key = format!("{client_file}:{package_name}");
+        if seen.insert(key) {
+            warnings.push(build_boundary_warning(
+                package_name,
+                package_name,
+                client_file,
+            ));
+        }
+    }
+
+    for (client_file, specifier) in collect_node_prefix_client_imports(context.project_root) {
+        let Some(package_name) = specifier.strip_prefix("node:") else {
+            continue;
+        };
+        if !is_server_only_package(package_name) {
+            continue;
+        }
+
+        let key = format!("{client_file}:{package_name}");
+        if seen.insert(key) {
+            warnings.push(build_boundary_warning(
+                package_name,
+                &specifier,
+                &client_file,
+            ));
+        }
     }
 
     warnings
 }
 
-fn build_boundary_warning(package_name: &str, client_file: &str) -> BoundaryWarning {
+fn build_boundary_warning(
+    package_name: &str,
+    raw_specifier: &str,
+    client_file: &str,
+) -> BoundaryWarning {
     BoundaryWarning {
         message: format!(
-            "Client surface `{client_file}` imports the Node-only `{package_name}` module."
+            "Client surface `{client_file}` imports the Node-only `{raw_specifier}` module."
         ),
         recommendation: "Keep Node-only work on the server and pass browser-safe data into the client component."
             .to_string(),
@@ -66,7 +99,7 @@ fn build_boundary_warning(package_name: &str, client_file: &str) -> BoundaryWarn
         .with_action_priority(1)
         .with_evidence([FindingEvidence::new("source-file")
             .with_file(client_file)
-            .with_specifier(package_name)
+            .with_specifier(raw_specifier)
             .with_detail("client surface imports a Node-only module")]),
     }
 }
@@ -101,4 +134,99 @@ fn is_client_surface(relative_path: &str) -> bool {
     Path::new(relative_path)
         .components()
         .any(|component| matches!(component, Component::Normal(segment) if segment == "client"))
+}
+
+fn collect_node_prefix_client_imports(project_root: &Path) -> Vec<(String, String)> {
+    let mut matches = Vec::new();
+    collect_node_prefix_client_imports_inner(project_root, project_root, &mut matches);
+    matches
+}
+
+fn collect_node_prefix_client_imports_inner(
+    project_root: &Path,
+    current: &Path,
+    matches: &mut Vec<(String, String)>,
+) {
+    let Ok(entries) = fs::read_dir(current) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+
+        if file_type.is_dir() {
+            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if matches!(
+                name,
+                ".git"
+                    | "node_modules"
+                    | "dist"
+                    | "build"
+                    | ".next"
+                    | ".turbo"
+                    | "coverage"
+                    | ".output"
+                    | "test"
+                    | "tests"
+                    | "__tests__"
+            ) {
+                continue;
+            }
+            collect_node_prefix_client_imports_inner(project_root, &path, matches);
+            continue;
+        }
+
+        if !is_supported_source_file(&path) {
+            continue;
+        }
+
+        let Some(relative_path) = path.strip_prefix(project_root).ok().map(to_posix) else {
+            continue;
+        };
+        if !is_client_surface(&relative_path) {
+            continue;
+        }
+
+        let Ok(contents) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for specifier in node_prefix_import_specifiers(&contents) {
+            matches.push((relative_path.clone(), specifier));
+        }
+    }
+}
+
+fn is_supported_source_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|value| value.to_str()),
+        Some("js" | "jsx" | "ts" | "tsx" | "cjs" | "cts" | "mjs" | "mts" | "vue" | "svelte")
+    )
+}
+
+fn node_prefix_import_specifiers(contents: &str) -> Vec<String> {
+    node_prefix_import_pattern()
+        .captures_iter(contents)
+        .filter_map(|captures| captures.get(1).map(|value| value.as_str().to_string()))
+        .collect()
+}
+
+fn node_prefix_import_pattern() -> &'static Regex {
+    NODE_PREFIX_IMPORT_PATTERN.get_or_init(|| {
+        Regex::new(r#"["'](node:[^"']+)["']"#).expect("valid node prefix import regex")
+    })
+}
+
+fn to_posix(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(segment) => Some(segment.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }

--- a/crates/legolas-core/tests/boundary_analysis.rs
+++ b/crates/legolas-core/tests/boundary_analysis.rs
@@ -1,0 +1,44 @@
+mod support;
+
+use legolas_core::{
+    analyze_project, FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata,
+};
+
+#[test]
+fn analyze_project_emits_general_server_client_boundary_warning() {
+    let analysis = analyze_project(support::fixture_path("tests/fixtures/boundaries/general"))
+        .expect("analyze boundary fixture");
+
+    assert_eq!(analysis.boundary_warnings.len(), 1);
+
+    let warning = &analysis.boundary_warnings[0];
+    assert_eq!(
+        warning.message,
+        "Client surface `src/client/App.tsx` imports the Node-only `fs` module."
+    );
+    assert_eq!(
+        warning.recommendation,
+        "Keep Node-only work on the server and pass browser-safe data into the client component."
+    );
+    assert_finding_metadata(
+        &warning.finding,
+        FindingMetadata::new(
+            "boundary:server-client:fs",
+            FindingAnalysisSource::SourceImport,
+        )
+        .with_confidence(FindingConfidence::High)
+        .with_action_priority(1)
+        .with_evidence([FindingEvidence::new("source-file")
+            .with_file("src/client/App.tsx")
+            .with_specifier("fs")
+            .with_detail("client surface imports a Node-only module")]),
+    );
+}
+
+fn assert_finding_metadata(actual: &FindingMetadata, expected: FindingMetadata) {
+    assert_eq!(actual.finding_id, expected.finding_id);
+    assert_eq!(actual.analysis_source, expected.analysis_source);
+    assert_eq!(actual.confidence, expected.confidence);
+    assert_eq!(actual.action_priority, expected.action_priority);
+    assert_eq!(actual.evidence, expected.evidence);
+}

--- a/crates/legolas-core/tests/boundary_analysis.rs
+++ b/crates/legolas-core/tests/boundary_analysis.rs
@@ -14,7 +14,7 @@ fn analyze_project_emits_general_server_client_boundary_warning() {
     let warning = &analysis.boundary_warnings[0];
     assert_eq!(
         warning.message,
-        "Client surface `src/client/App.tsx` imports the Node-only `fs` module."
+        "Client surface `src/client/App.tsx` imports the Node-only `node:fs` module."
     );
     assert_eq!(
         warning.recommendation,
@@ -30,7 +30,7 @@ fn analyze_project_emits_general_server_client_boundary_warning() {
         .with_action_priority(1)
         .with_evidence([FindingEvidence::new("source-file")
             .with_file("src/client/App.tsx")
-            .with_specifier("fs")
+            .with_specifier("node:fs")
             .with_detail("client surface imports a Node-only module")]),
     );
 }

--- a/tests/fixtures/boundaries/general/package.json
+++ b/tests/fixtures/boundaries/general/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "boundary-general-app",
+  "dependencies": {
+    "react": "^19.0.0"
+  }
+}

--- a/tests/fixtures/boundaries/general/src/client/App.tsx
+++ b/tests/fixtures/boundaries/general/src/client/App.tsx
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 
 export default function App() {
   return <pre>{fs.readFileSync("/etc/hosts", "utf8")}</pre>;

--- a/tests/fixtures/boundaries/general/src/client/App.tsx
+++ b/tests/fixtures/boundaries/general/src/client/App.tsx
@@ -1,0 +1,5 @@
+import fs from "fs";
+
+export default function App() {
+  return <pre>{fs.readFileSync("/etc/hosts", "utf8")}</pre>;
+}


### PR DESCRIPTION
## 배경
- base branch는 codex/seed-fit-workspace 입니다.
- PR-FIT-012A는 general server-client boundary detector만 다루는 core slice입니다.
- Next.js use client, RSC server-only leakage는 후속 PR-FIT-012B, PR-FIT-012C로 남깁니다.

## 변경 사항
- client path 기반 general boundary detector를 추가했습니다.
- boundary warning finding metadata와 evidence를 채웠습니다.
- general fixture와 core test를 추가했습니다.

## 검증
- cargo test -p legolas-core --test boundary_analysis
