### PR TITLE
PR-FIT-014C: regression-focused CI JSON envelope 추가

### DIFF
--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -120,6 +120,7 @@ fn run() -> Result<i32> {
                 budget_evaluation
                     .as_ref()
                     .expect("budget evaluation exists for ci command"),
+                regression_diff.as_ref(),
             ),
             _ => analysis_json_output(&output_analysis)?,
         };
@@ -253,7 +254,11 @@ fn budget_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEval
     Value::Object(output)
 }
 
-fn ci_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEvaluation) -> Value {
+fn ci_json_output(
+    analysis: &legolas_core::Analysis,
+    evaluation: &BudgetEvaluation,
+    regression_diff: Option<&legolas_core::BaselineDiff>,
+) -> Value {
     let mut output = Map::new();
     output.insert("schemaVersion".to_string(), json!(CI_SCHEMA_VERSION));
     output.insert("passed".to_string(), json!(!evaluation.has_failures()));
@@ -267,6 +272,16 @@ fn ci_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEvaluati
         output.insert(
             "workspaceSummaries".to_string(),
             json!(analysis.workspace_summaries),
+        );
+    }
+
+    if let Some(diff) = regression_diff {
+        output.insert(
+            "regression".to_string(),
+            json!({
+                "mode": "regression-only",
+                "baselineDiff": diff,
+            }),
         );
     }
 

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -3,6 +3,7 @@ mod support;
 use std::{fs, path::Path};
 
 use assert_cmd::Command;
+use legolas_core::{analyze_project, diff_analysis, BaselineSnapshot};
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -92,6 +93,17 @@ fn workspace_summaries() -> Vec<serde_json::Value> {
             "potentialKbSaved": 13
         }),
     ]
+}
+
+fn regression_baseline_diff() -> serde_json::Value {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let baseline_path = support::fixture_path("tests/fixtures/baseline/previous-scan.json");
+    let baseline: BaselineSnapshot =
+        serde_json::from_str(&fs::read_to_string(baseline_path).expect("read baseline fixture"))
+            .expect("parse baseline fixture");
+    let analysis = analyze_project(&current_app).expect("analyze current regression fixture");
+
+    serde_json::to_value(diff_analysis(&baseline, &analysis)).expect("serialize baseline diff")
 }
 
 #[test]
@@ -199,6 +211,34 @@ fn ci_json_output_uses_machine_readable_gate_shape() {
     assert_eq!(
         stderr(&output),
         "CI gate failed: overall status Fail (failing rules: potentialKbSaved, dynamicImportCount)\n"
+    );
+}
+
+#[test]
+fn regression_only_ci_json_includes_regression_envelope() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let baseline_path = support::fixture_path("tests/fixtures/baseline/previous-scan.json");
+    let output = run_cli(&[
+        "ci",
+        &current_app.display().to_string(),
+        "--baseline",
+        &baseline_path.display().to_string(),
+        "--regression-only",
+        "--json",
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let ci = support::normalize_ci_json_output(&stdout(&output));
+    assert_eq!(ci["passed"], json!(true));
+    assert_eq!(ci["overallStatus"], json!("Warn"));
+    assert_eq!(
+        ci["regression"],
+        json!({
+            "mode": "regression-only",
+            "baselineDiff": regression_baseline_diff()
+        })
     );
 }
 

--- a/crates/legolas-cli/tests/json_schema_contract.rs
+++ b/crates/legolas-cli/tests/json_schema_contract.rs
@@ -79,6 +79,32 @@ fn ci_json_matches_ci_schema_doc() {
     assert_matches_schema(&value, &schema, "$");
 }
 
+#[test]
+fn regression_only_ci_json_matches_ci_schema_doc() {
+    let fixture = support::fixture_path("tests/fixtures/baseline/current-app");
+    let baseline = support::fixture_path("tests/fixtures/baseline/previous-scan.json");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args([
+            "ci",
+            &fixture.display().to_string(),
+            "--baseline",
+            &baseline.display().to_string(),
+            "--regression-only",
+            "--json",
+        ])
+        .output()
+        .expect("run regression ci --json");
+
+    assert!(output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse regression ci json");
+    let schema = read_schema("ci.v1.schema.json");
+
+    assert_eq!(value["schemaVersion"], json!(CI_SCHEMA_VERSION));
+    assert_matches_schema(&value, &schema, "$");
+}
+
 fn read_schema(relative_path: &str) -> Value {
     let schema_path = support::workspace_root()
         .join("docs")

--- a/docs/schema/ci.v1.schema.json
+++ b/docs/schema/ci.v1.schema.json
@@ -86,6 +86,197 @@
         }
       }
     },
+    "regression": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "baselineDiff"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "const": "regression-only"
+        },
+        "baselineDiff": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "schemaVersion",
+            "projectNamePrevious",
+            "projectNameCurrent",
+            "packageManagerPrevious",
+            "packageManagerCurrent",
+            "dependencyCountPrevious",
+            "dependencyCountCurrent",
+            "devDependencyCountPrevious",
+            "devDependencyCountCurrent",
+            "sourceFileCountPrevious",
+            "sourceFileCountCurrent",
+            "dynamicImportCountPrevious",
+            "dynamicImportCountCurrent",
+            "potentialKbSavedPrevious",
+            "potentialKbSavedCurrent"
+          ],
+          "properties": {
+            "schemaVersion": {
+              "type": "integer",
+              "const": 5
+            },
+            "projectNamePrevious": {
+              "type": "string"
+            },
+            "projectNameCurrent": {
+              "type": "string"
+            },
+            "packageManagerPrevious": {
+              "type": "string"
+            },
+            "packageManagerCurrent": {
+              "type": "string"
+            },
+            "dependencyCountPrevious": {
+              "type": "integer"
+            },
+            "dependencyCountCurrent": {
+              "type": "integer"
+            },
+            "devDependencyCountPrevious": {
+              "type": "integer"
+            },
+            "devDependencyCountCurrent": {
+              "type": "integer"
+            },
+            "sourceFileCountPrevious": {
+              "type": "integer"
+            },
+            "sourceFileCountCurrent": {
+              "type": "integer"
+            },
+            "dynamicImportCountPrevious": {
+              "type": "integer"
+            },
+            "dynamicImportCountCurrent": {
+              "type": "integer"
+            },
+            "potentialKbSavedPrevious": {
+              "type": "integer"
+            },
+            "potentialKbSavedCurrent": {
+              "type": "integer"
+            },
+            "addedHeavyDependencyNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "removedHeavyDependencyNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "worsenedHeavyDependencyNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "addedTreeShakingWarningKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "removedTreeShakingWarningKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "worsenedTreeShakingWarningKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "addedDuplicatePackageKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "removedDuplicatePackageKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "worsenedDuplicatePackageKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "addedLazyLoadCandidateKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "removedLazyLoadCandidateKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "worsenedLazyLoadCandidateKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "addedBoundaryWarningKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "removedBoundaryWarningKeys": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "addedUnusedDependencyCandidateNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "removedUnusedDependencyCandidateNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "addedWarnings": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "removedWarnings": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "workspaceSummaries": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## 배경

- [#45](https://github.com/JeremyDev87/legolas/issues/45) 는 baseline regression 결과를 machine-readable consumer가 바로 읽을 수 있게 `ci --json`에 regression-focused envelope를 추가하는 작업입니다.
- 기존 `ci --json`은 regression-only mode에서도 top-level rule status만 노출해서 baseline diff를 별도 계산 없이 소비하기 어려웠습니다.

## 변경 사항

- `ci --json --baseline ... --regression-only`일 때만 additive `regression` envelope를 추가했습니다.
- `regression.mode`에 `regression-only`를 고정하고, `regression.baselineDiff`에 baseline diff를 그대로 노출합니다.
- normal `ci --json` shape는 유지했습니다.
- `ci_contract`와 `json_schema_contract`에 regression-only envelope 계약을 추가했습니다.
- `docs/schema/ci.v1.schema.json`를 새 optional `regression` object에 맞춰 확장했습니다.

## 검증

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p legolas-cli --test ci_contract`
- `cargo test -p legolas-cli --test json_schema_contract regression_only_ci_json_matches_ci_schema_doc -- --exact`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- ci tests/fixtures/baseline/current-app --baseline tests/fixtures/baseline/previous-scan.json --regression-only --json`
- `npm pack --dry-run --json --cache ./.npm-cache`
- `git diff --check`

## 리뷰 루프

- fresh-session Devil's Advocate review 1회 수행
- 결과: meaningful finding 없음
- 판단: `Critical 0 / High 0`, `review_loop_passed`

## 브랜치 / 워크트리

- branch: `codex/pr-fit-014c-ci-regression-envelope`
- worktree: `/tmp/legolas-pr45`
- base: `master`

## 이슈 연결

- closes #45
