### PR TITLE
PR-FIT-013B: workspace summaries를 scan/budget/ci output에 반영

### DIFF
--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -19,7 +19,7 @@ use legolas_core::{
     impact::estimate_impact,
     LegolasError, Result,
 };
-use serde_json::json;
+use serde_json::{json, Map, Value};
 
 const HELP_TEXT: &str = r#"Legolas
 Slim bundles with precision.
@@ -107,28 +107,21 @@ fn run() -> Result<i32> {
         match command {
             Command::Budget => println!(
                 "{}",
-                serde_json::to_string_pretty(
+                serde_json::to_string_pretty(&budget_json_output(
+                    &output_analysis,
                     budget_evaluation
                         .as_ref()
                         .expect("budget evaluation exists for budget command"),
-                )?
+                ))?
             ),
             Command::Ci => println!(
                 "{}",
-                serde_json::to_string_pretty(&json!({
-                    "passed": !budget_evaluation
+                serde_json::to_string_pretty(&ci_json_output(
+                    &output_analysis,
+                    budget_evaluation
                         .as_ref()
-                        .expect("budget evaluation exists for ci command")
-                        .has_failures(),
-                    "overallStatus": budget_evaluation
-                        .as_ref()
-                        .expect("budget evaluation exists for ci command")
-                        .overall_status,
-                    "rules": budget_evaluation
-                        .as_ref()
-                        .expect("budget evaluation exists for ci command")
-                        .rules,
-                }))?
+                        .expect("budget evaluation exists for ci command"),
+                ))?
             ),
             _ => println!("{}", serde_json::to_string_pretty(&output_analysis)?),
         }
@@ -232,6 +225,43 @@ fn resolve_baseline_snapshot(parsed: &argv::CliArgs) -> Result<Option<BaselineSn
 fn write_baseline_snapshot(path: &Path, analysis: &legolas_core::Analysis) -> Result<()> {
     let snapshot = BaselineSnapshot::from_analysis(analysis);
     fs::write(path, serde_json::to_string_pretty(&snapshot)?).map_err(Into::into)
+}
+
+fn budget_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEvaluation) -> Value {
+    let mut output = Map::new();
+    output.insert(
+        "overallStatus".to_string(),
+        json!(evaluation.overall_status),
+    );
+    output.insert("rules".to_string(), json!(evaluation.rules));
+
+    if !analysis.workspace_summaries.is_empty() {
+        output.insert(
+            "workspaceSummaries".to_string(),
+            json!(analysis.workspace_summaries),
+        );
+    }
+
+    Value::Object(output)
+}
+
+fn ci_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEvaluation) -> Value {
+    let mut output = Map::new();
+    output.insert("passed".to_string(), json!(!evaluation.has_failures()));
+    output.insert(
+        "overallStatus".to_string(),
+        json!(evaluation.overall_status),
+    );
+    output.insert("rules".to_string(), json!(evaluation.rules));
+
+    if !analysis.workspace_summaries.is_empty() {
+        output.insert(
+            "workspaceSummaries".to_string(),
+            json!(analysis.workspace_summaries),
+        );
+    }
+
+    Value::Object(output)
 }
 
 fn read_package_version() -> Result<String> {

--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -26,6 +26,7 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
         "Scanned {} source files and {} imported packages",
         analysis.source_summary.files_scanned, analysis.source_summary.imported_packages
     ));
+    append_workspace_summaries(&mut lines, analysis);
     lines.push(String::new());
     lines.push(format!(
         "Potential payload reduction: ~{} KB",
@@ -227,6 +228,7 @@ pub fn format_budget_report(analysis: &Analysis, evaluation: &BudgetEvaluation) 
         analysis.package_summary.name
     ));
     append_warnings(&mut lines, &analysis.warnings);
+    append_workspace_summaries(&mut lines, analysis);
     lines.push(String::new());
     lines.push(format!("Overall status: {:?}", evaluation.overall_status));
     lines.push(String::new());
@@ -251,6 +253,7 @@ pub fn format_ci_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> S
 
     lines.push(format!("Legolas CI for {}", analysis.package_summary.name));
     append_warnings(&mut lines, &analysis.warnings);
+    append_workspace_summaries(&mut lines, analysis);
     lines.push(String::new());
     lines.push(format!(
         "Gate result: {}",
@@ -272,6 +275,31 @@ pub fn format_ci_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> S
     ));
 
     lines.join("\n")
+}
+
+fn append_workspace_summaries(lines: &mut Vec<String>, analysis: &Analysis) {
+    if analysis.workspace_summaries.is_empty() {
+        return;
+    }
+
+    lines.push(String::new());
+    lines.push("Workspace summaries:".to_string());
+    append_section(
+        lines,
+        &analysis.workspace_summaries,
+        |item, _| {
+            format!(
+                "- {} ({}): {} imported packages, {} heavy dependencies, {} duplicate packages, ~{} KB potential saved",
+                item.name,
+                item.path,
+                item.imported_packages,
+                item.heavy_dependencies,
+                item.duplicate_packages,
+                item.potential_kb_saved
+            )
+        },
+        "- none",
+    );
 }
 
 #[derive(Clone)]

--- a/crates/legolas-cli/tests/budget_contract.rs
+++ b/crates/legolas-cli/tests/budget_contract.rs
@@ -81,6 +81,27 @@ fn dynamic_import_findings() -> Vec<serde_json::Value> {
     ]
 }
 
+fn workspace_summaries() -> Vec<serde_json::Value> {
+    vec![
+        json!({
+            "name": "admin-app",
+            "path": "apps/admin",
+            "importedPackages": 3,
+            "heavyDependencies": 2,
+            "duplicatePackages": 0,
+            "potentialKbSaved": 42
+        }),
+        json!({
+            "name": "storefront-app",
+            "path": "apps/storefront",
+            "importedPackages": 2,
+            "heavyDependencies": 1,
+            "duplicatePackages": 0,
+            "potentialKbSaved": 13
+        }),
+    ]
+}
+
 #[test]
 fn budget_text_output_uses_built_in_starter_thresholds() {
     let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
@@ -142,6 +163,17 @@ fn budget_json_output_has_a_stable_shape() {
         })
     );
     assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn budget_json_output_includes_workspace_summaries_for_monorepos() {
+    let workspace = support::fixture_path("tests/fixtures/monorepo/pnpm-workspace");
+    let output = run_cli(&["budget", &workspace.display().to_string(), "--json"]);
+
+    assert!(output.status.success());
+    let budget = support::normalize_budget_json_output(&stdout(&output));
+    assert_eq!(budget["workspaceSummaries"], json!(workspace_summaries()));
+    assert_eq!(budget["overallStatus"], json!("Fail"));
 }
 
 #[test]
@@ -274,6 +306,18 @@ fn budget_uses_discovered_config_from_project_root() {
         })
     );
     assert_eq!(stderr(&output), "");
+}
+
+#[test]
+fn budget_text_output_includes_workspace_summaries_for_monorepos() {
+    let workspace = support::fixture_path("tests/fixtures/monorepo/pnpm-workspace");
+    let output = run_cli(&["budget", &workspace.display().to_string()]);
+
+    assert!(output.status.success());
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Workspace summaries:"));
+    assert!(stdout.contains("admin-app (apps/admin): 3 imported packages, 2 heavy dependencies, 0 duplicate packages, ~42 KB potential saved"));
+    assert!(stdout.contains("storefront-app (apps/storefront): 2 imported packages, 1 heavy dependencies, 0 duplicate packages, ~13 KB potential saved"));
 }
 
 #[test]

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -73,6 +73,27 @@ fn dynamic_import_findings() -> Vec<serde_json::Value> {
     ]
 }
 
+fn workspace_summaries() -> Vec<serde_json::Value> {
+    vec![
+        json!({
+            "name": "admin-app",
+            "path": "apps/admin",
+            "importedPackages": 3,
+            "heavyDependencies": 2,
+            "duplicatePackages": 0,
+            "potentialKbSaved": 42
+        }),
+        json!({
+            "name": "storefront-app",
+            "path": "apps/storefront",
+            "importedPackages": 2,
+            "heavyDependencies": 1,
+            "duplicatePackages": 0,
+            "potentialKbSaved": 13
+        }),
+    ]
+}
+
 #[test]
 fn ci_fail_returns_exit_code_one_and_fixed_failure_prefix() {
     let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
@@ -181,6 +202,19 @@ fn ci_json_output_uses_machine_readable_gate_shape() {
 }
 
 #[test]
+fn ci_json_output_includes_workspace_summaries_for_monorepos() {
+    let workspace = support::fixture_path("tests/fixtures/monorepo/pnpm-workspace");
+    let output = run_cli(&["ci", &workspace.display().to_string(), "--json"]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    let ci = support::normalize_ci_json_output(&stdout(&output));
+    assert_eq!(ci["workspaceSummaries"], json!(workspace_summaries()));
+    assert_eq!(ci["overallStatus"], json!("Fail"));
+    assert_eq!(ci["passed"], json!(false));
+}
+
+#[test]
 fn ci_rejects_command_specific_numeric_flags() {
     let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
     let cases = [
@@ -282,6 +316,18 @@ Rule statuses: potentialKbSaved=Fail, duplicatePackageCount=Pass, dynamicImportC
         stderr(&output),
         "CI gate failed: overall status Fail (failing rules: potentialKbSaved, dynamicImportCount)\n"
     );
+}
+
+#[test]
+fn ci_text_output_includes_workspace_summaries_for_monorepos() {
+    let workspace = support::fixture_path("tests/fixtures/monorepo/pnpm-workspace");
+    let output = run_cli(&["ci", &workspace.display().to_string()]);
+
+    assert!(!output.status.success());
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Workspace summaries:"));
+    assert!(stdout.contains("admin-app (apps/admin): 3 imported packages, 2 heavy dependencies, 0 duplicate packages, ~42 KB potential saved"));
+    assert!(stdout.contains("storefront-app (apps/storefront): 2 imported packages, 1 heavy dependencies, 0 duplicate packages, ~13 KB potential saved"));
 }
 
 fn dynamic_import_project(name: &str, dynamic_imports: usize) -> TempDir {

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -107,6 +107,55 @@ fn matches_scan_json_oracle() {
 }
 
 #[test]
+fn monorepo_scan_outputs_workspace_summaries_in_text_and_json() {
+    let fixture = support::fixture_path("tests/fixtures/monorepo/pnpm-workspace");
+
+    let text_output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string()])
+        .output()
+        .expect("run monorepo scan");
+    assert!(text_output.status.success());
+    let text_stdout = String::from_utf8(text_output.stdout).expect("stdout");
+    assert!(text_stdout.contains("Workspace summaries:"));
+    assert!(text_stdout.contains("admin-app (apps/admin): 3 imported packages, 2 heavy dependencies, 0 duplicate packages, ~42 KB potential saved"));
+    assert!(text_stdout.contains("storefront-app (apps/storefront): 2 imported packages, 1 heavy dependencies, 0 duplicate packages, ~13 KB potential saved"));
+    assert_eq!(String::from_utf8(text_output.stderr).expect("stderr"), "");
+
+    let json_output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run monorepo scan --json");
+    assert!(json_output.status.success());
+    let analysis = support::normalize_analysis_json_output(
+        &String::from_utf8(json_output.stdout).expect("stdout"),
+    );
+    assert_eq!(
+        analysis["workspaceSummaries"],
+        json!([
+            {
+                "name": "admin-app",
+                "path": "apps/admin",
+                "importedPackages": 3,
+                "heavyDependencies": 2,
+                "duplicatePackages": 0,
+                "potentialKbSaved": 42
+            },
+            {
+                "name": "storefront-app",
+                "path": "apps/storefront",
+                "importedPackages": 2,
+                "heavyDependencies": 1,
+                "duplicatePackages": 0,
+                "potentialKbSaved": 13
+            }
+        ])
+    );
+    assert_eq!(String::from_utf8(json_output.stderr).expect("stderr"), "");
+}
+
+#[test]
 fn merge_app_scan_json_exposes_additive_artifact_contract() {
     let fixture = support::fixture_path("tests/fixtures/artifacts/merge-app");
     let output = Command::cargo_bin("legolas-cli")


### PR DESCRIPTION
## 배경

- `#44 PR-FIT-013B` 목표대로 monorepo `workspaceSummaries`를 `scan`, `budget`, `ci` 출력에 additive하게 반영했습니다.
- 후속 `#48`, `#46`이 같은 출력 표면을 건드리기 전에 workspace summary 계약을 먼저 고정하는 Wave A lane입니다.

## 변경 사항

- `scan` 텍스트 출력에 `Workspace summaries:` 섹션을 추가했습니다.
- `budget --json`, `ci --json` 응답에 monorepo일 때만 `workspaceSummaries` 필드를 추가했습니다.
- `budget`, `ci` 텍스트 출력에도 workspace summary 요약을 추가했습니다.
- monorepo fixture 기준 `scan`/`budget`/`ci` 계약 테스트를 보강했습니다.

## 검증

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p legolas-cli --test cli_contract`
- `cargo test -p legolas-cli --test budget_contract`
- `cargo test -p legolas-cli --test ci_contract`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- scan tests/fixtures/monorepo/pnpm-workspace --json`
- `cargo run -p legolas-cli -- budget tests/fixtures/monorepo/pnpm-workspace --json`
- `cargo run -p legolas-cli -- ci tests/fixtures/monorepo/pnpm-workspace --json`
- Devil's Advocate review Round 1: no findings

## 브랜치 / 워크트리

- branch: `codex/pr-fit-013b-workspace-summary-output`
- worktree: `/tmp/legolas-pr44`
- base: `master`

## 이슈 연결

- #44
