### PR TITLE
feat: schemaVersion 및 JSON schema 문서 추가

### DIFF
--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -21,6 +21,10 @@ use legolas_core::{
 };
 use serde_json::{json, Map, Value};
 
+const ANALYSIS_SCHEMA_VERSION: &str = "legolas.analysis.v1";
+const BUDGET_SCHEMA_VERSION: &str = "legolas.budget.v1";
+const CI_SCHEMA_VERSION: &str = "legolas.ci.v1";
+
 const HELP_TEXT: &str = r#"Legolas
 Slim bundles with precision.
 
@@ -104,27 +108,22 @@ fn run() -> Result<i32> {
     }
 
     if parsed.json {
-        match command {
-            Command::Budget => println!(
-                "{}",
-                serde_json::to_string_pretty(&budget_json_output(
-                    &output_analysis,
-                    budget_evaluation
-                        .as_ref()
-                        .expect("budget evaluation exists for budget command"),
-                ))?
+        let output = match command {
+            Command::Budget => budget_json_output(
+                &output_analysis,
+                budget_evaluation
+                    .as_ref()
+                    .expect("budget evaluation exists for budget command"),
             ),
-            Command::Ci => println!(
-                "{}",
-                serde_json::to_string_pretty(&ci_json_output(
-                    &output_analysis,
-                    budget_evaluation
-                        .as_ref()
-                        .expect("budget evaluation exists for ci command"),
-                ))?
+            Command::Ci => ci_json_output(
+                &output_analysis,
+                budget_evaluation
+                    .as_ref()
+                    .expect("budget evaluation exists for ci command"),
             ),
-            _ => println!("{}", serde_json::to_string_pretty(&output_analysis)?),
-        }
+            _ => analysis_json_output(&output_analysis)?,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
 
         if matches!(command, Command::Ci)
             && budget_evaluation
@@ -227,8 +226,17 @@ fn write_baseline_snapshot(path: &Path, analysis: &legolas_core::Analysis) -> Re
     fs::write(path, serde_json::to_string_pretty(&snapshot)?).map_err(Into::into)
 }
 
+fn analysis_json_output(analysis: &legolas_core::Analysis) -> Result<Value> {
+    let mut output = Map::new();
+    output.insert("schemaVersion".to_string(), json!(ANALYSIS_SCHEMA_VERSION));
+    output.extend(analysis_value_to_object(analysis)?);
+
+    Ok(Value::Object(output))
+}
+
 fn budget_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEvaluation) -> Value {
     let mut output = Map::new();
+    output.insert("schemaVersion".to_string(), json!(BUDGET_SCHEMA_VERSION));
     output.insert(
         "overallStatus".to_string(),
         json!(evaluation.overall_status),
@@ -247,6 +255,7 @@ fn budget_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEval
 
 fn ci_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEvaluation) -> Value {
     let mut output = Map::new();
+    output.insert("schemaVersion".to_string(), json!(CI_SCHEMA_VERSION));
     output.insert("passed".to_string(), json!(!evaluation.has_failures()));
     output.insert(
         "overallStatus".to_string(),
@@ -262,6 +271,14 @@ fn ci_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEvaluati
     }
 
     Value::Object(output)
+}
+
+fn analysis_value_to_object(analysis: &legolas_core::Analysis) -> Result<Map<String, Value>> {
+    let Value::Object(object) = serde_json::to_value(analysis)? else {
+        unreachable!("serialized JSON output must be an object");
+    };
+
+    Ok(object)
 }
 
 fn read_package_version() -> Result<String> {

--- a/crates/legolas-cli/tests/budget_contract.rs
+++ b/crates/legolas-cli/tests/budget_contract.rs
@@ -133,6 +133,7 @@ fn budget_json_output_has_a_stable_shape() {
     assert_eq!(
         support::normalize_budget_json_output(&stdout(&output)),
         json!({
+            "schemaVersion": "legolas.budget.v1",
             "overallStatus": "Fail",
             "rules": [
                 {
@@ -210,6 +211,7 @@ fn budget_uses_config_threshold_overrides_and_starter_fallbacks_together() {
     assert_eq!(
         support::normalize_budget_json_output(&stdout(&output)),
         json!({
+            "schemaVersion": "legolas.budget.v1",
             "overallStatus": "Fail",
             "rules": [
                 {
@@ -276,6 +278,7 @@ fn budget_uses_discovered_config_from_project_root() {
     assert_eq!(
         support::normalize_budget_json_output(&stdout(&output)),
         json!({
+            "schemaVersion": "legolas.budget.v1",
             "overallStatus": "Fail",
             "rules": [
                 {

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -165,6 +165,7 @@ fn ci_json_output_uses_machine_readable_gate_shape() {
     assert_eq!(
         support::normalize_ci_json_output(&stdout(&output)),
         json!({
+            "schemaVersion": "legolas.ci.v1",
             "passed": false,
             "overallStatus": "Fail",
             "rules": [

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -99,8 +99,15 @@ fn matches_scan_json_oracle() {
         .expect("run scan --json");
 
     assert!(output.status.success());
+    let mut analysis =
+        support::normalize_analysis_json_output(&String::from_utf8(output.stdout).expect("stdout"));
+    assert_eq!(analysis["schemaVersion"], json!("legolas.analysis.v1"));
+    analysis
+        .as_object_mut()
+        .expect("analysis object")
+        .remove("schemaVersion");
     assert_eq!(
-        support::normalize_analysis_json_output(&String::from_utf8(output.stdout).expect("stdout")),
+        analysis,
         support::normalize_analysis_json_output(&support::read_oracle("basic-app/scan.json"))
     );
     assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");

--- a/crates/legolas-cli/tests/json_schema_contract.rs
+++ b/crates/legolas-cli/tests/json_schema_contract.rs
@@ -1,0 +1,185 @@
+mod support;
+
+use assert_cmd::Command;
+use serde_json::{json, Value};
+
+const ANALYSIS_SCHEMA_VERSION: &str = "legolas.analysis.v1";
+const BUDGET_SCHEMA_VERSION: &str = "legolas.budget.v1";
+const CI_SCHEMA_VERSION: &str = "legolas.ci.v1";
+
+#[test]
+fn scan_json_matches_analysis_schema_doc() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run scan --json");
+
+    assert!(output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse scan json");
+    let schema = read_schema("analysis.v1.schema.json");
+
+    assert_eq!(value["schemaVersion"], json!(ANALYSIS_SCHEMA_VERSION));
+    assert_matches_schema(&value, &schema, "$");
+}
+
+#[test]
+fn optimize_json_matches_analysis_schema_doc() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["optimize", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run optimize --json");
+
+    assert!(output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse optimize json");
+    let schema = read_schema("analysis.v1.schema.json");
+
+    assert_eq!(value["schemaVersion"], json!(ANALYSIS_SCHEMA_VERSION));
+    assert_matches_schema(&value, &schema, "$");
+}
+
+#[test]
+fn budget_json_matches_budget_schema_doc() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["budget", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run budget --json");
+
+    assert!(output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse budget json");
+    let schema = read_schema("budget.v1.schema.json");
+
+    assert_eq!(value["schemaVersion"], json!(BUDGET_SCHEMA_VERSION));
+    assert_matches_schema(&value, &schema, "$");
+}
+
+#[test]
+fn ci_json_matches_ci_schema_doc() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["ci", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run ci --json");
+
+    assert!(!output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse ci json");
+    let schema = read_schema("ci.v1.schema.json");
+
+    assert_eq!(value["schemaVersion"], json!(CI_SCHEMA_VERSION));
+    assert_matches_schema(&value, &schema, "$");
+}
+
+fn read_schema(relative_path: &str) -> Value {
+    let schema_path = support::workspace_root()
+        .join("docs")
+        .join("schema")
+        .join(relative_path);
+    let contents = std::fs::read_to_string(&schema_path).expect("read schema");
+
+    serde_json::from_str(&contents).expect("parse schema")
+}
+
+fn assert_matches_schema(value: &Value, schema: &Value, path: &str) {
+    if let Some(expected) = schema.get("const") {
+        assert_eq!(value, expected, "{path}: const mismatch");
+    }
+
+    if let Some(expected) = schema.get("enum").and_then(Value::as_array) {
+        assert!(
+            expected.iter().any(|item| item == value),
+            "{path}: expected one of {expected:?}, got {value:?}"
+        );
+    }
+
+    let Some(expected_type) = schema.get("type").and_then(Value::as_str) else {
+        return;
+    };
+
+    match expected_type {
+        "object" => {
+            let object = value.as_object().unwrap_or_else(|| {
+                panic!("{path}: expected object, got {value:?}");
+            });
+            let schema_object = schema
+                .as_object()
+                .expect("object schema should be an object");
+            let required = schema_object
+                .get("required")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            let properties = schema_object
+                .get("properties")
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            let allow_additional_properties = schema_object
+                .get("additionalProperties")
+                .and_then(Value::as_bool)
+                .unwrap_or(properties.is_empty());
+
+            for required_key in required {
+                let required_key = required_key.as_str().expect("required key string");
+                assert!(
+                    object.contains_key(required_key),
+                    "{path}: missing required key `{required_key}`"
+                );
+            }
+
+            if !allow_additional_properties {
+                for key in object.keys() {
+                    assert!(
+                        properties.contains_key(key),
+                        "{path}: unexpected key `{key}`"
+                    );
+                }
+            }
+
+            for (key, property_schema) in properties {
+                if let Some(property_value) = object.get(&key) {
+                    assert_matches_schema(
+                        property_value,
+                        &property_schema,
+                        &format!("{path}.{key}"),
+                    );
+                }
+            }
+        }
+        "array" => {
+            let items = value.as_array().unwrap_or_else(|| {
+                panic!("{path}: expected array, got {value:?}");
+            });
+            let item_schema = schema.get("items").expect("array schema must define items");
+
+            for (index, item) in items.iter().enumerate() {
+                assert_matches_schema(item, item_schema, &format!("{path}[{index}]"));
+            }
+        }
+        "string" => {
+            assert!(value.is_string(), "{path}: expected string, got {value:?}");
+        }
+        "integer" => {
+            assert!(
+                value.as_i64().is_some() || value.as_u64().is_some(),
+                "{path}: expected integer, got {value:?}"
+            );
+        }
+        "boolean" => {
+            assert!(
+                value.is_boolean(),
+                "{path}: expected boolean, got {value:?}"
+            );
+        }
+        _ => panic!("{path}: unsupported schema type `{expected_type}`"),
+    }
+}

--- a/docs/schema/analysis.v1.schema.json
+++ b/docs/schema/analysis.v1.schema.json
@@ -1,0 +1,728 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/JeremyDev87/legolas/blob/master/docs/schema/analysis.v1.schema.json",
+  "title": "Legolas Analysis JSON v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "projectRoot",
+    "packageManager",
+    "frameworks",
+    "bundleArtifacts",
+    "packageSummary",
+    "sourceSummary",
+    "heavyDependencies",
+    "duplicatePackages",
+    "lazyLoadCandidates",
+    "treeShakingWarnings",
+    "unusedDependencyCandidates",
+    "warnings",
+    "impact",
+    "metadata"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "legolas.analysis.v1"
+    },
+    "projectRoot": {
+      "type": "string"
+    },
+    "packageManager": {
+      "type": "string"
+    },
+    "frameworks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "bundleArtifacts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "artifactSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bundler": {
+          "type": "string"
+        },
+        "entrypoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "chunks": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "modules": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "totalBytes": {
+          "type": "integer"
+        }
+      }
+    },
+    "packageSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "dependencyCount",
+        "devDependencyCount"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "dependencyCount": {
+          "type": "integer"
+        },
+        "devDependencyCount": {
+          "type": "integer"
+        }
+      }
+    },
+    "sourceSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "filesScanned",
+        "importedPackages",
+        "dynamicImports"
+      ],
+      "properties": {
+        "filesScanned": {
+          "type": "integer"
+        },
+        "importedPackages": {
+          "type": "integer"
+        },
+        "dynamicImports": {
+          "type": "integer"
+        }
+      }
+    },
+    "boundaryWarnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "message",
+          "recommendation"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "recommendation": {
+            "type": "string"
+          },
+          "findingId": {
+            "type": "string"
+          },
+          "analysisSource": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "string"
+          },
+          "actionPriority": {
+            "type": "integer"
+          },
+          "recommendedFix": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "title",
+              "targetFiles"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "targetFiles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "replacement": {
+                "type": "string"
+              }
+            }
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "kind"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "file": {
+                  "type": "string"
+                },
+                "specifier": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "workspaceSummaries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "path",
+          "importedPackages",
+          "heavyDependencies",
+          "duplicatePackages",
+          "potentialKbSaved"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "importedPackages": {
+            "type": "integer"
+          },
+          "heavyDependencies": {
+            "type": "integer"
+          },
+          "duplicatePackages": {
+            "type": "integer"
+          },
+          "potentialKbSaved": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "heavyDependencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "versionRange",
+          "estimatedKb",
+          "category",
+          "rationale",
+          "recommendation",
+          "importedBy",
+          "dynamicImportedBy",
+          "importCount"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "versionRange": {
+            "type": "string"
+          },
+          "estimatedKb": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string"
+          },
+          "rationale": {
+            "type": "string"
+          },
+          "recommendation": {
+            "type": "string"
+          },
+          "importedBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dynamicImportedBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "importCount": {
+            "type": "integer"
+          },
+          "findingId": {
+            "type": "string"
+          },
+          "analysisSource": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "string"
+          },
+          "actionPriority": {
+            "type": "integer"
+          },
+          "recommendedFix": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "title",
+              "targetFiles"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "targetFiles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "replacement": {
+                "type": "string"
+              }
+            }
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "kind"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "file": {
+                  "type": "string"
+                },
+                "specifier": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "duplicatePackages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "versions",
+          "count",
+          "estimatedExtraKb"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "versions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "count": {
+            "type": "integer"
+          },
+          "estimatedExtraKb": {
+            "type": "integer"
+          },
+          "origins": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "version",
+                "rootRequester",
+                "viaChain"
+              ],
+              "properties": {
+                "version": {
+                  "type": "string"
+                },
+                "rootRequester": {
+                  "type": "string"
+                },
+                "viaChain": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "findingId": {
+            "type": "string"
+          },
+          "analysisSource": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "string"
+          },
+          "actionPriority": {
+            "type": "integer"
+          },
+          "recommendedFix": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "title",
+              "targetFiles"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "targetFiles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "replacement": {
+                "type": "string"
+              }
+            }
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "kind"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "file": {
+                  "type": "string"
+                },
+                "specifier": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "lazyLoadCandidates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "estimatedSavingsKb",
+          "recommendation",
+          "files",
+          "reason"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "estimatedSavingsKb": {
+            "type": "integer"
+          },
+          "recommendation": {
+            "type": "string"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "reason": {
+            "type": "string"
+          },
+          "findingId": {
+            "type": "string"
+          },
+          "analysisSource": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "string"
+          },
+          "actionPriority": {
+            "type": "integer"
+          },
+          "recommendedFix": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "title",
+              "targetFiles"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "targetFiles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "replacement": {
+                "type": "string"
+              }
+            }
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "kind"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "file": {
+                  "type": "string"
+                },
+                "specifier": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "treeShakingWarnings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "packageName",
+          "message",
+          "recommendation",
+          "estimatedKb",
+          "files"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "packageName": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "recommendation": {
+            "type": "string"
+          },
+          "estimatedKb": {
+            "type": "integer"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "findingId": {
+            "type": "string"
+          },
+          "analysisSource": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "string"
+          },
+          "actionPriority": {
+            "type": "integer"
+          },
+          "recommendedFix": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "title",
+              "targetFiles"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "targetFiles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "replacement": {
+                "type": "string"
+              }
+            }
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "kind"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "file": {
+                  "type": "string"
+                },
+                "specifier": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "unusedDependencyCandidates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "versionRange"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "versionRange": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "potentialKbSaved",
+        "estimatedLcpImprovementMs",
+        "confidence",
+        "summary"
+      ],
+      "properties": {
+        "potentialKbSaved": {
+          "type": "integer"
+        },
+        "estimatedLcpImprovementMs": {
+          "type": "integer"
+        },
+        "confidence": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "generatedAt"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "generatedAt": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/schema/budget.v1.schema.json
+++ b/docs/schema/budget.v1.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/JeremyDev87/legolas/blob/master/docs/schema/budget.v1.schema.json",
+  "title": "Legolas Budget JSON v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "overallStatus",
+    "rules"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "legolas.budget.v1"
+    },
+    "overallStatus": {
+      "type": "string",
+      "enum": [
+        "Pass",
+        "Warn",
+        "Fail"
+      ]
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "actual",
+          "warnAt",
+          "failAt",
+          "status",
+          "triggeredFindings"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "actual": {
+            "type": "integer"
+          },
+          "warnAt": {
+            "type": "integer"
+          },
+          "failAt": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Pass",
+              "Warn",
+              "Fail"
+            ]
+          },
+          "triggeredFindings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "findingId",
+                "analysisSource",
+                "confidence"
+              ],
+              "properties": {
+                "findingId": {
+                  "type": "string"
+                },
+                "analysisSource": {
+                  "type": "string"
+                },
+                "confidence": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "workspaceSummaries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "path",
+          "importedPackages",
+          "heavyDependencies",
+          "duplicatePackages",
+          "potentialKbSaved"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "importedPackages": {
+            "type": "integer"
+          },
+          "heavyDependencies": {
+            "type": "integer"
+          },
+          "duplicatePackages": {
+            "type": "integer"
+          },
+          "potentialKbSaved": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/schema/ci.v1.schema.json
+++ b/docs/schema/ci.v1.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/JeremyDev87/legolas/blob/master/docs/schema/ci.v1.schema.json",
+  "title": "Legolas CI JSON v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "passed",
+    "overallStatus",
+    "rules"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "legolas.ci.v1"
+    },
+    "passed": {
+      "type": "boolean"
+    },
+    "overallStatus": {
+      "type": "string",
+      "enum": [
+        "Pass",
+        "Warn",
+        "Fail"
+      ]
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "actual",
+          "warnAt",
+          "failAt",
+          "status",
+          "triggeredFindings"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "actual": {
+            "type": "integer"
+          },
+          "warnAt": {
+            "type": "integer"
+          },
+          "failAt": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Pass",
+              "Warn",
+              "Fail"
+            ]
+          },
+          "triggeredFindings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "findingId",
+                "analysisSource",
+                "confidence"
+              ],
+              "properties": {
+                "findingId": {
+                  "type": "string"
+                },
+                "analysisSource": {
+                  "type": "string"
+                },
+                "confidence": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "workspaceSummaries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "path",
+          "importedPackages",
+          "heavyDependencies",
+          "duplicatePackages",
+          "potentialKbSaved"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "importedPackages": {
+            "type": "integer"
+          },
+          "heavyDependencies": {
+            "type": "integer"
+          },
+          "duplicatePackages": {
+            "type": "integer"
+          },
+          "potentialKbSaved": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "files": [
     "bin",
+    "docs/schema",
     "vendor"
   ],
   "os": [

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -6,7 +6,7 @@ const projectRoot = fileURLToPath(new URL("..", import.meta.url));
 
 const rootAllowlist = new Set(["LICENSE", "package.json"]);
 const rootReadmePattern = /^README(\.[^.]+)?\.md$/i;
-const packageDirs = ["bin", "vendor"];
+const packageDirs = ["bin", "docs/schema", "vendor"];
 const vendorReadmePath = "vendor/README.md";
 const vendorBinaryPattern = /^vendor\/[^/]+\/legolas(?:\.exe)?$/;
 


### PR DESCRIPTION
## 배경
- machine consumer가 JSON payload version을 top-level에서 식별할 수 있는 contract가 없었습니다.
- analysis/ci schema 문서도 unknown key drift를 충분히 막지 못했습니다.

## 변경 사항
- `scan`/`optimize` JSON output에 `legolas.analysis.v1` schemaVersion을 추가했습니다.
- `budget`/`ci` JSON output에 각각 `legolas.budget.v1`, `legolas.ci.v1` schemaVersion을 추가했습니다.
- `docs/schema/analysis.v1.schema.json`, `docs/schema/ci.v1.schema.json`을 추가하고 object-level unknown key를 거부하도록 고정했습니다.
- `json_schema_contract`를 추가하고 기존 CLI/budget/ci contract를 schemaVersion까지 검증하도록 보강했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p legolas-cli --test json_schema_contract`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app --json`
- `cargo run -p legolas-cli -- ci tests/fixtures/parity/basic-app --json` (`CI gate failed...` stderr와 함께 exit 1 expected)

## 브랜치 / 워크트리
- branch: `codex/pr-fit-014a-schema-version`
- worktree: `/tmp/legolas-pr46`

## 이슈 연결
- Closes #46
