### PR TITLE
fix: fix hint builder 공개 계약 회귀 수정

### DIFF
--- a/crates/legolas-core/src/fix_hints.rs
+++ b/crates/legolas-core/src/fix_hints.rs
@@ -14,10 +14,10 @@ pub enum FixHintKind {
 impl FixHintKind {
     fn as_str(self) -> &'static str {
         match self {
-            FixHintKind::DynamicImport => "dynamic-import",
-            FixHintKind::SubpathImport => "subpath-import",
-            FixHintKind::RouteSplit => "route-split",
-            FixHintKind::DedupeResolution => "dedupe-resolution",
+            FixHintKind::DynamicImport => "lazy-load",
+            FixHintKind::SubpathImport => "narrow-import",
+            FixHintKind::RouteSplit => "split-route",
+            FixHintKind::DedupeResolution => "dedupe-package",
         }
     }
 }
@@ -97,7 +97,11 @@ pub fn high_confidence_fix_hint(
 }
 
 fn normalized_files(files: Vec<String>) -> Vec<String> {
-    let mut files = files;
+    let mut files = files
+        .into_iter()
+        .map(|file| file.trim().to_string())
+        .filter(|file| !file.is_empty())
+        .collect::<Vec<_>>();
     files.sort();
     files.dedup();
     files

--- a/crates/legolas-core/tests/action_plan.rs
+++ b/crates/legolas-core/tests/action_plan.rs
@@ -317,7 +317,7 @@ fn finding_metadata_serializes_action_priority_and_recommended_fix_additively() 
     .with_confidence(FindingConfidence::High)
     .with_action_priority(1)
     .with_recommended_fix(RecommendedFix {
-        kind: "replace-package".to_string(),
+        kind: "narrow-import".to_string(),
         title: "Use per-method imports.".to_string(),
         target_files: vec!["src/App.tsx".to_string()],
         replacement: Some("lodash-es".to_string()),
@@ -333,7 +333,7 @@ fn finding_metadata_serializes_action_priority_and_recommended_fix_additively() 
             "confidence": "high",
             "actionPriority": 1,
             "recommendedFix": {
-                "kind": "replace-package",
+                "kind": "narrow-import",
                 "title": "Use per-method imports.",
                 "targetFiles": ["src/App.tsx"],
                 "replacement": "lodash-es"

--- a/crates/legolas-core/tests/fix_hints.rs
+++ b/crates/legolas-core/tests/fix_hints.rs
@@ -26,7 +26,7 @@ fn dynamic_import_fix_hint_requires_high_confidence_and_normalizes_target_files(
     )
     .expect("dynamic import fix hint");
 
-    assert_eq!(fix.kind, "dynamic-import");
+    assert_eq!(fix.kind, "lazy-load");
     assert_eq!(
         fix.target_files,
         vec![
@@ -51,7 +51,7 @@ fn subpath_import_fix_hint_preserves_replacement() {
     )
     .expect("subpath import fix hint");
 
-    assert_eq!(fix.kind, "subpath-import");
+    assert_eq!(fix.kind, "narrow-import");
     assert_eq!(
         fix.target_files,
         vec![
@@ -81,6 +81,32 @@ fn route_split_fix_hint_rejects_non_high_confidence_findings_and_empty_targets()
 }
 
 #[test]
+fn route_split_fix_hint_discards_blank_targets_before_validation() {
+    let blank_only_fix = route_split_fix_hint(
+        &high_confidence_finding("route-split-blank-only"),
+        "Split the route bundle.",
+        vec![String::new(), "   ".to_string()],
+    );
+
+    let mixed_fix = route_split_fix_hint(
+        &high_confidence_finding("route-split-mixed"),
+        "Split the route bundle.",
+        vec![
+            "  tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx  ".to_string(),
+            String::new(),
+            "tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx".to_string(),
+        ],
+    )
+    .expect("route split fix hint");
+
+    assert!(blank_only_fix.is_none());
+    assert_eq!(
+        mixed_fix.target_files,
+        vec!["tests/fixtures/fix-hints/dynamic-import/src/Dashboard.tsx".to_string()]
+    );
+}
+
+#[test]
 fn dedupe_resolution_fix_hint_allows_empty_target_files() {
     let fix = dedupe_resolution_fix_hint(
         &high_confidence_finding("dedupe-resolution"),
@@ -88,7 +114,7 @@ fn dedupe_resolution_fix_hint_allows_empty_target_files() {
     )
     .expect("dedupe resolution fix hint");
 
-    assert_eq!(fix.kind, "dedupe-resolution");
+    assert_eq!(fix.kind, "dedupe-package");
     assert!(fix.target_files.is_empty());
     assert_eq!(fix.replacement, None);
 }


### PR DESCRIPTION
## 배경
- merge된 PR #55 이후 `fix_hints` helper의 공개 `recommendedFix.kind` 값이 기존 optimize/scan 계약과 어긋난 상태였습니다.
- blank target path가 정규화 없이 helper를 통과할 수 있어서 후속 caller가 잘못된 `targetFiles`를 내보낼 여지도 있었습니다.

## 변경 사항
- `fix_hints` helper가 legacy 공개 kind 값(`lazy-load`, `narrow-import`, `split-route`, `dedupe-package`)을 유지하도록 수정했습니다.
- `targetFiles` 정규화 단계에서 blank/padded path를 trim/drop 하도록 보강했습니다.
- `action_plan` 직렬화 테스트와 `fix_hints` 테스트를 현재 공개 계약에 맞게 갱신했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p legolas-core --test action_plan --test fix_hints`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- optimize tests/fixtures/parity/basic-app`
- `cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app --json`

## 브랜치 / 워크트리
- publish branch: `codex/fix-fix-hint-wire-contract`
- publish worktree: `/tmp/legolas-pr50-fix-contract.B8pphs`
- source worktree: `/Users/pjw/workspace/legolas` (mixed root checkout에서 scoped delta만 이관)

## 이슈 연결
- Related: #50
- Follow-up for merged PR #55
