### PR TITLE
feat: RSC server-only leakage detector 추가

### DIFF
--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -1,6 +1,6 @@
 use legolas_core::{
-    budget::BudgetEvaluation, rank_actions, ActionDifficulty, Analysis, FindingConfidence,
-    FindingEvidence, FindingMetadata, RecommendedFix,
+    boundaries::BoundaryWarning, budget::BudgetEvaluation, rank_actions, ActionDifficulty,
+    Analysis, FindingConfidence, FindingEvidence, FindingMetadata, RecommendedFix,
 };
 use std::collections::BTreeMap;
 
@@ -28,6 +28,7 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
     ));
     append_workspace_summaries(&mut lines, analysis);
     lines.push(String::new());
+    append_boundary_warnings(&mut lines, &analysis.boundary_warnings);
     lines.push(format!(
         "Potential payload reduction: ~{} KB",
         analysis.impact.potential_kb_saved
@@ -734,5 +735,79 @@ fn append_warnings(lines: &mut Vec<String>, warnings: &[String]) {
     lines.push("Warnings:".to_string());
     for warning in warnings {
         lines.push(format!("- {warning}"));
+    }
+}
+
+fn append_boundary_warnings(lines: &mut Vec<String>, warnings: &[BoundaryWarning]) {
+    if warnings.is_empty() {
+        return;
+    }
+
+    lines.push("Boundary warnings:".to_string());
+    for warning in warnings {
+        lines.push(format!("- {}", warning.message));
+        lines.push(format!("  recommendation: {}", warning.recommendation));
+        for evidence in display_evidence_lines(&warning.finding) {
+            lines.push(format!("  evidence: {evidence}"));
+        }
+    }
+    lines.push(String::new());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_scan_report;
+    use legolas_core::{
+        boundaries::BoundaryWarning, Analysis, FindingAnalysisSource, FindingConfidence,
+        FindingEvidence, FindingMetadata, Impact, Metadata, PackageSummary, SourceSummary,
+    };
+
+    #[test]
+    fn format_scan_report_renders_boundary_warnings() {
+        let analysis = Analysis {
+            package_summary: PackageSummary {
+                name: "boundary-app".to_string(),
+                ..Default::default()
+            },
+            source_summary: SourceSummary {
+                files_scanned: 1,
+                imported_packages: 1,
+                ..Default::default()
+            },
+            impact: Impact {
+                summary: "summary".to_string(),
+                ..Default::default()
+            },
+            metadata: Metadata {
+                mode: "heuristic".to_string(),
+                generated_at: "2026-04-24T00:00:00Z".to_string(),
+            },
+            boundary_warnings: vec![BoundaryWarning {
+                message: "RSC surface `app/page.tsx` imports the server-only `server-only` module."
+                    .to_string(),
+                recommendation:
+                    "Keep server-only guards in server-only utilities and avoid importing them directly from RSC entrypoints."
+                        .to_string(),
+                finding: FindingMetadata::new(
+                    "boundary:rsc-server-only",
+                    FindingAnalysisSource::SourceImport,
+                )
+                .with_confidence(FindingConfidence::High)
+                .with_action_priority(1)
+                .with_evidence([FindingEvidence::new("source-file")
+                    .with_file("app/page.tsx")
+                    .with_specifier("server-only")
+                    .with_detail("RSC surface imports a server-only module")]),
+            }],
+            ..Default::default()
+        };
+
+        let report = format_scan_report(&analysis);
+
+        assert!(report.contains("Boundary warnings:"));
+        assert!(report
+            .contains("RSC surface `app/page.tsx` imports the server-only `server-only` module."));
+        assert!(report.contains("recommendation: Keep server-only guards in server-only utilities and avoid importing them directly from RSC entrypoints."));
+        assert!(report.contains("evidence: app/page.tsx | specifier: server-only | RSC surface imports a server-only module"));
     }
 }

--- a/crates/legolas-core/src/boundaries.rs
+++ b/crates/legolas-core/src/boundaries.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     findings::{FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata},
     import_scanner::SourceAnalysis,
+    route_context::{classify_route_context, RouteContextKind},
 };
 
 static SERVER_ONLY_PACKAGES: OnceLock<Vec<&'static str>> = OnceLock::new();
@@ -65,6 +66,18 @@ pub fn collect_boundary_warnings(context: &Phase8SeedContext<'_>) -> Vec<Boundar
         }
     }
 
+    for (rsc_file, specifier) in collect_server_only_rsc_imports(
+        context.project_root,
+        context.frameworks,
+        next_client_surface_enabled,
+        context.source_analysis,
+    ) {
+        let key = format!("{rsc_file}:{specifier}:rsc");
+        if seen.insert(key) {
+            warnings.push(build_rsc_boundary_warning(&specifier, &rsc_file));
+        }
+    }
+
     for (client_file, specifier) in
         collect_node_prefix_client_imports(context.project_root, next_client_surface_enabled)
     {
@@ -88,6 +101,24 @@ pub fn collect_boundary_warnings(context: &Phase8SeedContext<'_>) -> Vec<Boundar
     warnings
 }
 
+fn collect_server_only_rsc_imports(
+    project_root: &Path,
+    frameworks: &[String],
+    next_client_surface_enabled: bool,
+    source_analysis: &SourceAnalysis,
+) -> Vec<(String, String)> {
+    let Some(record) = source_analysis.by_package.get("server-only") else {
+        return Vec::new();
+    };
+
+    record
+        .files
+        .iter()
+        .filter(|file| is_rsc_surface(project_root, frameworks, file, next_client_surface_enabled))
+        .map(|file| (file.clone(), String::from("server-only")))
+        .collect()
+}
+
 fn build_boundary_warning(
     package_name: &str,
     raw_specifier: &str,
@@ -109,6 +140,27 @@ fn build_boundary_warning(
             .with_file(client_file)
             .with_specifier(raw_specifier)
             .with_detail("client surface imports a Node-only module")]),
+    }
+}
+
+fn build_rsc_boundary_warning(specifier: &str, rsc_file: &str) -> BoundaryWarning {
+    BoundaryWarning {
+        message: format!(
+            "RSC surface `{rsc_file}` imports the server-only `{specifier}` module."
+        ),
+        recommendation:
+            "Keep server-only guards in server-only utilities and avoid importing them directly from RSC entrypoints."
+                .to_string(),
+        finding: FindingMetadata::new(
+            "boundary:rsc-server-only",
+            FindingAnalysisSource::SourceImport,
+        )
+        .with_confidence(FindingConfidence::High)
+        .with_action_priority(1)
+        .with_evidence([FindingEvidence::new("source-file")
+            .with_file(rsc_file)
+            .with_specifier(specifier)
+            .with_detail("RSC surface imports a server-only module")]),
     }
 }
 
@@ -151,6 +203,24 @@ fn is_client_surface(
     }
 
     next_client_surface_enabled && has_use_client_directive(project_root.join(relative_path))
+}
+
+fn is_rsc_surface(
+    project_root: &Path,
+    frameworks: &[String],
+    relative_path: &str,
+    next_client_surface_enabled: bool,
+) -> bool {
+    if !next_client_surface_enabled || is_client_surface(project_root, relative_path, true) {
+        return false;
+    }
+
+    matches!(
+        classify_route_context(project_root, frameworks, Path::new(relative_path)),
+        RouteContextKind::RoutePage
+            | RouteContextKind::RouteLayout
+            | RouteContextKind::AdminSurface
+    )
 }
 
 fn collect_node_prefix_client_imports(

--- a/crates/legolas-core/tests/boundary_analysis.rs
+++ b/crates/legolas-core/tests/boundary_analysis.rs
@@ -1,8 +1,11 @@
 mod support;
 
+use std::fs;
+
 use legolas_core::{
     analyze_project, FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata,
 };
+use tempfile::tempdir;
 
 #[test]
 fn analyze_project_emits_general_server_client_boundary_warning() {
@@ -66,6 +69,65 @@ fn analyze_project_emits_next_use_client_boundary_warning() {
             .with_specifier("node:fs")
             .with_detail("client surface imports a Node-only module")]),
     );
+}
+
+#[test]
+fn analyze_project_emits_next_rsc_server_only_boundary_warning() {
+    let analysis = analyze_project(support::fixture_path(
+        "tests/fixtures/boundaries/rsc-server-only",
+    ))
+    .expect("analyze rsc boundary fixture");
+
+    assert_eq!(analysis.boundary_warnings.len(), 1);
+
+    let warning = &analysis.boundary_warnings[0];
+    assert_eq!(
+        warning.message,
+        "RSC surface `app/page.tsx` imports the server-only `server-only` module."
+    );
+    assert_eq!(
+        warning.recommendation,
+        "Keep server-only guards in server-only utilities and avoid importing them directly from RSC entrypoints."
+    );
+    assert_finding_metadata(
+        &warning.finding,
+        FindingMetadata::new(
+            "boundary:rsc-server-only",
+            FindingAnalysisSource::SourceImport,
+        )
+        .with_confidence(FindingConfidence::High)
+        .with_action_priority(1)
+        .with_evidence([FindingEvidence::new("source-file")
+            .with_file("app/page.tsx")
+            .with_specifier("server-only")
+            .with_detail("RSC surface imports a server-only module")]),
+    );
+}
+
+#[test]
+fn analyze_project_does_not_emit_next_rsc_server_only_boundary_warning_for_server_utils() {
+    let temp_dir = tempdir().expect("create temp dir");
+    fs::create_dir_all(temp_dir.path().join("app/lib/server")).expect("create app/lib/server");
+    fs::write(
+        temp_dir.path().join("package.json"),
+        r#"{
+  "name": "boundary-rsc-component-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}
+"#,
+    )
+    .expect("write package.json");
+    fs::write(
+        temp_dir.path().join("app/lib/server/db.ts"),
+        "import \"server-only\";\nexport function connect() {\n  return \"ok\";\n}\n",
+    )
+    .expect("write server utility");
+    let analysis = analyze_project(temp_dir.path()).expect("analyze next app server utility");
+
+    assert!(analysis.boundary_warnings.is_empty());
 }
 
 fn assert_finding_metadata(actual: &FindingMetadata, expected: FindingMetadata) {

--- a/tests/fixtures/boundaries/rsc-server-only/app/page.tsx
+++ b/tests/fixtures/boundaries/rsc-server-only/app/page.tsx
@@ -1,0 +1,5 @@
+import "server-only";
+
+export default function Page() {
+  return <main>Server-only RSC boundary</main>;
+}

--- a/tests/fixtures/boundaries/rsc-server-only/package.json
+++ b/tests/fixtures/boundaries/rsc-server-only/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "boundary-rsc-server-only-app",
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0"
+  }
+}


### PR DESCRIPTION
## 배경
- Next.js RSC 경로의 `server-only` import는 dedicated boundary warning 없이 지나가고 있었습니다.
- scan text surface도 boundary warning을 노출하지 않아 triage가 어려웠습니다.

## 변경 사항
- Next app-dir의 RSC surface가 `server-only`를 import하면 `boundary:rsc-server-only` warning을 emit하도록 추가했습니다.
- route entrypoint뿐 아니라 `app/**`의 non-client server component도 잡도록 범위를 넓혔습니다.
- scan text report에 `Boundary warnings:` 섹션과 recommendation/evidence 렌더링을 추가했습니다.
- dedicated fixture와 core regression test를 추가했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p legolas-core --test boundary_analysis`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- scan tests/fixtures/boundaries/rsc-server-only --json`
- `cargo run -p legolas-cli -- scan tests/fixtures/boundaries/rsc-server-only`

## 브랜치 / 워크트리
- branch: `codex/pr-fit-012c-rsc-server-only-leak`
- worktree: `/tmp/legolas-pr48`

## 이슈 연결
- Closes #48
