### PR TITLE
feat: Next use-client boundary 감지 추가

### DIFF
--- a/crates/legolas-core/src/boundaries.rs
+++ b/crates/legolas-core/src/boundaries.rs
@@ -39,13 +39,19 @@ pub struct Phase8SeedContext<'a> {
 pub fn collect_boundary_warnings(context: &Phase8SeedContext<'_>) -> Vec<BoundaryWarning> {
     let mut warnings = Vec::new();
     let mut seen = std::collections::BTreeSet::new();
+    let next_client_surface_enabled = context
+        .frameworks
+        .iter()
+        .any(|framework| framework == "Next.js");
 
     for (package_name, record) in &context.source_analysis.by_package {
         if !is_server_only_package(package_name) {
             continue;
         }
 
-        let Some(client_file) = record.files.iter().find(|file| is_client_surface(file)) else {
+        let Some(client_file) = record.files.iter().find(|file| {
+            is_client_surface(context.project_root, file, next_client_surface_enabled)
+        }) else {
             continue;
         };
 
@@ -59,7 +65,9 @@ pub fn collect_boundary_warnings(context: &Phase8SeedContext<'_>) -> Vec<Boundar
         }
     }
 
-    for (client_file, specifier) in collect_node_prefix_client_imports(context.project_root) {
+    for (client_file, specifier) in
+        collect_node_prefix_client_imports(context.project_root, next_client_surface_enabled)
+    {
         let Some(package_name) = specifier.strip_prefix("node:") else {
             continue;
         };
@@ -130,21 +138,39 @@ fn server_only_packages() -> &'static [&'static str] {
         .as_slice()
 }
 
-fn is_client_surface(relative_path: &str) -> bool {
-    Path::new(relative_path)
+fn is_client_surface(
+    project_root: &Path,
+    relative_path: &str,
+    next_client_surface_enabled: bool,
+) -> bool {
+    if Path::new(relative_path)
         .components()
         .any(|component| matches!(component, Component::Normal(segment) if segment == "client"))
+    {
+        return true;
+    }
+
+    next_client_surface_enabled && has_use_client_directive(project_root.join(relative_path))
 }
 
-fn collect_node_prefix_client_imports(project_root: &Path) -> Vec<(String, String)> {
+fn collect_node_prefix_client_imports(
+    project_root: &Path,
+    next_client_surface_enabled: bool,
+) -> Vec<(String, String)> {
     let mut matches = Vec::new();
-    collect_node_prefix_client_imports_inner(project_root, project_root, &mut matches);
+    collect_node_prefix_client_imports_inner(
+        project_root,
+        project_root,
+        next_client_surface_enabled,
+        &mut matches,
+    );
     matches
 }
 
 fn collect_node_prefix_client_imports_inner(
     project_root: &Path,
     current: &Path,
+    next_client_surface_enabled: bool,
     matches: &mut Vec<(String, String)>,
 ) {
     let Ok(entries) = fs::read_dir(current) else {
@@ -177,7 +203,12 @@ fn collect_node_prefix_client_imports_inner(
             ) {
                 continue;
             }
-            collect_node_prefix_client_imports_inner(project_root, &path, matches);
+            collect_node_prefix_client_imports_inner(
+                project_root,
+                &path,
+                next_client_surface_enabled,
+                matches,
+            );
             continue;
         }
 
@@ -188,7 +219,7 @@ fn collect_node_prefix_client_imports_inner(
         let Some(relative_path) = path.strip_prefix(project_root).ok().map(to_posix) else {
             continue;
         };
-        if !is_client_surface(&relative_path) {
+        if !is_client_surface(project_root, &relative_path, next_client_surface_enabled) {
             continue;
         }
 
@@ -199,6 +230,86 @@ fn collect_node_prefix_client_imports_inner(
             matches.push((relative_path.clone(), specifier));
         }
     }
+}
+
+fn has_use_client_directive(path: impl AsRef<Path>) -> bool {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+
+    has_directive_prologue_entry(&contents, "use client")
+}
+
+fn has_directive_prologue_entry(contents: &str, directive: &str) -> bool {
+    let mut in_block_comment = false;
+
+    for line in contents.lines() {
+        let mut remainder = line;
+
+        while let Some(fragment) = leading_directive_fragment(remainder, &mut in_block_comment) {
+            let Some((literal, rest)) = parse_directive_literal(fragment) else {
+                return false;
+            };
+            if literal == directive {
+                return true;
+            }
+
+            remainder = rest;
+        }
+    }
+
+    false
+}
+
+fn leading_directive_fragment<'a>(line: &'a str, in_block_comment: &mut bool) -> Option<&'a str> {
+    let mut fragment = line.trim().trim_start_matches('\u{feff}');
+
+    loop {
+        if fragment.is_empty() {
+            return None;
+        }
+
+        if *in_block_comment {
+            let block_end = fragment.find("*/")?;
+            *in_block_comment = false;
+            fragment = fragment[block_end + 2..].trim_start();
+            continue;
+        }
+
+        if fragment.starts_with("//") {
+            return None;
+        }
+
+        if fragment.starts_with("/*") {
+            if let Some(block_end) = fragment.find("*/") {
+                fragment = fragment[block_end + 2..].trim_start();
+                continue;
+            }
+
+            *in_block_comment = true;
+            return None;
+        }
+
+        return Some(fragment);
+    }
+}
+
+fn parse_directive_literal(fragment: &str) -> Option<(&str, &str)> {
+    let mut chars = fragment.char_indices();
+    let (_, quote) = chars.next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+
+    let closing = fragment[1..].find(quote)? + 1;
+    let literal = &fragment[1..closing];
+    let rest = fragment[closing + quote.len_utf8()..].trim_start();
+    if rest.is_empty() || rest.starts_with("//") || rest.starts_with("/*") {
+        return Some((literal, ""));
+    }
+
+    let rest = rest.strip_prefix(';')?.trim_start();
+    Some((literal, rest))
 }
 
 fn is_supported_source_file(path: &Path) -> bool {
@@ -229,4 +340,39 @@ fn to_posix(path: &Path) -> String {
         })
         .collect::<Vec<_>>()
         .join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_directive_prologue_entry;
+
+    #[test]
+    fn directive_prologue_accepts_same_line_block_comment_prefix() {
+        let contents = "/* eslint-disable */ \"use client\";\nimport fs from \"node:fs\";";
+        assert!(has_directive_prologue_entry(contents, "use client"));
+    }
+
+    #[test]
+    fn directive_prologue_accepts_trailing_comment_after_directive() {
+        let contents = "\"use client\"; // keep client-only behavior";
+        assert!(has_directive_prologue_entry(contents, "use client"));
+    }
+
+    #[test]
+    fn directive_prologue_accepts_target_after_use_strict() {
+        let contents = "\"use strict\"; \"use client\";\nimport fs from \"node:fs\";";
+        assert!(has_directive_prologue_entry(contents, "use client"));
+    }
+
+    #[test]
+    fn directive_prologue_accepts_utf8_bom_prefix() {
+        let contents = "\u{feff}\"use client\";\nimport fs from \"node:fs\";";
+        assert!(has_directive_prologue_entry(contents, "use client"));
+    }
+
+    #[test]
+    fn directive_prologue_stops_after_non_directive_code() {
+        let contents = "const mode = \"client\";\n\"use client\";";
+        assert!(!has_directive_prologue_entry(contents, "use client"));
+    }
 }

--- a/crates/legolas-core/tests/boundary_analysis.rs
+++ b/crates/legolas-core/tests/boundary_analysis.rs
@@ -35,6 +35,39 @@ fn analyze_project_emits_general_server_client_boundary_warning() {
     );
 }
 
+#[test]
+fn analyze_project_emits_next_use_client_boundary_warning() {
+    let analysis = analyze_project(support::fixture_path(
+        "tests/fixtures/boundaries/next-use-client",
+    ))
+    .expect("analyze next boundary fixture");
+
+    assert_eq!(analysis.boundary_warnings.len(), 1);
+
+    let warning = &analysis.boundary_warnings[0];
+    assert_eq!(
+        warning.message,
+        "Client surface `app/page.tsx` imports the Node-only `node:fs` module."
+    );
+    assert_eq!(
+        warning.recommendation,
+        "Keep Node-only work on the server and pass browser-safe data into the client component."
+    );
+    assert_finding_metadata(
+        &warning.finding,
+        FindingMetadata::new(
+            "boundary:server-client:fs",
+            FindingAnalysisSource::SourceImport,
+        )
+        .with_confidence(FindingConfidence::High)
+        .with_action_priority(1)
+        .with_evidence([FindingEvidence::new("source-file")
+            .with_file("app/page.tsx")
+            .with_specifier("node:fs")
+            .with_detail("client surface imports a Node-only module")]),
+    );
+}
+
 fn assert_finding_metadata(actual: &FindingMetadata, expected: FindingMetadata) {
     assert_eq!(actual.finding_id, expected.finding_id);
     assert_eq!(actual.analysis_source, expected.analysis_source);

--- a/tests/fixtures/boundaries/next-use-client/app/page.tsx
+++ b/tests/fixtures/boundaries/next-use-client/app/page.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/no-danger */ "use client";
+
+import fs from "node:fs";
+
+export default function Page() {
+  return <pre>{fs.readFileSync("/etc/hosts", "utf8")}</pre>;
+}

--- a/tests/fixtures/boundaries/next-use-client/package.json
+++ b/tests/fixtures/boundaries/next-use-client/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "boundary-next-use-client-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}


### PR DESCRIPTION
배경
- `PR-FIT-012A`에서 general boundary detector를 도입했고, 이번 slice는 Next.js `use client` surface까지 boundary 감지를 확장합니다.
- 목표는 Next client component에서 `node:` builtin import가 새는 케이스를 dedicated boundary warning으로 잡는 것입니다.

변경 사항
- Next.js framework가 감지된 프로젝트에서 `use client` directive를 client surface로 해석하도록 boundary detector를 확장했습니다.
- `use client` directive parsing regression을 `boundary_analysis`에 추가했습니다.
- `tests/fixtures/boundaries/next-use-client` fixture를 추가해서 `app/page.tsx`의 `node:fs` 누수를 재현하도록 했습니다.

검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p legolas-core --test boundary_analysis`
- `cargo run -p legolas-cli -- scan tests/fixtures/boundaries/next-use-client --json`

브랜치 / 워크트리
- target branch: `codex/pr-fit-012b-next-use-client`
- base branch: `master`
- worktree: `/Users/pjw/workspace/legolas`

주의 사항
- boundary warning은 JSON/analysis surface에는 반영되지만, 사람이 읽는 scan text report에서의 boundary section adoption은 후속 slice 범위입니다.
