### PR TITLE
PR-FIT-015A: high-confidence fix hint builder 추가

### DIFF
--- a/crates/legolas-core/src/fix_hints.rs
+++ b/crates/legolas-core/src/fix_hints.rs
@@ -1,0 +1,104 @@
+use crate::{
+    findings::{FindingConfidence, FindingMetadata},
+    models::RecommendedFix,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FixHintKind {
+    DynamicImport,
+    SubpathImport,
+    RouteSplit,
+    DedupeResolution,
+}
+
+impl FixHintKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            FixHintKind::DynamicImport => "dynamic-import",
+            FixHintKind::SubpathImport => "subpath-import",
+            FixHintKind::RouteSplit => "route-split",
+            FixHintKind::DedupeResolution => "dedupe-resolution",
+        }
+    }
+}
+
+pub fn dynamic_import_fix_hint(
+    finding: &FindingMetadata,
+    title: impl Into<String>,
+    target_files: Vec<String>,
+) -> Option<RecommendedFix> {
+    high_confidence_fix_hint(
+        FixHintKind::DynamicImport,
+        finding,
+        title,
+        target_files,
+        None,
+    )
+}
+
+pub fn subpath_import_fix_hint(
+    finding: &FindingMetadata,
+    title: impl Into<String>,
+    target_files: Vec<String>,
+    replacement: Option<String>,
+) -> Option<RecommendedFix> {
+    high_confidence_fix_hint(
+        FixHintKind::SubpathImport,
+        finding,
+        title,
+        target_files,
+        replacement,
+    )
+}
+
+pub fn route_split_fix_hint(
+    finding: &FindingMetadata,
+    title: impl Into<String>,
+    target_files: Vec<String>,
+) -> Option<RecommendedFix> {
+    high_confidence_fix_hint(FixHintKind::RouteSplit, finding, title, target_files, None)
+}
+
+pub fn dedupe_resolution_fix_hint(
+    finding: &FindingMetadata,
+    title: impl Into<String>,
+) -> Option<RecommendedFix> {
+    high_confidence_fix_hint(
+        FixHintKind::DedupeResolution,
+        finding,
+        title,
+        Vec::new(),
+        None,
+    )
+}
+
+pub fn high_confidence_fix_hint(
+    kind: FixHintKind,
+    finding: &FindingMetadata,
+    title: impl Into<String>,
+    target_files: Vec<String>,
+    replacement: Option<String>,
+) -> Option<RecommendedFix> {
+    if finding.confidence != Some(FindingConfidence::High) {
+        return None;
+    }
+
+    let target_files = normalized_files(target_files);
+    if target_files.is_empty() && !matches!(kind, FixHintKind::DedupeResolution) {
+        return None;
+    }
+
+    Some(RecommendedFix {
+        kind: kind.as_str().to_string(),
+        title: title.into(),
+        target_files,
+        replacement,
+    })
+}
+
+fn normalized_files(files: Vec<String>) -> Vec<String> {
+    let mut files = files;
+    files.sort();
+    files.dedup();
+    files
+}

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod confidence;
 pub mod config;
 pub mod error;
 pub mod findings;
+pub mod fix_hints;
 pub mod impact;
 pub mod import_scanner;
 pub mod lockfiles;

--- a/crates/legolas-core/tests/fix_hints.rs
+++ b/crates/legolas-core/tests/fix_hints.rs
@@ -1,0 +1,104 @@
+mod support;
+
+use legolas_core::{
+    fix_hints::{
+        dedupe_resolution_fix_hint, dynamic_import_fix_hint, route_split_fix_hint,
+        subpath_import_fix_hint,
+    },
+    FindingAnalysisSource, FindingConfidence, FindingMetadata,
+};
+
+#[test]
+fn dynamic_import_fix_hint_requires_high_confidence_and_normalizes_target_files() {
+    assert!(
+        support::fixture_path("tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx").exists()
+    );
+    assert!(support::fixture_path("tests/fixtures/fix-hints/subpath-import/src/App.tsx").exists());
+
+    let fix = dynamic_import_fix_hint(
+        &high_confidence_finding("dynamic-import"),
+        "Split the dashboard code path.",
+        vec![
+            "tests/fixtures/fix-hints/subpath-import/src/App.tsx".to_string(),
+            "tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx".to_string(),
+            "tests/fixtures/fix-hints/subpath-import/src/App.tsx".to_string(),
+        ],
+    )
+    .expect("dynamic import fix hint");
+
+    assert_eq!(fix.kind, "dynamic-import");
+    assert_eq!(
+        fix.target_files,
+        vec![
+            "tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx".to_string(),
+            "tests/fixtures/fix-hints/subpath-import/src/App.tsx".to_string(),
+        ]
+    );
+    assert_eq!(fix.replacement, None);
+}
+
+#[test]
+fn subpath_import_fix_hint_preserves_replacement() {
+    let fix = subpath_import_fix_hint(
+        &high_confidence_finding("subpath-import"),
+        "Use package subpath imports.",
+        vec![
+            "tests/fixtures/fix-hints/subpath-import/src/App.tsx".to_string(),
+            "tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx".to_string(),
+            "tests/fixtures/fix-hints/subpath-import/src/App.tsx".to_string(),
+        ],
+        Some("lodash-es".to_string()),
+    )
+    .expect("subpath import fix hint");
+
+    assert_eq!(fix.kind, "subpath-import");
+    assert_eq!(
+        fix.target_files,
+        vec![
+            "tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx".to_string(),
+            "tests/fixtures/fix-hints/subpath-import/src/App.tsx".to_string(),
+        ]
+    );
+    assert_eq!(fix.replacement.as_deref(), Some("lodash-es"));
+}
+
+#[test]
+fn route_split_fix_hint_rejects_non_high_confidence_findings_and_empty_targets() {
+    let low_confidence_fix = route_split_fix_hint(
+        &low_confidence_finding("route-split"),
+        "Split the route bundle.",
+        vec!["tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx".to_string()],
+    );
+
+    let empty_target_fix = route_split_fix_hint(
+        &high_confidence_finding("route-split-empty"),
+        "Split the route bundle.",
+        Vec::new(),
+    );
+
+    assert!(low_confidence_fix.is_none());
+    assert!(empty_target_fix.is_none());
+}
+
+#[test]
+fn dedupe_resolution_fix_hint_allows_empty_target_files() {
+    let fix = dedupe_resolution_fix_hint(
+        &high_confidence_finding("dedupe-resolution"),
+        "Deduplicate lodash to one installed version.",
+    )
+    .expect("dedupe resolution fix hint");
+
+    assert_eq!(fix.kind, "dedupe-resolution");
+    assert!(fix.target_files.is_empty());
+    assert_eq!(fix.replacement, None);
+}
+
+fn high_confidence_finding(finding_id: &str) -> FindingMetadata {
+    FindingMetadata::new(finding_id, FindingAnalysisSource::Heuristic)
+        .with_confidence(FindingConfidence::High)
+}
+
+fn low_confidence_finding(finding_id: &str) -> FindingMetadata {
+    FindingMetadata::new(finding_id, FindingAnalysisSource::Heuristic)
+        .with_confidence(FindingConfidence::Low)
+}

--- a/tests/fixtures/fix-hints/dynamic-import/package.json
+++ b/tests/fixtures/fix-hints/dynamic-import/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fix-hints-dynamic-import",
+  "private": true,
+  "dependencies": {
+    "chart.js": "^4.4.1",
+    "react": "^18.2.0"
+  }
+}

--- a/tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx
+++ b/tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx
@@ -1,0 +1,5 @@
+export async function loadDashboardChart() {
+  const chart = await import("chart.js");
+
+  return chart.Chart;
+}

--- a/tests/fixtures/fix-hints/subpath-import/package.json
+++ b/tests/fixtures/fix-hints/subpath-import/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fix-hints-subpath-import",
+  "private": true,
+  "dependencies": {
+    "@mui/material": "5.15.0",
+    "lodash": "^4.17.21",
+    "react": "^18.2.0"
+  }
+}

--- a/tests/fixtures/fix-hints/subpath-import/src/App.tsx
+++ b/tests/fixtures/fix-hints/subpath-import/src/App.tsx
@@ -1,0 +1,5 @@
+import { debounce } from "lodash";
+
+export function App() {
+  return debounce(() => "ready", 100);
+}


### PR DESCRIPTION
## 배경

- `#50 PR-FIT-015A` 목표대로 high-confidence finding에만 붙는 reusable fix hint builder foundation을 추가했습니다.
- 후속 `#47`에서 adoption을 안전하게 진행할 수 있도록 builder만 먼저 분리한 Wave A lane입니다.

## 변경 사항

- `crates/legolas-core/src/fix_hints.rs`를 추가해 `dynamic-import`, `subpath-import`, `route-split`, `dedupe-resolution` kind를 고정했습니다.
- high confidence가 아니면 `None`을 반환하고, `target_files`는 정렬/중복 제거하도록 했습니다.
- `dedupe-resolution`만 빈 `target_files`를 허용하도록 제한했습니다.
- fixture 기반 `fix_hints` 전용 테스트와 관련 fixture를 추가했습니다.
- 이번 PR에서는 `action_plan`/CLI adoption을 일부러 포함하지 않았습니다.

## 검증

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p legolas-core --test fix_hints`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- optimize tests/fixtures/parity/basic-app`
- Devil's Advocate review Round 1: no findings

## 브랜치 / 워크트리

- branch: `codex/pr-fit-015a-fix-hint-builder`
- worktree: `/tmp/legolas-pr50`
- base: `master`

## 이슈 연결

- #50
