### PR TITLE
PR-FIT-015B: optimize/JSON finding에 safe fix hint 반영

### DIFF
--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -114,6 +114,42 @@ fn matches_scan_json_oracle() {
 }
 
 #[test]
+fn scan_json_only_exposes_recommended_fix_for_safe_high_confidence_findings() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run scan --json");
+
+    assert!(output.status.success());
+    let analysis =
+        support::normalize_analysis_json_output(&String::from_utf8(output.stdout).expect("stdout"));
+
+    assert_eq!(
+        analysis["heavyDependencies"][0]["recommendedFix"]["kind"],
+        json!("lazy-load")
+    );
+    assert_eq!(
+        analysis["lazyLoadCandidates"][0].get("recommendedFix"),
+        None
+    );
+    assert_eq!(
+        analysis["lazyLoadCandidates"][1].get("recommendedFix"),
+        None
+    );
+    assert_eq!(
+        analysis["lazyLoadCandidates"][2].get("recommendedFix"),
+        None
+    );
+    assert_eq!(
+        analysis["duplicatePackages"][0]["recommendedFix"]["kind"],
+        json!("dedupe-package")
+    );
+    assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
+}
+
+#[test]
 fn monorepo_scan_outputs_workspace_summaries_in_text_and_json() {
     let fixture = support::fixture_path("tests/fixtures/monorepo/pnpm-workspace");
 

--- a/crates/legolas-cli/tests/optimize_action_ranking.rs
+++ b/crates/legolas-cli/tests/optimize_action_ranking.rs
@@ -16,3 +16,22 @@ fn optimize_report_matches_ranked_action_oracle() {
         support::read_oracle("basic-app/optimize-ranked.txt")
     );
 }
+
+#[test]
+fn optimize_report_only_renders_safe_fix_hints_for_high_confidence_actions() {
+    let analysis = load_analysis();
+    let report = format_optimize_report(&analysis, 5);
+
+    assert!(report.contains(
+        "1. Review chart.js upfront bundle weight [hard | high confidence | ~160 KB]\n   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces."
+    ));
+    assert!(report.contains(
+        "4. Review lodash upfront bundle weight [hard | high confidence | ~72 KB]\n   recommended fix: narrow-import - Use per-method imports or switch to lodash-es when the toolchain supports it."
+    ));
+    assert!(!report.contains(
+        "2. Lazy load chart.js [medium | low confidence | ~120 KB]\n   recommended fix:"
+    ));
+    assert!(!report.contains(
+        "5. Lazy load react-icons [medium | low confidence | ~68 KB]\n   recommended fix:"
+    ));
+}

--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -59,6 +59,9 @@ fn scan_and_optimize_reports_render_compact_evidence_lines() {
     assert!(optimize.contains(
         "4. Review lodash upfront bundle weight [hard | high confidence | ~72 KB]\n   recommended fix: narrow-import - Use per-method imports or switch to lodash-es when the toolchain supports it.\n   targets: src/Dashboard.tsx\n   replacement: lodash-es\n   evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses."
     ));
+    assert!(!optimize.contains(
+        "2. Lazy load chart.js [medium | low confidence | ~120 KB]\n   recommended fix:"
+    ));
 }
 
 #[test]
@@ -98,9 +101,10 @@ fn scan_and_optimize_reports_only_render_the_first_evidence_line_per_finding() {
     let optimize = format_optimize_report(&analysis, 1);
     assert!(
         optimize.contains(
-            "1. Review chart.js upfront bundle weight [hard | low confidence | ~160 KB]\n   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.\n   targets: src/Admin.tsx, src/Reports.tsx\n   evidence: src/Admin.tsx | specifier: chart.js | first evidence detail"
+            "1. Review chart.js upfront bundle weight [hard | low confidence | ~160 KB]\n   evidence: src/Admin.tsx | specifier: chart.js | first evidence detail"
         )
     );
+    assert!(!optimize.contains("recommended fix:"));
     assert!(!optimize.contains("second evidence detail"));
 }
 

--- a/crates/legolas-core/src/action_plan.rs
+++ b/crates/legolas-core/src/action_plan.rs
@@ -2,7 +2,14 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
     findings::{FindingConfidence, FindingMetadata},
-    models::{ActionDifficulty, ActionPlanItem, Analysis, RecommendedFix},
+    fix_hints::{
+        dedupe_resolution_fix_hint, dynamic_import_fix_hint, route_split_fix_hint,
+        subpath_import_fix_hint,
+    },
+    models::{
+        ActionDifficulty, ActionPlanItem, Analysis, DuplicatePackage, HeavyDependency,
+        LazyLoadCandidate, RecommendedFix, TreeShakingWarning,
+    },
 };
 
 pub fn rank_actions(analysis: &Analysis) -> Vec<ActionPlanItem> {
@@ -14,12 +21,7 @@ pub fn rank_actions(analysis: &Analysis) -> Vec<ActionPlanItem> {
             &item.finding,
             item.estimated_kb,
             ActionDifficulty::Hard,
-            Some(recommended_fix(
-                recommended_fix_kind(&item.name, &item.recommendation),
-                item.recommendation.clone(),
-                item.imported_by.clone(),
-                &item.name,
-            )),
+            heavy_dependency_fix(item),
         );
     }
 
@@ -29,12 +31,7 @@ pub fn rank_actions(analysis: &Analysis) -> Vec<ActionPlanItem> {
             &item.finding,
             item.estimated_savings_kb,
             ActionDifficulty::Medium,
-            Some(recommended_fix(
-                "lazy-load",
-                item.recommendation.clone(),
-                item.files.clone(),
-                &item.name,
-            )),
+            lazy_load_fix(item),
         );
     }
 
@@ -44,12 +41,7 @@ pub fn rank_actions(analysis: &Analysis) -> Vec<ActionPlanItem> {
             &item.finding,
             item.estimated_kb,
             ActionDifficulty::Easy,
-            Some(recommended_fix(
-                "narrow-import",
-                item.recommendation.clone(),
-                item.files.clone(),
-                &item.package_name,
-            )),
+            tree_shaking_fix(item),
         );
     }
 
@@ -59,12 +51,7 @@ pub fn rank_actions(analysis: &Analysis) -> Vec<ActionPlanItem> {
             &item.finding,
             item.estimated_extra_kb,
             ActionDifficulty::Medium,
-            Some(RecommendedFix {
-                kind: "dedupe-package".to_string(),
-                title: format!("Deduplicate {} to one installed version.", item.name),
-                target_files: Vec::new(),
-                replacement: None,
-            }),
+            duplicate_package_fix(item),
         );
     }
 
@@ -134,27 +121,6 @@ fn push_action(
     });
 }
 
-fn recommended_fix(
-    kind: &str,
-    title: String,
-    target_files: Vec<String>,
-    package_name: &str,
-) -> RecommendedFix {
-    RecommendedFix {
-        kind: kind.to_string(),
-        title,
-        target_files: normalized_files(target_files),
-        replacement: replacement_candidate(kind, package_name),
-    }
-}
-
-fn normalized_files(files: Vec<String>) -> Vec<String> {
-    let mut files = files;
-    files.sort();
-    files.dedup();
-    files
-}
-
 fn apply_action_metadata(
     finding: &mut FindingMetadata,
     action_by_id: &BTreeMap<String, ActionPlanItem>,
@@ -174,39 +140,95 @@ fn apply_action_metadata(
     finding.recommended_fix = action.recommended_fix.clone();
 }
 
-fn recommended_fix_kind(package_name: &str, recommendation: &str) -> &'static str {
+fn heavy_dependency_fix(item: &HeavyDependency) -> Option<RecommendedFix> {
+    match supported_heavy_dependency_fix_kind(&item.name, &item.recommendation) {
+        Some(SupportedFixHintKind::DynamicImport) => dynamic_import_fix_hint(
+            &item.finding,
+            item.recommendation.clone(),
+            item.imported_by.clone(),
+        ),
+        Some(SupportedFixHintKind::SubpathImport) => subpath_import_fix_hint(
+            &item.finding,
+            item.recommendation.clone(),
+            item.imported_by.clone(),
+            replacement_candidate("narrow-import", &item.name),
+        ),
+        Some(SupportedFixHintKind::RouteSplit) => route_split_fix_hint(
+            &item.finding,
+            item.recommendation.clone(),
+            item.imported_by.clone(),
+        ),
+        None => None,
+    }
+}
+
+fn lazy_load_fix(item: &LazyLoadCandidate) -> Option<RecommendedFix> {
+    dynamic_import_fix_hint(
+        &item.finding,
+        item.recommendation.clone(),
+        item.files.clone(),
+    )
+}
+
+fn tree_shaking_fix(item: &TreeShakingWarning) -> Option<RecommendedFix> {
+    subpath_import_fix_hint(
+        &item.finding,
+        item.recommendation.clone(),
+        item.files.clone(),
+        replacement_candidate("narrow-import", &item.package_name),
+    )
+}
+
+fn duplicate_package_fix(item: &DuplicatePackage) -> Option<RecommendedFix> {
+    dedupe_resolution_fix_hint(
+        &item.finding,
+        format!("Deduplicate {} to one installed version.", item.name),
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupportedFixHintKind {
+    DynamicImport,
+    SubpathImport,
+    RouteSplit,
+}
+
+fn supported_heavy_dependency_fix_kind(
+    package_name: &str,
+    recommendation: &str,
+) -> Option<SupportedFixHintKind> {
     let normalized = recommendation.to_ascii_lowercase();
 
     if package_name == "moment" {
-        return "replace-package";
+        return None;
     }
 
     if normalized.contains("server boundar") {
-        return "move-boundary";
+        return None;
     }
 
     if normalized.contains("lazy load")
         || normalized.contains("on demand")
         || normalized.contains("defer")
     {
-        return "lazy-load";
+        return Some(SupportedFixHintKind::DynamicImport);
     }
 
     if normalized.contains("route")
         || normalized.contains("split ")
         || normalized.contains("split-")
     {
-        return "split-route";
+        return Some(SupportedFixHintKind::RouteSplit);
     }
 
     if normalized.contains("import")
         || normalized.contains("modular")
         || normalized.contains("register only")
     {
-        return "narrow-import";
+        return Some(SupportedFixHintKind::SubpathImport);
     }
 
-    "reduce-usage"
+    None
 }
 
 fn replacement_candidate(kind: &str, package_name: &str) -> Option<String> {

--- a/crates/legolas-core/tests/action_plan.rs
+++ b/crates/legolas-core/tests/action_plan.rs
@@ -232,17 +232,7 @@ fn rank_actions_maps_fix_kind_and_replacement_from_recommendation_shape() {
         .iter()
         .find(|item| item.finding_id == "heavy-dependency:moment")
         .expect("moment action");
-    assert_eq!(
-        moment.recommended_fix.as_ref().map(|fix| fix.kind.as_str()),
-        Some("replace-package")
-    );
-    assert_eq!(
-        moment
-            .recommended_fix
-            .as_ref()
-            .and_then(|fix| fix.replacement.as_deref()),
-        Some("date-fns or Day.js")
-    );
+    assert_eq!(moment.recommended_fix, None);
 }
 
 #[test]
@@ -270,6 +260,52 @@ fn rank_actions_dedupes_by_finding_id_not_recommended_fix_text() {
     assert_eq!(actions.len(), 1);
     assert_eq!(actions[0].finding_id, "tree-shaking:lodash-root-import");
     assert_eq!(actions[0].estimated_savings_kb, 26);
+}
+
+#[test]
+fn apply_action_plan_only_exposes_safe_fix_hints_for_high_confidence_findings() {
+    let mut analysis = Analysis {
+        heavy_dependencies: vec![heavy_dependency_with_recommendation(
+            "heavy-dependency:chart.js",
+            "chart.js",
+            160,
+            FindingConfidence::Low,
+            "Register only the chart primitives you use and lazy load dashboard surfaces.",
+        )],
+        lazy_load_candidates: vec![lazy_load_candidate(
+            "lazy-load:chart.js",
+            "chart.js",
+            120,
+            FindingConfidence::High,
+        )],
+        duplicate_packages: vec![duplicate_package(
+            "duplicate-package:lodash",
+            "lodash",
+            18,
+            FindingConfidence::High,
+        )],
+        ..Default::default()
+    };
+
+    apply_action_plan(&mut analysis);
+
+    assert_eq!(analysis.heavy_dependencies[0].finding.recommended_fix, None);
+    assert_eq!(
+        analysis.lazy_load_candidates[0]
+            .finding
+            .recommended_fix
+            .as_ref()
+            .map(|fix| fix.kind.as_str()),
+        Some("lazy-load")
+    );
+    assert_eq!(
+        analysis.duplicate_packages[0]
+            .finding
+            .recommended_fix
+            .as_ref()
+            .map(|fix| fix.kind.as_str()),
+        Some("dedupe-package")
+    );
 }
 
 #[test]

--- a/crates/legolas-core/tests/finding_evidence.rs
+++ b/crates/legolas-core/tests/finding_evidence.rs
@@ -65,12 +65,7 @@ fn analyze_project_populates_lazy_load_candidate_evidence() {
                 .with_detail("route-like UI surface matched `admin` keyword")]),
     );
     assert_eq!(candidate.finding.action_priority, Some(2));
-    assert_recommended_fix(
-        candidate.finding.recommended_fix.as_ref(),
-        "lazy-load",
-        &["src/AdminDashboard.tsx"],
-        None,
-    );
+    assert!(candidate.finding.recommended_fix.is_none());
 }
 
 #[test]
@@ -150,12 +145,7 @@ fn analyze_project_limits_lazy_load_evidence_to_candidate_files() {
                 .with_detail("route-like UI surface matched `dashboard` keyword")]),
     );
     assert_eq!(candidate.finding.action_priority, Some(2));
-    assert_recommended_fix(
-        candidate.finding.recommended_fix.as_ref(),
-        "lazy-load",
-        &["src/Dashboard.tsx"],
-        None,
-    );
+    assert!(candidate.finding.recommended_fix.is_none());
 }
 
 fn write_file(root: &std::path::Path, relative_path: &str, contents: &str) {

--- a/tests/oracles/basic-app/optimize-ranked.txt
+++ b/tests/oracles/basic-app/optimize-ranked.txt
@@ -5,8 +5,6 @@ Legolas optimize for basic-parity-app
    targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
 2. Lazy load chart.js [medium | low confidence | ~120 KB]
-   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
-   targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
 3. Review react-icons upfront bundle weight [hard | high confidence | ~90 KB]
    recommended fix: narrow-import - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
@@ -18,8 +16,6 @@ Legolas optimize for basic-parity-app
    replacement: lodash-es
    evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
 5. Lazy load react-icons [medium | low confidence | ~68 KB]
-   recommended fix: lazy-load - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
-   targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
 
 Projected savings: ~366 KB, with directional confidence.

--- a/tests/oracles/basic-app/optimize.txt
+++ b/tests/oracles/basic-app/optimize.txt
@@ -5,8 +5,6 @@ Legolas optimize for basic-parity-app
    targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
 2. Lazy load chart.js [medium | low confidence | ~120 KB]
-   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
-   targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
 3. Review react-icons upfront bundle weight [hard | high confidence | ~90 KB]
    recommended fix: narrow-import - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
@@ -18,8 +16,6 @@ Legolas optimize for basic-parity-app
    replacement: lodash-es
    evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
 5. Lazy load react-icons [medium | low confidence | ~68 KB]
-   recommended fix: lazy-load - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
-   targets: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
 
 Projected savings: ~366 KB, with directional confidence.

--- a/tests/oracles/basic-app/scan.json
+++ b/tests/oracles/basic-app/scan.json
@@ -164,13 +164,6 @@
       "analysisSource": "heuristic",
       "confidence": "low",
       "actionPriority": 2,
-      "recommendedFix": {
-        "kind": "lazy-load",
-        "title": "Register only the chart primitives you use and lazy load dashboard surfaces.",
-        "targetFiles": [
-          "src/Dashboard.tsx"
-        ]
-      },
       "evidence": [
         {
           "kind": "source-file",
@@ -192,13 +185,6 @@
       "analysisSource": "heuristic",
       "confidence": "low",
       "actionPriority": 5,
-      "recommendedFix": {
-        "kind": "lazy-load",
-        "title": "Import narrowly from specific icon files or migrate to a more tree-shakable icon set.",
-        "targetFiles": [
-          "src/Dashboard.tsx"
-        ]
-      },
       "evidence": [
         {
           "kind": "source-file",
@@ -220,13 +206,6 @@
       "analysisSource": "heuristic",
       "confidence": "low",
       "actionPriority": 6,
-      "recommendedFix": {
-        "kind": "lazy-load",
-        "title": "Use per-method imports or switch to lodash-es when the toolchain supports it.",
-        "targetFiles": [
-          "src/Dashboard.tsx"
-        ]
-      },
       "evidence": [
         {
           "kind": "source-file",


### PR DESCRIPTION
## 배경

- `#47`은 `optimize` text output과 JSON finding surface에 safe fix hint를 additive하게 노출하는 작업이다.
- 기존 구현은 heuristic lazy-load candidate처럼 low-confidence finding에도 `recommendedFix`를 붙여서, 안전하지 않은 힌트가 같이 노출되고 있었다.

## 변경 사항

- `crates/legolas-core/src/action_plan.rs`에서 heuristic 문자열 매핑 대신 `fix_hints` builder를 사용하도록 바꿨다.
- high-confidence finding에만 `recommendedFix`가 붙도록 정리했다.
- low-confidence lazy-load candidate는 `scan --json`과 `optimize` text output에서 `recommendedFix`를 노출하지 않도록 계약을 맞췄다.
- 관련 CLI/test/oracle 회귀 테스트를 추가하고 parity oracle을 갱신했다.

## 검증

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo run -p legolas-cli -- optimize tests/fixtures/parity/basic-app`
- `cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app --json`
- fresh-session `devils-advocate-review-loop` Round 1: no findings

## 브랜치 / 워크트리

- base: `master`
- head: `codex/pr-fit-015b-safe-fix-hint-adoption`
- worktree: `/Users/pjw/workspace/legolas`

## 이슈 연결

- #47
