### PR TITLE
feat: baseline regression CLI 추가

### DIFF
--- a/crates/legolas-cli/src/argv.rs
+++ b/crates/legolas-cli/src/argv.rs
@@ -18,6 +18,9 @@ pub struct CliArgs {
     pub command: Option<Command>,
     pub target_path: Option<PathBuf>,
     pub config_path: Option<PathBuf>,
+    pub baseline_path: Option<PathBuf>,
+    pub write_baseline_path: Option<PathBuf>,
+    pub regression_only: bool,
     pub json: bool,
     pub limit: Option<usize>,
     pub top: Option<usize>,
@@ -69,18 +72,20 @@ where
                 parsed.json = true;
             }
             "--config" => {
-                let next = tokens
-                    .get(index + 1)
-                    .ok_or_else(|| LegolasError::CliUsage("--config expects a path".to_string()))?;
-
-                if next.starts_with('-') {
-                    return Err(LegolasError::CliUsage(
-                        "--config expects a path".to_string(),
-                    ));
-                }
-
-                parsed.config_path = Some(resolve_path_token(next)?);
+                parsed.config_path = Some(parse_path_flag(&tokens, index, "--config")?);
                 index += 1;
+            }
+            "--baseline" => {
+                parsed.baseline_path = Some(parse_path_flag(&tokens, index, "--baseline")?);
+                index += 1;
+            }
+            "--write-baseline" => {
+                parsed.write_baseline_path =
+                    Some(parse_path_flag(&tokens, index, "--write-baseline")?);
+                index += 1;
+            }
+            "--regression-only" => {
+                parsed.regression_only = true;
             }
             "--limit" | "--top" => {
                 let command_known = parsed.command.is_some();
@@ -118,6 +123,8 @@ where
         return Ok(parsed);
     }
 
+    validate_baseline_flags(&parsed)?;
+
     parsed.limit = finalize_numeric_flag(parsed.command.as_ref(), pending_limit, "--limit")?;
     parsed.top = finalize_numeric_flag(parsed.command.as_ref(), pending_top, "--top")?;
 
@@ -145,6 +152,58 @@ fn resolve_path_token(token: &str) -> Result<PathBuf> {
     Ok(std::env::current_dir()?.join(path))
 }
 
+fn parse_path_flag(tokens: &[String], index: usize, flag: &str) -> Result<PathBuf> {
+    let next = tokens
+        .get(index + 1)
+        .ok_or_else(|| LegolasError::CliUsage(format!("{flag} expects a path")))?;
+
+    if next.starts_with('-') {
+        return Err(LegolasError::CliUsage(format!("{flag} expects a path")));
+    }
+
+    resolve_path_token(next)
+}
+
+fn validate_baseline_flags(parsed: &CliArgs) -> Result<()> {
+    if parsed.baseline_path.is_none()
+        && parsed.write_baseline_path.is_none()
+        && !parsed.regression_only
+    {
+        return Ok(());
+    }
+
+    let command_supports = matches!(
+        parsed.command,
+        Some(Command::Scan) | Some(Command::Optimize) | Some(Command::Budget) | Some(Command::Ci)
+    );
+
+    if !command_supports {
+        let flag = if parsed.baseline_path.is_some() {
+            "--baseline"
+        } else if parsed.write_baseline_path.is_some() {
+            "--write-baseline"
+        } else {
+            "--regression-only"
+        };
+
+        return Err(LegolasError::CliUsage(format!("unknown flag \"{flag}\"")));
+    }
+
+    if parsed.write_baseline_path.is_some() && !matches!(parsed.command, Some(Command::Scan)) {
+        return Err(LegolasError::CliUsage(
+            "unknown flag \"--write-baseline\"".to_string(),
+        ));
+    }
+
+    if parsed.baseline_path.is_some() && !parsed.regression_only {
+        return Err(LegolasError::CliUsage(
+            "--baseline requires --regression-only".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 fn finalize_numeric_flag(
     command: Option<&Command>,
     pending_value: Option<PendingNumericValue>,
@@ -154,7 +213,7 @@ fn finalize_numeric_flag(
         return Ok(None);
     };
 
-    if matches!(command, Some(Command::Budget | Command::Ci)) {
+    if matches!(command, Some(Command::Budget) | Some(Command::Ci)) {
         return Err(LegolasError::CliUsage(format!("unknown flag \"{token}\"")));
     }
 

--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -1,4 +1,8 @@
-use std::{fs, path::PathBuf};
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use legolas_cli::{
     argv::{self, Command},
@@ -9,8 +13,10 @@ use legolas_cli::{
 };
 use legolas_core::{
     analyze_project,
+    baseline::{boundary_warning_key, diff_analysis, BaselineSnapshot},
     budget::{evaluate_budget, BudgetEvaluation},
     config::{load_config_file, load_discovered_config, LoadedConfig},
+    impact::estimate_impact,
     LegolasError, Result,
 };
 use serde_json::json;
@@ -19,20 +25,22 @@ const HELP_TEXT: &str = r#"Legolas
 Slim bundles with precision.
 
 Usage:
-  legolas scan [path] [--config file] [--json]
+  legolas scan [path] [--config file] [--json] [--write-baseline file] [--baseline file --regression-only]
   legolas visualize [path] [--config file] [--limit 10]
-  legolas optimize [path] [--config file] [--top 5]
-  legolas budget [path] [--config file] [--json]
-  legolas ci [path] [--config file] [--json]
+  legolas optimize [path] [--config file] [--top 5] [--baseline file --regression-only]
+  legolas budget [path] [--config file] [--json] [--baseline file --regression-only]
+  legolas ci [path] [--config file] [--json] [--baseline file --regression-only]
   legolas help
 
 Examples:
   legolas scan .
+  legolas scan ./apps/storefront --write-baseline ./baseline.json --json
+  legolas scan ./apps/storefront --baseline ./baseline.json --regression-only --json
   legolas scan --config ./legolas.config.json
   legolas visualize ./apps/storefront --limit 12
-  legolas optimize --top 7
-  legolas budget ./apps/storefront --json
-  legolas ci ./apps/storefront
+  legolas optimize ./apps/storefront --top 7 --baseline ./baseline.json --regression-only
+  legolas budget ./apps/storefront --baseline ./baseline.json --regression-only --json
+  legolas ci ./apps/storefront --baseline ./baseline.json --regression-only
 "#;
 
 fn main() {
@@ -69,7 +77,31 @@ fn run() -> Result<i32> {
     emit_config_warnings(&command, loaded_config.as_ref(), parsed.json);
     let target_path = resolve_target_path(&parsed, loaded_config.as_ref())?;
     let analysis = analyze_project(&target_path)?;
-    let budget_evaluation = resolve_budget_evaluation(&command, &analysis, loaded_config.as_ref());
+    let baseline = resolve_baseline_snapshot(&parsed)?;
+    let (output_analysis, regression_diff) = if parsed.regression_only {
+        let Some(baseline) = baseline.as_ref() else {
+            return Err(LegolasError::CliUsage(
+                "--regression-only requires --baseline".to_string(),
+            ));
+        };
+
+        (
+            regression_only_analysis(&analysis, baseline),
+            Some(diff_analysis(baseline, &analysis)),
+        )
+    } else {
+        (analysis.clone(), None)
+    };
+    let mut budget_evaluation =
+        resolve_budget_evaluation(&command, &output_analysis, loaded_config.as_ref());
+    if let Some(diff) = regression_diff.as_ref() {
+        budget_evaluation = budget_evaluation
+            .map(|evaluation| filter_regression_budget_evaluation(evaluation, diff));
+    }
+
+    if let Some(write_baseline_path) = &parsed.write_baseline_path {
+        write_baseline_snapshot(write_baseline_path, &analysis)?;
+    }
 
     if parsed.json {
         match command {
@@ -98,7 +130,7 @@ fn run() -> Result<i32> {
                         .rules,
                 }))?
             ),
-            _ => println!("{}", serde_json::to_string_pretty(&analysis)?),
+            _ => println!("{}", serde_json::to_string_pretty(&output_analysis)?),
         }
 
         if matches!(command, Command::Ci)
@@ -122,23 +154,23 @@ fn run() -> Result<i32> {
     }
 
     let output = match command {
-        Command::Scan => format_scan_report(&analysis),
+        Command::Scan => format_scan_report(&output_analysis),
         Command::Visualize => format_visualization_report(
-            &analysis,
+            &output_analysis,
             resolve_visualize_limit(&parsed, loaded_config.as_ref()),
         ),
         Command::Optimize => format_optimize_report(
-            &analysis,
+            &output_analysis,
             resolve_optimize_top(&parsed, loaded_config.as_ref()),
         ),
         Command::Budget => format_budget_report(
-            &analysis,
+            &output_analysis,
             budget_evaluation
                 .as_ref()
                 .expect("budget evaluation exists for budget command"),
         ),
         Command::Ci => format_ci_report(
-            &analysis,
+            &output_analysis,
             budget_evaluation
                 .as_ref()
                 .expect("budget evaluation exists for ci command"),
@@ -165,6 +197,41 @@ fn run() -> Result<i32> {
     }
 
     Ok(0)
+}
+
+fn resolve_baseline_snapshot(parsed: &argv::CliArgs) -> Result<Option<BaselineSnapshot>> {
+    let Some(baseline_path) = &parsed.baseline_path else {
+        return Ok(None);
+    };
+
+    let raw_baseline = fs::read_to_string(baseline_path).map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => {
+            LegolasError::PathNotFound(baseline_path.display().to_string())
+        }
+        _ => error.into(),
+    })?;
+    let snapshot: BaselineSnapshot = serde_json::from_str(&raw_baseline).map_err(|error| {
+        LegolasError::CliUsage(format!(
+            "malformed baseline {}: {}",
+            baseline_path.display(),
+            error
+        ))
+    })?;
+
+    if snapshot.schema_version != legolas_core::baseline::BASELINE_SCHEMA_VERSION {
+        return Err(LegolasError::CliUsage(format!(
+            "unsupported baseline schema version: {} (expected {}; regenerate with --write-baseline)",
+            snapshot.schema_version,
+            legolas_core::baseline::BASELINE_SCHEMA_VERSION
+        )));
+    }
+
+    Ok(Some(snapshot))
+}
+
+fn write_baseline_snapshot(path: &Path, analysis: &legolas_core::Analysis) -> Result<()> {
+    let snapshot = BaselineSnapshot::from_analysis(analysis);
+    fs::write(path, serde_json::to_string_pretty(&snapshot)?).map_err(Into::into)
 }
 
 fn read_package_version() -> Result<String> {
@@ -258,6 +325,151 @@ fn resolve_budget_evaluation(
     })
 }
 
+fn regression_only_analysis(
+    analysis: &legolas_core::Analysis,
+    baseline: &BaselineSnapshot,
+) -> legolas_core::Analysis {
+    let diff = diff_analysis(baseline, analysis);
+    let potential_kb_saved_worsened =
+        diff.potential_kb_saved_current > diff.potential_kb_saved_previous;
+    let dynamic_import_count_decreased =
+        diff.dynamic_import_count_current < diff.dynamic_import_count_previous;
+    let added_heavy_dependencies = diff
+        .added_heavy_dependency_names
+        .into_iter()
+        .chain(diff.worsened_heavy_dependency_names)
+        .collect::<BTreeSet<_>>();
+    let added_tree_shaking_warning_keys = diff
+        .added_tree_shaking_warning_keys
+        .into_iter()
+        .chain(diff.worsened_tree_shaking_warning_keys)
+        .collect::<BTreeSet<_>>();
+    let added_duplicate_package_keys = diff
+        .added_duplicate_package_keys
+        .into_iter()
+        .chain(diff.worsened_duplicate_package_keys)
+        .collect::<BTreeSet<_>>();
+    let added_lazy_load_candidate_keys = diff
+        .added_lazy_load_candidate_keys
+        .into_iter()
+        .chain(diff.worsened_lazy_load_candidate_keys)
+        .collect::<BTreeSet<_>>();
+    let added_boundary_warning_keys = diff
+        .added_boundary_warning_keys
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let added_unused_dependency_candidate_names = diff
+        .added_unused_dependency_candidate_names
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let added_warnings = diff.added_warnings.into_iter().collect::<BTreeSet<_>>();
+    let mut filtered = analysis.clone();
+
+    filtered
+        .heavy_dependencies
+        .retain(|item| added_heavy_dependencies.contains(item.name.as_str()));
+    filtered
+        .tree_shaking_warnings
+        .retain(|item| added_tree_shaking_warning_keys.contains(item.key.as_str()));
+    filtered.duplicate_packages.retain(|item| {
+        added_duplicate_package_keys.contains(regression_finding_key(
+            item.finding.finding_id.as_deref(),
+            item.name.as_str(),
+        ))
+    });
+    filtered.lazy_load_candidates.retain(|item| {
+        added_lazy_load_candidate_keys.contains(regression_finding_key(
+            item.finding.finding_id.as_deref(),
+            item.name.as_str(),
+        ))
+    });
+    filtered
+        .boundary_warnings
+        .retain(|item| added_boundary_warning_keys.contains(boundary_warning_key(item).as_str()));
+    filtered
+        .warnings
+        .retain(|warning| added_warnings.contains(warning.as_str()));
+    filtered
+        .unused_dependency_candidates
+        .retain(|item| added_unused_dependency_candidate_names.contains(item.name.as_str()));
+
+    if potential_kb_saved_worsened
+        && filtered.heavy_dependencies.is_empty()
+        && filtered.duplicate_packages.is_empty()
+        && filtered.lazy_load_candidates.is_empty()
+        && filtered.tree_shaking_warnings.is_empty()
+    {
+        filtered.heavy_dependencies = analysis.heavy_dependencies.clone();
+        filtered.duplicate_packages = analysis.duplicate_packages.clone();
+        filtered.lazy_load_candidates = analysis.lazy_load_candidates.clone();
+        filtered.tree_shaking_warnings = analysis.tree_shaking_warnings.clone();
+    }
+
+    if dynamic_import_count_decreased && filtered.lazy_load_candidates.is_empty() {
+        filtered.lazy_load_candidates = analysis.lazy_load_candidates.clone();
+    }
+
+    filtered.impact = estimate_impact(
+        &filtered.heavy_dependencies,
+        &filtered.duplicate_packages,
+        &filtered.lazy_load_candidates,
+        &filtered.tree_shaking_warnings,
+    );
+
+    filtered
+}
+
+fn regression_finding_key<'a>(finding_id: Option<&'a str>, fallback: &'a str) -> &'a str {
+    finding_id.unwrap_or(fallback)
+}
+
+fn filter_regression_budget_evaluation(
+    evaluation: BudgetEvaluation,
+    diff: &legolas_core::BaselineDiff,
+) -> BudgetEvaluation {
+    let potential_kb_saved_worsened =
+        diff.potential_kb_saved_current > diff.potential_kb_saved_previous;
+    let duplicate_package_regressed = !diff.added_duplicate_package_keys.is_empty()
+        || !diff.worsened_duplicate_package_keys.is_empty();
+    let lazy_load_regressed = !diff.added_lazy_load_candidate_keys.is_empty()
+        || !diff.worsened_lazy_load_candidate_keys.is_empty();
+    let dynamic_import_count_decreased =
+        diff.dynamic_import_count_current < diff.dynamic_import_count_previous;
+    let rules = evaluation
+        .rules
+        .into_iter()
+        .filter(|item| {
+            if item.status == legolas_core::budget::BudgetStatus::Pass {
+                return false;
+            }
+
+            match item.key.as_str() {
+                "potentialKbSaved" => {
+                    potential_kb_saved_worsened && !item.triggered_findings.is_empty()
+                }
+                "duplicatePackageCount" => {
+                    duplicate_package_regressed && !item.triggered_findings.is_empty()
+                }
+                "dynamicImportCount" => {
+                    dynamic_import_count_decreased
+                        || (lazy_load_regressed && !item.triggered_findings.is_empty())
+                }
+                _ => !item.triggered_findings.is_empty(),
+            }
+        })
+        .collect::<Vec<_>>();
+    let overall_status = rules
+        .iter()
+        .map(|item| item.status)
+        .max()
+        .unwrap_or_default();
+
+    BudgetEvaluation {
+        overall_status,
+        rules,
+    }
+}
+
 fn resolve_config_relative_path(config: &LoadedConfig, value: &str) -> PathBuf {
     let path = PathBuf::from(value);
     if path.is_absolute() {
@@ -291,4 +503,440 @@ fn ci_failure_message(evaluation: &BudgetEvaluation) -> String {
         evaluation.overall_status,
         failing_rules.join(", ")
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_regression_budget_evaluation, regression_only_analysis};
+    use legolas_core::{
+        budget::{evaluate_budget, BudgetStatus},
+        config::{BudgetRules, BudgetThresholds},
+        Analysis, BaselineSnapshot, DuplicatePackage, FindingAnalysisSource, FindingConfidence,
+        FindingMetadata, Impact, LazyLoadCandidate, SourceSummary,
+    };
+
+    #[test]
+    fn regression_only_budget_keeps_new_duplicate_package_failures() {
+        let analysis = Analysis {
+            source_summary: SourceSummary {
+                dynamic_imports: 2,
+                ..SourceSummary::default()
+            },
+            duplicate_packages: vec![DuplicatePackage {
+                name: "react".to_string(),
+                versions: vec!["17.0.0".to_string(), "18.0.0".to_string()],
+                count: 2,
+                estimated_extra_kb: 12,
+                finding: FindingMetadata::new(
+                    "duplicate-package:react",
+                    FindingAnalysisSource::LockfileTrace,
+                )
+                .with_confidence(FindingConfidence::High),
+                ..DuplicatePackage::default()
+            }],
+            impact: Impact::default(),
+            ..Analysis::default()
+        };
+        let filtered = regression_only_analysis(
+            &analysis,
+            &BaselineSnapshot {
+                duplicate_package_keys: Vec::new(),
+                lazy_load_candidate_keys: Vec::new(),
+                ..BaselineSnapshot::default()
+            },
+        );
+        let diff = legolas_core::diff_analysis(
+            &BaselineSnapshot {
+                duplicate_package_keys: Vec::new(),
+                lazy_load_candidate_keys: Vec::new(),
+                ..BaselineSnapshot::default()
+            },
+            &analysis,
+        );
+
+        assert_eq!(filtered.duplicate_packages.len(), 1);
+
+        let evaluation = filter_regression_budget_evaluation(
+            evaluate_budget(
+                &filtered,
+                Some(&BudgetRules {
+                    potential_kb_saved: Some(BudgetThresholds {
+                        warn_at: usize::MAX,
+                        fail_at: usize::MAX,
+                    }),
+                    duplicate_package_count: Some(BudgetThresholds {
+                        warn_at: 1,
+                        fail_at: 1,
+                    }),
+                    dynamic_import_count: Some(BudgetThresholds {
+                        warn_at: 1,
+                        fail_at: 0,
+                    }),
+                }),
+            ),
+            &diff,
+        );
+
+        assert_eq!(evaluation.overall_status, BudgetStatus::Fail);
+        assert_eq!(evaluation.rules.len(), 1);
+        assert_eq!(evaluation.rules[0].key, "duplicatePackageCount");
+        assert_eq!(evaluation.rules[0].triggered_findings.len(), 1);
+    }
+
+    #[test]
+    fn regression_only_budget_keeps_new_lazy_load_failures() {
+        let analysis = Analysis {
+            source_summary: SourceSummary::default(),
+            lazy_load_candidates: vec![LazyLoadCandidate {
+                name: "chart.js".to_string(),
+                estimated_savings_kb: 48,
+                recommendation: "Lazy-load chart routes.".to_string(),
+                files: vec!["src/routes/dashboard.tsx".to_string()],
+                reason: "Route-only import".to_string(),
+                finding: FindingMetadata::new(
+                    "lazy-load:chart.js",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_confidence(FindingConfidence::Medium),
+            }],
+            impact: Impact::default(),
+            ..Analysis::default()
+        };
+        let filtered = regression_only_analysis(
+            &analysis,
+            &BaselineSnapshot {
+                duplicate_package_keys: Vec::new(),
+                lazy_load_candidate_keys: Vec::new(),
+                ..BaselineSnapshot::default()
+            },
+        );
+        let diff = legolas_core::diff_analysis(
+            &BaselineSnapshot {
+                duplicate_package_keys: Vec::new(),
+                lazy_load_candidate_keys: Vec::new(),
+                ..BaselineSnapshot::default()
+            },
+            &analysis,
+        );
+
+        assert_eq!(filtered.lazy_load_candidates.len(), 1);
+
+        let evaluation = filter_regression_budget_evaluation(
+            evaluate_budget(
+                &filtered,
+                Some(&BudgetRules {
+                    potential_kb_saved: Some(BudgetThresholds {
+                        warn_at: usize::MAX,
+                        fail_at: usize::MAX,
+                    }),
+                    duplicate_package_count: Some(BudgetThresholds {
+                        warn_at: usize::MAX,
+                        fail_at: usize::MAX,
+                    }),
+                    dynamic_import_count: Some(BudgetThresholds {
+                        warn_at: 1,
+                        fail_at: 0,
+                    }),
+                }),
+            ),
+            &diff,
+        );
+
+        assert_eq!(evaluation.overall_status, BudgetStatus::Fail);
+        assert_eq!(evaluation.rules.len(), 1);
+        assert_eq!(evaluation.rules[0].key, "dynamicImportCount");
+        assert_eq!(evaluation.rules[0].triggered_findings.len(), 1);
+    }
+
+    #[test]
+    fn regression_only_keeps_worsened_existing_findings() {
+        let analysis = Analysis {
+            heavy_dependencies: vec![legolas_core::HeavyDependency {
+                name: "lodash".to_string(),
+                version_range: "^4.17.21".to_string(),
+                estimated_kb: 72,
+                category: "utility".to_string(),
+                rationale: "same package".to_string(),
+                recommendation: "narrow import".to_string(),
+                imported_by: vec!["src/a.ts".to_string(), "src/b.ts".to_string()],
+                dynamic_imported_by: Vec::new(),
+                import_count: 2,
+                finding: FindingMetadata::new(
+                    "heavy-dependency:lodash",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_confidence(FindingConfidence::High),
+            }],
+            duplicate_packages: vec![DuplicatePackage {
+                name: "react".to_string(),
+                versions: vec!["17.0.0".to_string(), "18.0.0".to_string()],
+                count: 2,
+                estimated_extra_kb: 20,
+                finding: FindingMetadata::new(
+                    "duplicate-package:react",
+                    FindingAnalysisSource::LockfileTrace,
+                )
+                .with_confidence(FindingConfidence::High),
+                ..DuplicatePackage::default()
+            }],
+            lazy_load_candidates: vec![LazyLoadCandidate {
+                name: "chart.js".to_string(),
+                estimated_savings_kb: 64,
+                recommendation: "Lazy-load chart routes.".to_string(),
+                files: vec![
+                    "src/routes/dashboard.tsx".to_string(),
+                    "src/routes/report.tsx".to_string(),
+                ],
+                reason: "Route-only import".to_string(),
+                finding: FindingMetadata::new(
+                    "lazy-load:chart.js",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_confidence(FindingConfidence::Medium),
+            }],
+            impact: Impact {
+                potential_kb_saved: 156,
+                ..Impact::default()
+            },
+            ..Analysis::default()
+        };
+        let filtered = regression_only_analysis(
+            &analysis,
+            &BaselineSnapshot {
+                heavy_dependency_names: vec!["lodash".to_string()],
+                duplicate_package_keys: vec!["duplicate-package:react".to_string()],
+                lazy_load_candidate_keys: vec!["lazy-load:chart.js".to_string()],
+                heavy_dependency_metrics: vec![legolas_core::baseline::BaselineFindingMetric {
+                    key: "lodash".to_string(),
+                    primary_metric: 72,
+                    secondary_metric: Some(1),
+                }],
+                duplicate_package_metrics: vec![legolas_core::baseline::BaselineFindingMetric {
+                    key: "duplicate-package:react".to_string(),
+                    primary_metric: 12,
+                    secondary_metric: Some(1),
+                }],
+                lazy_load_candidate_metrics: vec![legolas_core::baseline::BaselineFindingMetric {
+                    key: "lazy-load:chart.js".to_string(),
+                    primary_metric: 48,
+                    secondary_metric: Some(1),
+                }],
+                potential_kb_saved: 132,
+                ..BaselineSnapshot::default()
+            },
+        );
+
+        assert_eq!(filtered.heavy_dependencies.len(), 1);
+        assert_eq!(filtered.duplicate_packages.len(), 1);
+        assert_eq!(filtered.lazy_load_candidates.len(), 1);
+    }
+
+    #[test]
+    fn regression_only_keeps_aggregate_regressions_when_finding_keys_are_unchanged() {
+        let analysis = Analysis {
+            source_summary: SourceSummary {
+                dynamic_imports: 1,
+                ..SourceSummary::default()
+            },
+            heavy_dependencies: vec![legolas_core::HeavyDependency {
+                name: "chart.js".to_string(),
+                version_range: "^4.4.1".to_string(),
+                estimated_kb: 160,
+                category: "charts".to_string(),
+                rationale: "same package".to_string(),
+                recommendation: "lazy-load".to_string(),
+                imported_by: vec!["src/App.tsx".to_string()],
+                dynamic_imported_by: Vec::new(),
+                import_count: 1,
+                finding: FindingMetadata::new(
+                    "heavy-dependency:chart.js",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_confidence(FindingConfidence::High),
+            }],
+            lazy_load_candidates: vec![LazyLoadCandidate {
+                name: "chart.js".to_string(),
+                estimated_savings_kb: 48,
+                recommendation: "Lazy-load chart routes.".to_string(),
+                files: vec!["src/routes/dashboard.tsx".to_string()],
+                reason: "Route-only import".to_string(),
+                finding: FindingMetadata::new(
+                    "lazy-load:chart.js",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_confidence(FindingConfidence::Medium),
+            }],
+            impact: Impact {
+                potential_kb_saved: 72,
+                ..Impact::default()
+            },
+            unused_dependency_candidates: vec![legolas_core::UnusedDependencyCandidate {
+                name: "unused".to_string(),
+                version_range: "^1.0.0".to_string(),
+            }],
+            ..Analysis::default()
+        };
+        let filtered = regression_only_analysis(
+            &analysis,
+            &BaselineSnapshot {
+                dynamic_import_count: 2,
+                potential_kb_saved: 48,
+                heavy_dependency_names: vec!["chart.js".to_string()],
+                lazy_load_candidate_keys: vec!["lazy-load:chart.js".to_string()],
+                heavy_dependency_metrics: vec![legolas_core::baseline::BaselineFindingMetric {
+                    key: "chart.js".to_string(),
+                    primary_metric: 160,
+                    secondary_metric: Some(1),
+                }],
+                lazy_load_candidate_metrics: vec![legolas_core::baseline::BaselineFindingMetric {
+                    key: "lazy-load:chart.js".to_string(),
+                    primary_metric: 48,
+                    secondary_metric: Some(1),
+                }],
+                ..BaselineSnapshot::default()
+            },
+        );
+
+        assert_eq!(filtered.heavy_dependencies.len(), 1);
+        assert_eq!(filtered.lazy_load_candidates.len(), 1);
+        assert_eq!(filtered.unused_dependency_candidates.len(), 1);
+        assert_eq!(filtered.unused_dependency_candidates[0].name, "unused");
+    }
+
+    #[test]
+    fn regression_only_budget_drops_potential_kb_saved_failures_when_only_dynamic_import_count_regresses(
+    ) {
+        let analysis = Analysis {
+            source_summary: SourceSummary {
+                dynamic_imports: 1,
+                ..SourceSummary::default()
+            },
+            heavy_dependencies: vec![legolas_core::HeavyDependency {
+                name: "chart.js".to_string(),
+                version_range: "^4.4.1".to_string(),
+                estimated_kb: 160,
+                category: "charts".to_string(),
+                rationale: "route-only import".to_string(),
+                recommendation: "lazy-load".to_string(),
+                imported_by: vec!["src/routes/Dashboard.tsx".to_string()],
+                dynamic_imported_by: Vec::new(),
+                import_count: 1,
+                finding: FindingMetadata::new(
+                    "heavy-dependency:chart.js",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_confidence(FindingConfidence::High),
+            }],
+            lazy_load_candidates: vec![LazyLoadCandidate {
+                name: "chart.js".to_string(),
+                estimated_savings_kb: 128,
+                recommendation: "Lazy-load dashboard routes.".to_string(),
+                files: vec!["src/routes/Dashboard.tsx".to_string()],
+                reason: "Route-only import".to_string(),
+                finding: FindingMetadata::new(
+                    "lazy-load:chart.js",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_confidence(FindingConfidence::Medium),
+            }],
+            impact: Impact {
+                potential_kb_saved: 157,
+                ..Impact::default()
+            },
+            ..Analysis::default()
+        };
+        let baseline = BaselineSnapshot {
+            dynamic_import_count: 2,
+            potential_kb_saved: 157,
+            heavy_dependency_names: vec!["chart.js".to_string()],
+            lazy_load_candidate_keys: vec!["lazy-load:chart.js".to_string()],
+            heavy_dependency_metrics: vec![legolas_core::baseline::BaselineFindingMetric {
+                key: "chart.js".to_string(),
+                primary_metric: 160,
+                secondary_metric: Some(1),
+            }],
+            lazy_load_candidate_metrics: vec![legolas_core::baseline::BaselineFindingMetric {
+                key: "lazy-load:chart.js".to_string(),
+                primary_metric: 128,
+                secondary_metric: Some(1),
+            }],
+            ..BaselineSnapshot::default()
+        };
+        let filtered = regression_only_analysis(&analysis, &baseline);
+        let diff = legolas_core::diff_analysis(&baseline, &analysis);
+
+        assert_eq!(filtered.lazy_load_candidates.len(), 1);
+        assert_eq!(filtered.impact.potential_kb_saved, 128);
+
+        let evaluation = filter_regression_budget_evaluation(
+            evaluate_budget(
+                &filtered,
+                Some(&BudgetRules {
+                    potential_kb_saved: Some(BudgetThresholds {
+                        warn_at: 40,
+                        fail_at: 80,
+                    }),
+                    duplicate_package_count: Some(BudgetThresholds {
+                        warn_at: usize::MAX,
+                        fail_at: usize::MAX,
+                    }),
+                    dynamic_import_count: Some(BudgetThresholds {
+                        warn_at: 1,
+                        fail_at: 0,
+                    }),
+                }),
+            ),
+            &diff,
+        );
+
+        assert_eq!(evaluation.overall_status, BudgetStatus::Warn);
+        assert_eq!(evaluation.rules.len(), 1);
+        assert_eq!(evaluation.rules[0].key, "dynamicImportCount");
+        assert_eq!(evaluation.rules[0].status, BudgetStatus::Warn);
+    }
+
+    #[test]
+    fn regression_only_budget_keeps_dynamic_import_failures_without_lazy_load_findings() {
+        let analysis = Analysis {
+            source_summary: SourceSummary {
+                dynamic_imports: 0,
+                ..SourceSummary::default()
+            },
+            impact: Impact::default(),
+            ..Analysis::default()
+        };
+        let baseline = BaselineSnapshot {
+            dynamic_import_count: 1,
+            ..BaselineSnapshot::default()
+        };
+        let filtered = regression_only_analysis(&analysis, &baseline);
+        let diff = legolas_core::diff_analysis(&baseline, &analysis);
+
+        let evaluation = filter_regression_budget_evaluation(
+            evaluate_budget(
+                &filtered,
+                Some(&BudgetRules {
+                    potential_kb_saved: Some(BudgetThresholds {
+                        warn_at: usize::MAX,
+                        fail_at: usize::MAX,
+                    }),
+                    duplicate_package_count: Some(BudgetThresholds {
+                        warn_at: usize::MAX,
+                        fail_at: usize::MAX,
+                    }),
+                    dynamic_import_count: Some(BudgetThresholds {
+                        warn_at: 1,
+                        fail_at: 0,
+                    }),
+                }),
+            ),
+            &diff,
+        );
+
+        assert_eq!(evaluation.overall_status, BudgetStatus::Fail);
+        assert_eq!(evaluation.rules.len(), 1);
+        assert_eq!(evaluation.rules[0].key, "dynamicImportCount");
+        assert_eq!(evaluation.rules[0].status, BudgetStatus::Fail);
+        assert!(evaluation.rules[0].triggered_findings.is_empty());
+    }
 }

--- a/crates/legolas-cli/tests/baseline_contract.rs
+++ b/crates/legolas-cli/tests/baseline_contract.rs
@@ -1,0 +1,692 @@
+mod support;
+
+use std::{fs, path::Path};
+
+use assert_cmd::Command;
+use legolas_core::{analyze_project, BaselineSnapshot};
+use tempfile::tempdir;
+
+fn run_cli(args: Vec<String>) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(args)
+        .output()
+        .expect("run command")
+}
+
+fn run_cli_in_dir(current_dir: &Path, args: Vec<String>) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .current_dir(current_dir)
+        .args(args)
+        .output()
+        .expect("run command in directory")
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout")
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr")
+}
+
+fn baseline_fixture_path() -> String {
+    support::fixture_path("tests/fixtures/baseline/previous-scan.json")
+        .display()
+        .to_string()
+}
+
+fn write_temp_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directory");
+    }
+    fs::write(path, contents).expect("write temp file");
+}
+
+fn write_temp_baseline(path: &Path, project_root: &Path) {
+    let analysis = analyze_project(project_root).expect("analyze project for baseline");
+    let snapshot = BaselineSnapshot::from_analysis(&analysis);
+    write_temp_snapshot(path, &snapshot);
+}
+
+fn write_temp_snapshot(path: &Path, snapshot: &BaselineSnapshot) {
+    fs::write(
+        path,
+        serde_json::to_string_pretty(snapshot).expect("serialize baseline snapshot"),
+    )
+    .expect("write baseline snapshot");
+}
+
+fn setup_dynamic_import_regression_fixture(
+) -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let temp_dir = tempdir().expect("create temp dir");
+    let project_root = temp_dir.path().join("app");
+    let baseline_path = project_root.join("baseline.json");
+
+    write_temp_file(
+        &project_root.join("package.json"),
+        r#"{
+  "name": "dynamic-import-regression-app",
+  "dependencies": {
+    "chart.js": "^4.4.1"
+  }
+}"#,
+    );
+    write_temp_file(
+        &project_root.join("src/routes/Dashboard.tsx"),
+        "import { Chart } from \"chart.js\";\nexport default function Dashboard() { return Chart; }\n",
+    );
+    write_temp_file(
+        &project_root.join("src/load.ts"),
+        "export const loadDashboard = () => import(\"./routes/Dashboard\");\n",
+    );
+
+    let analysis = analyze_project(&project_root).expect("analyze current fixture");
+    assert_eq!(analysis.source_summary.dynamic_imports, 1);
+    assert_eq!(analysis.impact.potential_kb_saved, 157);
+
+    let mut baseline = BaselineSnapshot::from_analysis(&analysis);
+    baseline.dynamic_import_count = 2;
+    write_temp_snapshot(&baseline_path, &baseline);
+
+    (temp_dir, project_root, baseline_path)
+}
+
+fn setup_dynamic_import_count_only_regression_fixture(
+) -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let temp_dir = tempdir().expect("create temp dir");
+    let project_root = temp_dir.path().join("app");
+    let baseline_path = project_root.join("baseline.json");
+
+    write_temp_file(
+        &project_root.join("package.json"),
+        r#"{
+  "name": "dynamic-import-count-only-regression-app",
+  "dependencies": {}
+}"#,
+    );
+    write_temp_file(
+        &project_root.join("src/load.ts"),
+        "export const loadSettings = () => import(\"./Settings\");\n",
+    );
+    write_temp_file(
+        &project_root.join("src/Settings.ts"),
+        "export const Settings = null;\n",
+    );
+
+    let baseline = BaselineSnapshot::from_analysis(
+        &analyze_project(&project_root).expect("analyze baseline fixture"),
+    );
+    assert_eq!(baseline.dynamic_import_count, 1);
+    write_temp_snapshot(&baseline_path, &baseline);
+
+    write_temp_file(
+        &project_root.join("src/load.ts"),
+        "export const loadSettings = () => null;\n",
+    );
+
+    let current = analyze_project(&project_root).expect("analyze current fixture");
+    assert_eq!(current.source_summary.dynamic_imports, 0);
+    assert!(current.lazy_load_candidates.is_empty());
+
+    (temp_dir, project_root, baseline_path)
+}
+
+#[test]
+fn regression_only_scan_json_filters_to_new_findings() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let output = run_cli(vec![
+        "scan".to_string(),
+        current_app.display().to_string(),
+        "--baseline".to_string(),
+        baseline_fixture_path(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let analysis = support::normalize_analysis_json_output(&stdout(&output));
+    assert_eq!(analysis["packageSummary"]["name"], "baseline-app");
+    assert_eq!(analysis["heavyDependencies"].as_array().unwrap().len(), 2);
+    assert_eq!(analysis["heavyDependencies"][0]["name"], "chart.js");
+    assert_eq!(analysis["heavyDependencies"][1]["name"], "lodash");
+    assert_eq!(analysis["treeShakingWarnings"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        analysis["treeShakingWarnings"][0]["key"],
+        "lodash-root-import"
+    );
+    assert_eq!(analysis["duplicatePackages"], serde_json::json!([]));
+}
+
+#[test]
+fn regression_only_scan_text_only_mentions_new_findings() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let output = run_cli(vec![
+        "scan".to_string(),
+        current_app.display().to_string(),
+        "--baseline".to_string(),
+        baseline_fixture_path(),
+        "--regression-only".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Legolas scan for baseline-app"));
+    assert!(stdout.contains("- chart.js"));
+    assert!(stdout.contains("- lodash"));
+    assert!(stdout.contains("Tree-shaking warnings:"));
+    assert!(stdout
+        .contains("Root lodash imports often keep more code than expected in client bundles."));
+}
+
+#[test]
+fn regression_only_budget_json_filters_pass_rules() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let output = run_cli(vec![
+        "budget".to_string(),
+        current_app.display().to_string(),
+        "--baseline".to_string(),
+        baseline_fixture_path(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let budget = support::normalize_budget_json_output(&stdout(&output));
+    assert_eq!(budget["overallStatus"], serde_json::json!("Warn"));
+    assert_eq!(budget["rules"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        budget["rules"][0]["key"],
+        serde_json::json!("potentialKbSaved")
+    );
+    assert_eq!(budget["rules"][0]["status"], serde_json::json!("Warn"));
+    assert_eq!(
+        budget["rules"][0]["triggeredFindings"]
+            .as_array()
+            .unwrap()
+            .len(),
+        3
+    );
+}
+
+#[test]
+fn regression_only_ci_json_filters_pass_rules() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let output = run_cli(vec![
+        "ci".to_string(),
+        current_app.display().to_string(),
+        "--baseline".to_string(),
+        baseline_fixture_path(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let ci = support::normalize_ci_json_output(&stdout(&output));
+    assert_eq!(ci["passed"], serde_json::json!(true));
+    assert_eq!(ci["overallStatus"], serde_json::json!("Warn"));
+    assert_eq!(ci["rules"].as_array().unwrap().len(), 1);
+    assert_eq!(ci["rules"][0]["key"], serde_json::json!("potentialKbSaved"));
+    assert_eq!(ci["rules"][0]["status"], serde_json::json!("Warn"));
+}
+
+#[test]
+fn regression_only_budget_json_drops_potential_kb_failures_for_dynamic_import_only_regressions() {
+    let (_temp_dir, project_root, baseline_path) = setup_dynamic_import_regression_fixture();
+    let output = run_cli(vec![
+        "budget".to_string(),
+        project_root.display().to_string(),
+        "--baseline".to_string(),
+        baseline_path.display().to_string(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let budget = support::normalize_budget_json_output(&stdout(&output));
+    assert_eq!(budget["overallStatus"], serde_json::json!("Warn"));
+    assert_eq!(budget["rules"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        budget["rules"][0]["key"],
+        serde_json::json!("dynamicImportCount")
+    );
+    assert_eq!(budget["rules"][0]["status"], serde_json::json!("Warn"));
+}
+
+#[test]
+fn regression_only_ci_json_drops_potential_kb_failures_for_dynamic_import_only_regressions() {
+    let (_temp_dir, project_root, baseline_path) = setup_dynamic_import_regression_fixture();
+    let output = run_cli(vec![
+        "ci".to_string(),
+        project_root.display().to_string(),
+        "--baseline".to_string(),
+        baseline_path.display().to_string(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let ci = support::normalize_ci_json_output(&stdout(&output));
+    assert_eq!(ci["passed"], serde_json::json!(true));
+    assert_eq!(ci["overallStatus"], serde_json::json!("Warn"));
+    assert_eq!(ci["rules"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        ci["rules"][0]["key"],
+        serde_json::json!("dynamicImportCount")
+    );
+    assert_eq!(ci["rules"][0]["status"], serde_json::json!("Warn"));
+}
+
+#[test]
+fn regression_only_budget_json_keeps_dynamic_import_failures_without_lazy_candidates() {
+    let (_temp_dir, project_root, baseline_path) =
+        setup_dynamic_import_count_only_regression_fixture();
+    let output = run_cli(vec![
+        "budget".to_string(),
+        project_root.display().to_string(),
+        "--baseline".to_string(),
+        baseline_path.display().to_string(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let budget = support::normalize_budget_json_output(&stdout(&output));
+    assert_eq!(budget["overallStatus"], serde_json::json!("Fail"));
+    assert_eq!(budget["rules"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        budget["rules"][0]["key"],
+        serde_json::json!("dynamicImportCount")
+    );
+    assert_eq!(budget["rules"][0]["status"], serde_json::json!("Fail"));
+    assert_eq!(
+        budget["rules"][0]["triggeredFindings"],
+        serde_json::json!([])
+    );
+}
+
+#[test]
+fn regression_only_ci_json_keeps_dynamic_import_failures_without_lazy_candidates() {
+    let (_temp_dir, project_root, baseline_path) =
+        setup_dynamic_import_count_only_regression_fixture();
+    let output = run_cli(vec![
+        "ci".to_string(),
+        project_root.display().to_string(),
+        "--baseline".to_string(),
+        baseline_path.display().to_string(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr(&output).contains("CI gate failed: overall status Fail"));
+
+    let ci = support::normalize_ci_json_output(&stdout(&output));
+    assert_eq!(ci["passed"], serde_json::json!(false));
+    assert_eq!(ci["overallStatus"], serde_json::json!("Fail"));
+    assert_eq!(ci["rules"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        ci["rules"][0]["key"],
+        serde_json::json!("dynamicImportCount")
+    );
+    assert_eq!(ci["rules"][0]["status"], serde_json::json!("Fail"));
+    assert_eq!(ci["rules"][0]["triggeredFindings"], serde_json::json!([]));
+}
+
+#[test]
+fn write_baseline_persists_the_current_snapshot() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let temp_dir = tempdir().expect("create temp dir");
+    let baseline_path = temp_dir.path().join("baseline.json");
+    let output = run_cli(vec![
+        "scan".to_string(),
+        current_app.display().to_string(),
+        "--write-baseline".to_string(),
+        baseline_path.display().to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+    assert!(baseline_path.exists());
+
+    let current_analysis = analyze_project(&current_app).expect("analyze current app");
+    let expected_snapshot = BaselineSnapshot::from_analysis(&current_analysis);
+    let written_snapshot: BaselineSnapshot =
+        serde_json::from_str(&fs::read_to_string(&baseline_path).expect("read written baseline"))
+            .expect("parse written baseline");
+
+    assert_eq!(written_snapshot, expected_snapshot);
+}
+
+#[test]
+fn regression_only_requires_an_explicit_baseline() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let output = run_cli(vec![
+        "scan".to_string(),
+        current_app.display().to_string(),
+        "--regression-only".to_string(),
+    ]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout(&output), "");
+    assert_eq!(
+        stderr(&output),
+        "legolas: --regression-only requires --baseline\n"
+    );
+}
+
+#[test]
+fn baseline_flag_requires_regression_only() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let output = run_cli(vec![
+        "scan".to_string(),
+        current_app.display().to_string(),
+        "--baseline".to_string(),
+        baseline_fixture_path(),
+    ]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout(&output), "");
+    assert_eq!(
+        stderr(&output),
+        "legolas: --baseline requires --regression-only\n"
+    );
+}
+
+#[test]
+fn help_allows_baseline_related_flags_without_usage_errors() {
+    let output = run_cli(vec!["--help".to_string(), "--regression-only".to_string()]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Usage:"));
+    assert!(stdout.contains("--write-baseline file"));
+    assert!(stdout.contains("--baseline file --regression-only"));
+}
+
+#[test]
+fn write_baseline_is_rejected_for_budget_commands() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let temp_dir = tempdir().expect("create temp dir");
+    let baseline_path = temp_dir.path().join("budget-baseline.json");
+    let output = run_cli(vec![
+        "budget".to_string(),
+        current_app.display().to_string(),
+        "--write-baseline".to_string(),
+        baseline_path.display().to_string(),
+    ]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout(&output), "");
+    assert_eq!(
+        stderr(&output),
+        "legolas: unknown flag \"--write-baseline\"\n"
+    );
+    assert!(!baseline_path.exists());
+}
+
+#[test]
+fn legacy_baseline_schema_requires_regeneration() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let temp_dir = tempdir().expect("create temp dir");
+    let legacy_baseline = temp_dir.path().join("legacy-baseline.json");
+    fs::write(
+        &legacy_baseline,
+        r#"{
+  "schemaVersion": 1,
+  "projectName": "baseline-app",
+  "packageManager": "npm",
+  "dependencyCount": 1,
+  "devDependencyCount": 0,
+  "sourceFileCount": 1,
+  "heavyDependencyNames": ["chart.js"],
+  "treeShakingWarningKeys": [],
+  "warnings": []
+}"#,
+    )
+    .expect("write legacy baseline");
+
+    let output = run_cli(vec![
+        "scan".to_string(),
+        current_app.display().to_string(),
+        "--baseline".to_string(),
+        legacy_baseline.display().to_string(),
+        "--regression-only".to_string(),
+    ]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout(&output), "");
+    assert!(stderr(&output).contains("unsupported baseline schema version: 1"));
+    assert!(stderr(&output).contains("regenerate with --write-baseline"));
+}
+
+#[test]
+fn missing_baseline_file_is_reported_explicitly() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let missing_baseline = tempdir()
+        .expect("create temp dir")
+        .path()
+        .join("missing.json");
+    let output = run_cli(vec![
+        "scan".to_string(),
+        current_app.display().to_string(),
+        "--baseline".to_string(),
+        missing_baseline.display().to_string(),
+        "--regression-only".to_string(),
+    ]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout(&output), "");
+    assert!(
+        stderr(&output).starts_with("legolas: path not found: "),
+        "unexpected stderr: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn malformed_baseline_file_is_reported_separately() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let temp_dir = tempdir().expect("create temp dir");
+    let malformed_baseline = temp_dir.path().join("baseline.json");
+    fs::write(&malformed_baseline, "{not-json").expect("write malformed baseline");
+
+    let output = run_cli(vec![
+        "scan".to_string(),
+        current_app.display().to_string(),
+        "--baseline".to_string(),
+        malformed_baseline.display().to_string(),
+        "--regression-only".to_string(),
+    ]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(stdout(&output), "");
+    assert!(stderr(&output).contains("legolas: malformed baseline "));
+}
+
+#[test]
+fn regression_only_works_in_an_existing_project_directory() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let output = run_cli_in_dir(
+        &current_app,
+        vec![
+            "scan".to_string(),
+            "--baseline".to_string(),
+            baseline_fixture_path(),
+            "--regression-only".to_string(),
+        ],
+    );
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn regression_only_scan_json_filters_boundary_warnings_to_new_keys() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let project_root = temp_dir.path();
+    let baseline_path = project_root.join("baseline.json");
+
+    write_temp_file(
+        &project_root.join("package.json"),
+        r#"{
+  "name": "boundary-regression-app",
+  "dependencies": {}
+}"#,
+    );
+    write_temp_file(
+        &project_root.join("src/client/existing.ts"),
+        "\"use client\";\nimport \"node:fs\";\n",
+    );
+    write_temp_baseline(&baseline_path, project_root);
+    write_temp_file(
+        &project_root.join("src/client/new.ts"),
+        "\"use client\";\nimport \"node:path\";\n",
+    );
+
+    let output = run_cli(vec![
+        "scan".to_string(),
+        project_root.display().to_string(),
+        "--baseline".to_string(),
+        baseline_path.display().to_string(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let analysis = support::normalize_analysis_json_output(&stdout(&output));
+    assert_eq!(analysis["boundaryWarnings"].as_array().unwrap().len(), 1);
+    assert!(analysis["boundaryWarnings"][0]["message"]
+        .as_str()
+        .unwrap()
+        .contains("node:path"));
+    assert!(!analysis["boundaryWarnings"][0]["message"]
+        .as_str()
+        .unwrap()
+        .contains("node:fs"));
+}
+
+#[test]
+fn regression_only_scan_json_filters_boundary_warnings_by_file_for_same_package() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let project_root = temp_dir.path();
+    let baseline_path = project_root.join("baseline.json");
+
+    write_temp_file(
+        &project_root.join("package.json"),
+        r#"{
+  "name": "boundary-regression-file-app",
+  "dependencies": {}
+}"#,
+    );
+    write_temp_file(
+        &project_root.join("src/client/existing.ts"),
+        "\"use client\";\nimport \"node:fs\";\n",
+    );
+    write_temp_baseline(&baseline_path, project_root);
+    write_temp_file(
+        &project_root.join("src/client/new.ts"),
+        "\"use client\";\nimport \"node:fs\";\n",
+    );
+
+    let output = run_cli(vec![
+        "scan".to_string(),
+        project_root.display().to_string(),
+        "--baseline".to_string(),
+        baseline_path.display().to_string(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let analysis = support::normalize_analysis_json_output(&stdout(&output));
+    assert_eq!(analysis["boundaryWarnings"].as_array().unwrap().len(), 1);
+    assert!(analysis["boundaryWarnings"][0]["message"]
+        .as_str()
+        .unwrap()
+        .contains("src/client/new.ts"));
+    assert!(analysis["boundaryWarnings"][0]["message"]
+        .as_str()
+        .unwrap()
+        .contains("node:fs"));
+}
+
+#[test]
+fn regression_only_scan_json_filters_unused_dependencies_to_new_candidates() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let project_root = temp_dir.path();
+    let baseline_path = project_root.join("baseline.json");
+
+    write_temp_file(
+        &project_root.join("package.json"),
+        r#"{
+  "name": "unused-regression-app",
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "lodash": "^4.17.21"
+  }
+}"#,
+    );
+    write_temp_file(
+        &project_root.join("src/App.ts"),
+        "import \"chart.js/auto\";\nexport const App = null;\n",
+    );
+    write_temp_baseline(&baseline_path, project_root);
+    write_temp_file(
+        &project_root.join("src/App.ts"),
+        "export const App = null;\n",
+    );
+
+    let output = run_cli(vec![
+        "scan".to_string(),
+        project_root.display().to_string(),
+        "--baseline".to_string(),
+        baseline_path.display().to_string(),
+        "--regression-only".to_string(),
+        "--json".to_string(),
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let analysis = support::normalize_analysis_json_output(&stdout(&output));
+    assert_eq!(
+        analysis["unusedDependencyCandidates"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        analysis["unusedDependencyCandidates"][0]["name"],
+        serde_json::json!("chart.js")
+    );
+}

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -336,6 +336,32 @@ fn matches_missing_number_and_unknown_flag_contracts() {
             vec!["scan".to_string(), "--config".to_string()],
             "legolas: --config expects a path\n",
         ),
+        (
+            vec![
+                "visualize".to_string(),
+                fixture.display().to_string(),
+                "--baseline".to_string(),
+                fixture.join("baseline.json").display().to_string(),
+            ],
+            "legolas: unknown flag \"--baseline\"\n",
+        ),
+        (
+            vec![
+                "visualize".to_string(),
+                fixture.display().to_string(),
+                "--write-baseline".to_string(),
+                fixture.join("baseline.json").display().to_string(),
+            ],
+            "legolas: unknown flag \"--write-baseline\"\n",
+        ),
+        (
+            vec![
+                "visualize".to_string(),
+                fixture.display().to_string(),
+                "--regression-only".to_string(),
+            ],
+            "legolas: unknown flag \"--regression-only\"\n",
+        ),
     ];
 
     for (args, expected_stderr) in cases {

--- a/crates/legolas-core/src/baseline.rs
+++ b/crates/legolas-core/src/baseline.rs
@@ -2,9 +2,21 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::Analysis;
+use crate::{
+    models::{DuplicatePackage, LazyLoadCandidate},
+    Analysis,
+};
 
-pub const BASELINE_SCHEMA_VERSION: u32 = 1;
+pub const BASELINE_SCHEMA_VERSION: u32 = 5;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BaselineFindingMetric {
+    pub key: String,
+    pub primary_metric: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secondary_metric: Option<usize>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,10 +27,30 @@ pub struct BaselineSnapshot {
     pub dependency_count: usize,
     pub dev_dependency_count: usize,
     pub source_file_count: usize,
+    #[serde(default)]
+    pub dynamic_import_count: usize,
+    #[serde(default)]
+    pub potential_kb_saved: usize,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub heavy_dependency_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tree_shaking_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub duplicate_package_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lazy_load_candidate_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub boundary_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unused_dependency_candidate_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub heavy_dependency_metrics: Vec<BaselineFindingMetric>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tree_shaking_warning_metrics: Vec<BaselineFindingMetric>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub duplicate_package_metrics: Vec<BaselineFindingMetric>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lazy_load_candidate_metrics: Vec<BaselineFindingMetric>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
 }
@@ -32,8 +64,18 @@ impl Default for BaselineSnapshot {
             dependency_count: 0,
             dev_dependency_count: 0,
             source_file_count: 0,
+            dynamic_import_count: 0,
+            potential_kb_saved: 0,
             heavy_dependency_names: Vec::new(),
             tree_shaking_warning_keys: Vec::new(),
+            duplicate_package_keys: Vec::new(),
+            lazy_load_candidate_keys: Vec::new(),
+            boundary_warning_keys: Vec::new(),
+            unused_dependency_candidate_names: Vec::new(),
+            heavy_dependency_metrics: Vec::new(),
+            tree_shaking_warning_metrics: Vec::new(),
+            duplicate_package_metrics: Vec::new(),
+            lazy_load_candidate_metrics: Vec::new(),
             warnings: Vec::new(),
         }
     }
@@ -48,6 +90,8 @@ impl BaselineSnapshot {
             dependency_count: analysis.package_summary.dependency_count,
             dev_dependency_count: analysis.package_summary.dev_dependency_count,
             source_file_count: analysis.source_summary.files_scanned,
+            dynamic_import_count: analysis.source_summary.dynamic_imports,
+            potential_kb_saved: analysis.impact.potential_kb_saved,
             heavy_dependency_names: unique_sorted(
                 analysis
                     .heavy_dependencies
@@ -59,6 +103,51 @@ impl BaselineSnapshot {
                     .tree_shaking_warnings
                     .iter()
                     .map(|item| item.key.clone()),
+            ),
+            duplicate_package_keys: unique_sorted(
+                analysis
+                    .duplicate_packages
+                    .iter()
+                    .map(duplicate_package_key),
+            ),
+            lazy_load_candidate_keys: unique_sorted(
+                analysis
+                    .lazy_load_candidates
+                    .iter()
+                    .map(lazy_load_candidate_key),
+            ),
+            boundary_warning_keys: unique_sorted(
+                analysis.boundary_warnings.iter().map(boundary_warning_key),
+            ),
+            unused_dependency_candidate_names: unique_sorted(
+                analysis
+                    .unused_dependency_candidates
+                    .iter()
+                    .map(|item| item.name.clone()),
+            ),
+            heavy_dependency_metrics: unique_sorted_metrics(
+                analysis
+                    .heavy_dependencies
+                    .iter()
+                    .map(heavy_dependency_metric),
+            ),
+            tree_shaking_warning_metrics: unique_sorted_metrics(
+                analysis
+                    .tree_shaking_warnings
+                    .iter()
+                    .map(tree_shaking_warning_metric),
+            ),
+            duplicate_package_metrics: unique_sorted_metrics(
+                analysis
+                    .duplicate_packages
+                    .iter()
+                    .map(duplicate_package_metric),
+            ),
+            lazy_load_candidate_metrics: unique_sorted_metrics(
+                analysis
+                    .lazy_load_candidates
+                    .iter()
+                    .map(lazy_load_candidate_metric),
             ),
             warnings: unique_sorted(analysis.warnings.iter().cloned()),
         }
@@ -79,14 +168,42 @@ pub struct BaselineDiff {
     pub dev_dependency_count_current: usize,
     pub source_file_count_previous: usize,
     pub source_file_count_current: usize,
+    pub dynamic_import_count_previous: usize,
+    pub dynamic_import_count_current: usize,
+    pub potential_kb_saved_previous: usize,
+    pub potential_kb_saved_current: usize,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub added_heavy_dependency_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub removed_heavy_dependency_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub worsened_heavy_dependency_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub added_tree_shaking_warning_keys: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub removed_tree_shaking_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub worsened_tree_shaking_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_duplicate_package_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_duplicate_package_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub worsened_duplicate_package_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_lazy_load_candidate_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_lazy_load_candidate_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub worsened_lazy_load_candidate_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_boundary_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_boundary_warning_keys: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub added_unused_dependency_candidate_names: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed_unused_dependency_candidate_names: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub added_warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -100,10 +217,24 @@ impl BaselineDiff {
             && self.dependency_count_previous == self.dependency_count_current
             && self.dev_dependency_count_previous == self.dev_dependency_count_current
             && self.source_file_count_previous == self.source_file_count_current
+            && self.dynamic_import_count_previous == self.dynamic_import_count_current
+            && self.potential_kb_saved_previous == self.potential_kb_saved_current
             && self.added_heavy_dependency_names.is_empty()
             && self.removed_heavy_dependency_names.is_empty()
+            && self.worsened_heavy_dependency_names.is_empty()
             && self.added_tree_shaking_warning_keys.is_empty()
             && self.removed_tree_shaking_warning_keys.is_empty()
+            && self.worsened_tree_shaking_warning_keys.is_empty()
+            && self.added_duplicate_package_keys.is_empty()
+            && self.removed_duplicate_package_keys.is_empty()
+            && self.worsened_duplicate_package_keys.is_empty()
+            && self.added_lazy_load_candidate_keys.is_empty()
+            && self.removed_lazy_load_candidate_keys.is_empty()
+            && self.worsened_lazy_load_candidate_keys.is_empty()
+            && self.added_boundary_warning_keys.is_empty()
+            && self.removed_boundary_warning_keys.is_empty()
+            && self.added_unused_dependency_candidate_names.is_empty()
+            && self.removed_unused_dependency_candidate_names.is_empty()
             && self.added_warnings.is_empty()
             && self.removed_warnings.is_empty()
     }
@@ -122,6 +253,10 @@ pub fn diff_baselines(previous: &BaselineSnapshot, current: &BaselineSnapshot) -
         dev_dependency_count_current: current.dev_dependency_count,
         source_file_count_previous: previous.source_file_count,
         source_file_count_current: current.source_file_count,
+        dynamic_import_count_previous: previous.dynamic_import_count,
+        dynamic_import_count_current: current.dynamic_import_count,
+        potential_kb_saved_previous: previous.potential_kb_saved,
+        potential_kb_saved_current: current.potential_kb_saved,
         added_heavy_dependency_names: diff_added(
             previous.heavy_dependency_names.as_slice(),
             current.heavy_dependency_names.as_slice(),
@@ -130,6 +265,10 @@ pub fn diff_baselines(previous: &BaselineSnapshot, current: &BaselineSnapshot) -
             previous.heavy_dependency_names.as_slice(),
             current.heavy_dependency_names.as_slice(),
         ),
+        worsened_heavy_dependency_names: diff_worsened(
+            previous.heavy_dependency_metrics.as_slice(),
+            current.heavy_dependency_metrics.as_slice(),
+        ),
         added_tree_shaking_warning_keys: diff_added(
             previous.tree_shaking_warning_keys.as_slice(),
             current.tree_shaking_warning_keys.as_slice(),
@@ -137,6 +276,50 @@ pub fn diff_baselines(previous: &BaselineSnapshot, current: &BaselineSnapshot) -
         removed_tree_shaking_warning_keys: diff_removed(
             previous.tree_shaking_warning_keys.as_slice(),
             current.tree_shaking_warning_keys.as_slice(),
+        ),
+        worsened_tree_shaking_warning_keys: diff_worsened(
+            previous.tree_shaking_warning_metrics.as_slice(),
+            current.tree_shaking_warning_metrics.as_slice(),
+        ),
+        added_duplicate_package_keys: diff_added(
+            previous.duplicate_package_keys.as_slice(),
+            current.duplicate_package_keys.as_slice(),
+        ),
+        removed_duplicate_package_keys: diff_removed(
+            previous.duplicate_package_keys.as_slice(),
+            current.duplicate_package_keys.as_slice(),
+        ),
+        worsened_duplicate_package_keys: diff_worsened(
+            previous.duplicate_package_metrics.as_slice(),
+            current.duplicate_package_metrics.as_slice(),
+        ),
+        added_lazy_load_candidate_keys: diff_added(
+            previous.lazy_load_candidate_keys.as_slice(),
+            current.lazy_load_candidate_keys.as_slice(),
+        ),
+        removed_lazy_load_candidate_keys: diff_removed(
+            previous.lazy_load_candidate_keys.as_slice(),
+            current.lazy_load_candidate_keys.as_slice(),
+        ),
+        worsened_lazy_load_candidate_keys: diff_worsened(
+            previous.lazy_load_candidate_metrics.as_slice(),
+            current.lazy_load_candidate_metrics.as_slice(),
+        ),
+        added_boundary_warning_keys: diff_added(
+            previous.boundary_warning_keys.as_slice(),
+            current.boundary_warning_keys.as_slice(),
+        ),
+        removed_boundary_warning_keys: diff_removed(
+            previous.boundary_warning_keys.as_slice(),
+            current.boundary_warning_keys.as_slice(),
+        ),
+        added_unused_dependency_candidate_names: diff_added(
+            previous.unused_dependency_candidate_names.as_slice(),
+            current.unused_dependency_candidate_names.as_slice(),
+        ),
+        removed_unused_dependency_candidate_names: diff_removed(
+            previous.unused_dependency_candidate_names.as_slice(),
+            current.unused_dependency_candidate_names.as_slice(),
         ),
         added_warnings: diff_added(previous.warnings.as_slice(), current.warnings.as_slice()),
         removed_warnings: diff_removed(previous.warnings.as_slice(), current.warnings.as_slice()),
@@ -158,6 +341,80 @@ where
         .collect()
 }
 
+fn unique_sorted_metrics<I>(values: I) -> Vec<BaselineFindingMetric>
+where
+    I: IntoIterator<Item = BaselineFindingMetric>,
+{
+    let mut values = values.into_iter().collect::<Vec<_>>();
+    values.sort_by(|left, right| left.key.cmp(&right.key));
+    values
+}
+
+fn heavy_dependency_metric(item: &crate::models::HeavyDependency) -> BaselineFindingMetric {
+    BaselineFindingMetric {
+        key: item.name.clone(),
+        primary_metric: item.estimated_kb,
+        secondary_metric: Some(item.import_count),
+    }
+}
+
+fn tree_shaking_warning_metric(item: &crate::models::TreeShakingWarning) -> BaselineFindingMetric {
+    BaselineFindingMetric {
+        key: item.key.clone(),
+        primary_metric: item.estimated_kb,
+        secondary_metric: Some(item.files.len()),
+    }
+}
+
+fn duplicate_package_key(item: &DuplicatePackage) -> String {
+    item.finding
+        .finding_id
+        .clone()
+        .unwrap_or_else(|| item.name.clone())
+}
+
+fn duplicate_package_metric(item: &DuplicatePackage) -> BaselineFindingMetric {
+    BaselineFindingMetric {
+        key: duplicate_package_key(item),
+        primary_metric: item.estimated_extra_kb,
+        secondary_metric: Some(item.count),
+    }
+}
+
+fn lazy_load_candidate_key(item: &LazyLoadCandidate) -> String {
+    item.finding
+        .finding_id
+        .clone()
+        .unwrap_or_else(|| item.name.clone())
+}
+
+pub fn boundary_warning_key(item: &crate::boundaries::BoundaryWarning) -> String {
+    let finding_id = item
+        .finding
+        .finding_id
+        .as_deref()
+        .unwrap_or("boundary-warning");
+    let evidence = item.finding.evidence.first();
+
+    match (
+        evidence.and_then(|entry| entry.file.as_deref()),
+        evidence.and_then(|entry| entry.specifier.as_deref()),
+    ) {
+        (Some(file), Some(specifier)) => format!("{finding_id}:{file}:{specifier}"),
+        (Some(file), None) => format!("{finding_id}:{file}"),
+        (None, Some(specifier)) => format!("{finding_id}:{specifier}"),
+        (None, None) => item.message.clone(),
+    }
+}
+
+fn lazy_load_candidate_metric(item: &LazyLoadCandidate) -> BaselineFindingMetric {
+    BaselineFindingMetric {
+        key: lazy_load_candidate_key(item),
+        primary_metric: item.estimated_savings_kb,
+        secondary_metric: Some(item.files.len()),
+    }
+}
+
 fn diff_added(previous: &[String], current: &[String]) -> Vec<String> {
     let previous = previous.iter().cloned().collect::<BTreeSet<_>>();
     current
@@ -174,4 +431,28 @@ fn diff_removed(previous: &[String], current: &[String]) -> Vec<String> {
         .filter(|item| !current.contains(item.as_str()))
         .cloned()
         .collect()
+}
+
+fn diff_worsened(
+    previous: &[BaselineFindingMetric],
+    current: &[BaselineFindingMetric],
+) -> Vec<String> {
+    let previous_by_key = previous
+        .iter()
+        .map(|item| (&item.key, item))
+        .collect::<std::collections::BTreeMap<_, _>>();
+
+    current
+        .iter()
+        .filter_map(|item| {
+            let previous = previous_by_key.get(&item.key)?;
+            is_worsened_metric(previous, item).then(|| item.key.clone())
+        })
+        .collect()
+}
+
+fn is_worsened_metric(previous: &BaselineFindingMetric, current: &BaselineFindingMetric) -> bool {
+    current.primary_metric > previous.primary_metric
+        || (current.primary_metric == previous.primary_metric
+            && current.secondary_metric.unwrap_or(0) > previous.secondary_metric.unwrap_or(0))
 }

--- a/crates/legolas-core/tests/baseline_diff.rs
+++ b/crates/legolas-core/tests/baseline_diff.rs
@@ -2,7 +2,10 @@ mod support;
 
 use std::fs;
 
-use legolas_core::{analyze_project, diff_analysis, BaselineSnapshot};
+use legolas_core::{
+    analyze_project, baseline::BASELINE_SCHEMA_VERSION, diff_analysis, BaselineFindingMetric,
+    BaselineSnapshot,
+};
 
 #[test]
 fn baseline_diff_detects_new_package_and_tree_shaking_warning() {
@@ -27,28 +30,68 @@ fn baseline_diff_detects_new_package_and_tree_shaking_warning() {
     );
     assert_eq!(diff.removed_heavy_dependency_names, Vec::<String>::new());
     assert_eq!(
+        diff.worsened_heavy_dependency_names,
+        vec!["chart.js".to_string()]
+    );
+    assert_eq!(
         diff.added_tree_shaking_warning_keys,
         vec!["lodash-root-import".to_string()]
     );
     assert_eq!(diff.removed_tree_shaking_warning_keys, Vec::<String>::new());
+    assert_eq!(
+        diff.worsened_tree_shaking_warning_keys,
+        Vec::<String>::new()
+    );
+    assert_eq!(diff.added_duplicate_package_keys, Vec::<String>::new());
+    assert_eq!(diff.removed_duplicate_package_keys, Vec::<String>::new());
+    assert_eq!(diff.worsened_duplicate_package_keys, Vec::<String>::new());
+    assert_eq!(diff.added_lazy_load_candidate_keys, Vec::<String>::new());
+    assert_eq!(diff.removed_lazy_load_candidate_keys, Vec::<String>::new());
+    assert_eq!(diff.worsened_lazy_load_candidate_keys, Vec::<String>::new());
     assert_eq!(diff.dependency_count_previous, 1);
     assert_eq!(diff.dependency_count_current, 2);
     assert_eq!(diff.source_file_count_previous, 1);
     assert_eq!(diff.source_file_count_current, 1);
+    assert_eq!(diff.dynamic_import_count_previous, 0);
+    assert_eq!(diff.dynamic_import_count_current, 0);
     assert!(!diff.is_empty());
 }
 
 #[test]
 fn baseline_snapshot_round_trips_as_json() {
     let snapshot = BaselineSnapshot {
-        schema_version: 1,
+        schema_version: BASELINE_SCHEMA_VERSION,
         project_name: "baseline-app".to_string(),
         package_manager: "npm".to_string(),
         dependency_count: 1,
         dev_dependency_count: 0,
         source_file_count: 1,
+        dynamic_import_count: 1,
+        potential_kb_saved: 42,
         heavy_dependency_names: vec!["chart.js".to_string()],
         tree_shaking_warning_keys: Vec::new(),
+        duplicate_package_keys: vec!["duplicate-package:react".to_string()],
+        lazy_load_candidate_keys: vec!["lazy-load:chart.js".to_string()],
+        boundary_warning_keys: vec![
+            "boundary:server-client:fs:src/client/App.tsx:node:fs".to_string()
+        ],
+        unused_dependency_candidate_names: vec!["lodash".to_string()],
+        heavy_dependency_metrics: vec![BaselineFindingMetric {
+            key: "chart.js".to_string(),
+            primary_metric: 66,
+            secondary_metric: Some(1),
+        }],
+        tree_shaking_warning_metrics: Vec::new(),
+        duplicate_package_metrics: vec![BaselineFindingMetric {
+            key: "duplicate-package:react".to_string(),
+            primary_metric: 12,
+            secondary_metric: Some(2),
+        }],
+        lazy_load_candidate_metrics: vec![BaselineFindingMetric {
+            key: "lazy-load:chart.js".to_string(),
+            primary_metric: 48,
+            secondary_metric: Some(1),
+        }],
         warnings: Vec::new(),
     };
 
@@ -56,4 +99,219 @@ fn baseline_snapshot_round_trips_as_json() {
     let decoded: BaselineSnapshot = serde_json::from_str(&encoded).expect("deserialize snapshot");
 
     assert_eq!(decoded, snapshot);
+}
+
+#[test]
+fn baseline_diff_detects_worsened_existing_findings() {
+    let previous = BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        project_name: "baseline-app".to_string(),
+        package_manager: "npm".to_string(),
+        dependency_count: 1,
+        dev_dependency_count: 0,
+        source_file_count: 1,
+        dynamic_import_count: 2,
+        potential_kb_saved: 120,
+        heavy_dependency_names: vec!["lodash".to_string()],
+        tree_shaking_warning_keys: Vec::new(),
+        duplicate_package_keys: vec!["duplicate-package:react".to_string()],
+        lazy_load_candidate_keys: vec!["lazy-load:chart.js".to_string()],
+        boundary_warning_keys: Vec::new(),
+        unused_dependency_candidate_names: Vec::new(),
+        heavy_dependency_metrics: vec![BaselineFindingMetric {
+            key: "lodash".to_string(),
+            primary_metric: 72,
+            secondary_metric: Some(1),
+        }],
+        tree_shaking_warning_metrics: Vec::new(),
+        duplicate_package_metrics: vec![BaselineFindingMetric {
+            key: "duplicate-package:react".to_string(),
+            primary_metric: 12,
+            secondary_metric: Some(1),
+        }],
+        lazy_load_candidate_metrics: vec![BaselineFindingMetric {
+            key: "lazy-load:chart.js".to_string(),
+            primary_metric: 48,
+            secondary_metric: Some(1),
+        }],
+        warnings: Vec::new(),
+    };
+    let current = BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        project_name: "baseline-app".to_string(),
+        package_manager: "npm".to_string(),
+        dependency_count: 1,
+        dev_dependency_count: 0,
+        source_file_count: 1,
+        dynamic_import_count: 1,
+        potential_kb_saved: 156,
+        heavy_dependency_names: vec!["lodash".to_string()],
+        tree_shaking_warning_keys: Vec::new(),
+        duplicate_package_keys: vec!["duplicate-package:react".to_string()],
+        lazy_load_candidate_keys: vec!["lazy-load:chart.js".to_string()],
+        boundary_warning_keys: Vec::new(),
+        unused_dependency_candidate_names: Vec::new(),
+        heavy_dependency_metrics: vec![BaselineFindingMetric {
+            key: "lodash".to_string(),
+            primary_metric: 72,
+            secondary_metric: Some(2),
+        }],
+        tree_shaking_warning_metrics: Vec::new(),
+        duplicate_package_metrics: vec![BaselineFindingMetric {
+            key: "duplicate-package:react".to_string(),
+            primary_metric: 20,
+            secondary_metric: Some(2),
+        }],
+        lazy_load_candidate_metrics: vec![BaselineFindingMetric {
+            key: "lazy-load:chart.js".to_string(),
+            primary_metric: 64,
+            secondary_metric: Some(2),
+        }],
+        warnings: Vec::new(),
+    };
+
+    let diff = legolas_core::diff_baselines(&previous, &current);
+
+    assert_eq!(
+        diff.worsened_heavy_dependency_names,
+        vec!["lodash".to_string()]
+    );
+    assert_eq!(
+        diff.worsened_duplicate_package_keys,
+        vec!["duplicate-package:react".to_string()]
+    );
+    assert_eq!(
+        diff.worsened_lazy_load_candidate_keys,
+        vec!["lazy-load:chart.js".to_string()]
+    );
+    assert_eq!(diff.dynamic_import_count_previous, 2);
+    assert_eq!(diff.dynamic_import_count_current, 1);
+    assert_eq!(diff.potential_kb_saved_previous, 120);
+    assert_eq!(diff.potential_kb_saved_current, 156);
+}
+
+#[test]
+fn baseline_diff_detects_added_boundary_and_unused_dependency_regressions() {
+    let previous = BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        project_name: "baseline-app".to_string(),
+        package_manager: "npm".to_string(),
+        dependency_count: 2,
+        dev_dependency_count: 0,
+        source_file_count: 1,
+        dynamic_import_count: 0,
+        potential_kb_saved: 0,
+        heavy_dependency_names: Vec::new(),
+        tree_shaking_warning_keys: Vec::new(),
+        duplicate_package_keys: Vec::new(),
+        lazy_load_candidate_keys: Vec::new(),
+        boundary_warning_keys: vec![
+            "boundary:server-client:fs:src/client/existing.ts:node:fs".to_string()
+        ],
+        unused_dependency_candidate_names: vec!["lodash".to_string()],
+        heavy_dependency_metrics: Vec::new(),
+        tree_shaking_warning_metrics: Vec::new(),
+        duplicate_package_metrics: Vec::new(),
+        lazy_load_candidate_metrics: Vec::new(),
+        warnings: Vec::new(),
+    };
+    let current = BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        project_name: "baseline-app".to_string(),
+        package_manager: "npm".to_string(),
+        dependency_count: 2,
+        dev_dependency_count: 0,
+        source_file_count: 1,
+        dynamic_import_count: 0,
+        potential_kb_saved: 0,
+        heavy_dependency_names: Vec::new(),
+        tree_shaking_warning_keys: Vec::new(),
+        duplicate_package_keys: Vec::new(),
+        lazy_load_candidate_keys: Vec::new(),
+        boundary_warning_keys: vec![
+            "boundary:server-client:fs:src/client/existing.ts:node:fs".to_string(),
+            "boundary:server-client:path:src/client/new.ts:node:path".to_string(),
+        ],
+        unused_dependency_candidate_names: vec!["chart.js".to_string(), "lodash".to_string()],
+        heavy_dependency_metrics: Vec::new(),
+        tree_shaking_warning_metrics: Vec::new(),
+        duplicate_package_metrics: Vec::new(),
+        lazy_load_candidate_metrics: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    let diff = legolas_core::diff_baselines(&previous, &current);
+
+    assert_eq!(
+        diff.added_boundary_warning_keys,
+        vec!["boundary:server-client:path:src/client/new.ts:node:path".to_string()]
+    );
+    assert_eq!(diff.removed_boundary_warning_keys, Vec::<String>::new());
+    assert_eq!(
+        diff.added_unused_dependency_candidate_names,
+        vec!["chart.js".to_string()]
+    );
+    assert_eq!(
+        diff.removed_unused_dependency_candidate_names,
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn baseline_diff_detects_added_boundary_warning_for_same_package_in_new_file() {
+    let previous = BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        project_name: "baseline-app".to_string(),
+        package_manager: "npm".to_string(),
+        dependency_count: 0,
+        dev_dependency_count: 0,
+        source_file_count: 1,
+        dynamic_import_count: 0,
+        potential_kb_saved: 0,
+        heavy_dependency_names: Vec::new(),
+        tree_shaking_warning_keys: Vec::new(),
+        duplicate_package_keys: Vec::new(),
+        lazy_load_candidate_keys: Vec::new(),
+        boundary_warning_keys: vec![
+            "boundary:server-client:fs:src/client/existing.ts:node:fs".to_string()
+        ],
+        unused_dependency_candidate_names: Vec::new(),
+        heavy_dependency_metrics: Vec::new(),
+        tree_shaking_warning_metrics: Vec::new(),
+        duplicate_package_metrics: Vec::new(),
+        lazy_load_candidate_metrics: Vec::new(),
+        warnings: Vec::new(),
+    };
+    let current = BaselineSnapshot {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        project_name: "baseline-app".to_string(),
+        package_manager: "npm".to_string(),
+        dependency_count: 0,
+        dev_dependency_count: 0,
+        source_file_count: 2,
+        dynamic_import_count: 0,
+        potential_kb_saved: 0,
+        heavy_dependency_names: Vec::new(),
+        tree_shaking_warning_keys: Vec::new(),
+        duplicate_package_keys: Vec::new(),
+        lazy_load_candidate_keys: Vec::new(),
+        boundary_warning_keys: vec![
+            "boundary:server-client:fs:src/client/existing.ts:node:fs".to_string(),
+            "boundary:server-client:fs:src/client/new.ts:node:fs".to_string(),
+        ],
+        unused_dependency_candidate_names: Vec::new(),
+        heavy_dependency_metrics: Vec::new(),
+        tree_shaking_warning_metrics: Vec::new(),
+        duplicate_package_metrics: Vec::new(),
+        lazy_load_candidate_metrics: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    let diff = legolas_core::diff_baselines(&previous, &current);
+
+    assert_eq!(
+        diff.added_boundary_warning_keys,
+        vec!["boundary:server-client:fs:src/client/new.ts:node:fs".to_string()]
+    );
+    assert_eq!(diff.removed_boundary_warning_keys, Vec::<String>::new());
 }

--- a/tests/fixtures/baseline/previous-scan.json
+++ b/tests/fixtures/baseline/previous-scan.json
@@ -1,13 +1,29 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 5,
   "projectName": "baseline-app",
   "packageManager": "npm",
   "dependencyCount": 1,
   "devDependencyCount": 0,
   "sourceFileCount": 1,
+  "dynamicImportCount": 0,
+  "potentialKbSaved": 66,
   "heavyDependencyNames": [
     "chart.js"
   ],
   "treeShakingWarningKeys": [],
+  "duplicatePackageKeys": [],
+  "lazyLoadCandidateKeys": [],
+  "boundaryWarningKeys": [],
+  "unusedDependencyCandidateNames": [],
+  "heavyDependencyMetrics": [
+    {
+      "key": "chart.js",
+      "primaryMetric": 66,
+      "secondaryMetric": 1
+    }
+  ],
+  "treeShakingWarningMetrics": [],
+  "duplicatePackageMetrics": [],
+  "lazyLoadCandidateMetrics": [],
   "warnings": []
 }

--- a/tests/oracles/cli/help.txt
+++ b/tests/oracles/cli/help.txt
@@ -2,17 +2,19 @@ Legolas
 Slim bundles with precision.
 
 Usage:
-  legolas scan [path] [--config file] [--json]
+  legolas scan [path] [--config file] [--json] [--write-baseline file] [--baseline file --regression-only]
   legolas visualize [path] [--config file] [--limit 10]
-  legolas optimize [path] [--config file] [--top 5]
-  legolas budget [path] [--config file] [--json]
-  legolas ci [path] [--config file] [--json]
+  legolas optimize [path] [--config file] [--top 5] [--baseline file --regression-only]
+  legolas budget [path] [--config file] [--json] [--baseline file --regression-only]
+  legolas ci [path] [--config file] [--json] [--baseline file --regression-only]
   legolas help
 
 Examples:
   legolas scan .
+  legolas scan ./apps/storefront --write-baseline ./baseline.json --json
+  legolas scan ./apps/storefront --baseline ./baseline.json --regression-only --json
   legolas scan --config ./legolas.config.json
   legolas visualize ./apps/storefront --limit 12
-  legolas optimize --top 7
-  legolas budget ./apps/storefront --json
-  legolas ci ./apps/storefront
+  legolas optimize ./apps/storefront --top 7 --baseline ./baseline.json --regression-only
+  legolas budget ./apps/storefront --baseline ./baseline.json --regression-only --json
+  legolas ci ./apps/storefront --baseline ./baseline.json --regression-only


### PR DESCRIPTION
배경
- `PR-FIT-011A`로 들어간 baseline snapshot/diff core를 CLI 명령에서 실제 사용할 수 있게 이어 붙입니다.
- 이번 slice는 `scan`, `budget`, `ci`에서 baseline 파일 기반 regression-only 흐름을 열어 주는 adoption 단계입니다.

변경 사항
- `--baseline`, `--write-baseline`, `--regression-only` 플래그를 추가했습니다.
- baseline snapshot 읽기/쓰기와 regression-only 분석 경로를 CLI main flow에 연결했습니다.
- unsupported command에서 baseline 플래그를 거부하는 CLI contract를 추가했습니다.
- baseline 전용 contract test를 추가해서 scan/budget/ci regression-only 동작, baseline write, missing baseline, malformed baseline error를 고정했습니다.

검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- scan tests/fixtures/baseline/current-app --baseline tests/fixtures/baseline/previous-scan.json --regression-only --json`
- `cargo run -p legolas-cli -- budget tests/fixtures/baseline/current-app --baseline tests/fixtures/baseline/previous-scan.json --regression-only --json`
- `cargo run -p legolas-cli -- ci tests/fixtures/baseline/current-app --baseline tests/fixtures/baseline/previous-scan.json --regression-only --json`
- `cargo run -p legolas-cli -- scan tests/fixtures/baseline/current-app --write-baseline /tmp/legolas-baseline-check.json --json`

브랜치 / 워크트리
- target branch: `codex/pr-fit-011b-baseline-regression`
- base branch: `master`
- worktree: `/Users/pjw/workspace/legolas`

주의 사항
- regression-only `budget`/`ci`는 baseline-filtered 결과를 기준으로 하며, compact baseline snapshot 한계 때문에 완전한 historical metric comparator는 아닙니다.
