### PR TITLE
PR-FIT-014B: SARIF 리포터 추가

### DIFF
--- a/crates/legolas-cli/src/argv.rs
+++ b/crates/legolas-cli/src/argv.rs
@@ -22,6 +22,7 @@ pub struct CliArgs {
     pub write_baseline_path: Option<PathBuf>,
     pub regression_only: bool,
     pub json: bool,
+    pub sarif: bool,
     pub limit: Option<usize>,
     pub top: Option<usize>,
     pub help: bool,
@@ -70,6 +71,9 @@ where
             }
             "--json" => {
                 parsed.json = true;
+            }
+            "--sarif" => {
+                parsed.sarif = true;
             }
             "--config" => {
                 parsed.config_path = Some(parse_path_flag(&tokens, index, "--config")?);
@@ -123,8 +127,8 @@ where
         return Ok(parsed);
     }
 
+    validate_output_flags(&parsed)?;
     validate_baseline_flags(&parsed)?;
-
     parsed.limit = finalize_numeric_flag(parsed.command.as_ref(), pending_limit, "--limit")?;
     parsed.top = finalize_numeric_flag(parsed.command.as_ref(), pending_top, "--top")?;
 
@@ -198,6 +202,27 @@ fn validate_baseline_flags(parsed: &CliArgs) -> Result<()> {
     if parsed.baseline_path.is_some() && !parsed.regression_only {
         return Err(LegolasError::CliUsage(
             "--baseline requires --regression-only".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_output_flags(parsed: &CliArgs) -> Result<()> {
+    if !parsed.sarif {
+        return Ok(());
+    }
+
+    let command_supports = matches!(parsed.command, Some(Command::Scan) | Some(Command::Ci));
+    if !command_supports {
+        return Err(LegolasError::CliUsage(
+            "unknown flag \"--sarif\"".to_string(),
+        ));
+    }
+
+    if parsed.json {
+        return Err(LegolasError::CliUsage(
+            "--json and --sarif cannot be used together".to_string(),
         ));
     }
 

--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -6,9 +6,12 @@ use std::{
 
 use legolas_cli::{
     argv::{self, Command},
-    reporters::text::{
-        format_budget_report, format_ci_report, format_optimize_report, format_scan_report,
-        format_visualization_report,
+    reporters::{
+        sarif::{ci_sarif_output, scan_sarif_output},
+        text::{
+            format_budget_report, format_ci_report, format_optimize_report, format_scan_report,
+            format_visualization_report,
+        },
     },
 };
 use legolas_core::{
@@ -29,22 +32,23 @@ const HELP_TEXT: &str = r#"Legolas
 Slim bundles with precision.
 
 Usage:
-  legolas scan [path] [--config file] [--json] [--write-baseline file] [--baseline file --regression-only]
+  legolas scan [path] [--config file] [--json | --sarif] [--write-baseline file] [--baseline file --regression-only]
   legolas visualize [path] [--config file] [--limit 10]
   legolas optimize [path] [--config file] [--top 5] [--baseline file --regression-only]
   legolas budget [path] [--config file] [--json] [--baseline file --regression-only]
-  legolas ci [path] [--config file] [--json] [--baseline file --regression-only]
+  legolas ci [path] [--config file] [--json | --sarif] [--baseline file --regression-only]
   legolas help
 
 Examples:
   legolas scan .
+  legolas scan ./apps/storefront --sarif
   legolas scan ./apps/storefront --write-baseline ./baseline.json --json
   legolas scan ./apps/storefront --baseline ./baseline.json --regression-only --json
   legolas scan --config ./legolas.config.json
   legolas visualize ./apps/storefront --limit 12
   legolas optimize ./apps/storefront --top 7 --baseline ./baseline.json --regression-only
   legolas budget ./apps/storefront --baseline ./baseline.json --regression-only --json
-  legolas ci ./apps/storefront --baseline ./baseline.json --regression-only
+  legolas ci ./apps/storefront --baseline ./baseline.json --regression-only --sarif
 "#;
 
 fn main() {
@@ -78,7 +82,11 @@ fn run() -> Result<i32> {
     }
 
     let loaded_config = resolve_loaded_config(&parsed)?;
-    emit_config_warnings(&command, loaded_config.as_ref(), parsed.json);
+    emit_config_warnings(
+        &command,
+        loaded_config.as_ref(),
+        parsed.json || parsed.sarif,
+    );
     let target_path = resolve_target_path(&parsed, loaded_config.as_ref())?;
     let analysis = analyze_project(&target_path)?;
     let baseline = resolve_baseline_snapshot(&parsed)?;
@@ -105,6 +113,43 @@ fn run() -> Result<i32> {
 
     if let Some(write_baseline_path) = &parsed.write_baseline_path {
         write_baseline_snapshot(write_baseline_path, &analysis)?;
+    }
+
+    if parsed.sarif {
+        let output = match command {
+            Command::Scan => scan_sarif_output(&output_analysis),
+            Command::Ci => ci_sarif_output(
+                &output_analysis,
+                budget_evaluation
+                    .as_ref()
+                    .expect("budget evaluation exists for ci command"),
+                regression_diff.as_ref(),
+            ),
+            Command::Visualize | Command::Optimize | Command::Budget => {
+                unreachable!("argv validation already restricts --sarif")
+            }
+            Command::Help | Command::Unknown(_) => unreachable!("handled above"),
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+
+        if matches!(command, Command::Ci)
+            && budget_evaluation
+                .as_ref()
+                .expect("budget evaluation exists for ci command")
+                .has_failures()
+        {
+            eprintln!(
+                "{}",
+                ci_failure_message(
+                    budget_evaluation
+                        .as_ref()
+                        .expect("budget evaluation exists for ci command"),
+                )
+            );
+            return Ok(1);
+        }
+
+        return Ok(0);
     }
 
     if parsed.json {

--- a/crates/legolas-cli/src/reporters/mod.rs
+++ b/crates/legolas-cli/src/reporters/mod.rs
@@ -1,1 +1,2 @@
+pub mod sarif;
 pub mod text;

--- a/crates/legolas-cli/src/reporters/sarif.rs
+++ b/crates/legolas-cli/src/reporters/sarif.rs
@@ -1,0 +1,352 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use legolas_core::{
+    boundaries::BoundaryWarning, budget::BudgetEvaluation, Analysis, BaselineDiff,
+    DuplicatePackage, FindingConfidence, FindingEvidence, FindingMetadata, HeavyDependency,
+    LazyLoadCandidate, TreeShakingWarning,
+};
+use serde_json::{json, Map, Value};
+
+const SARIF_SCHEMA_URL: &str = "https://json.schemastore.org/sarif-2.1.0.json";
+const SARIF_VERSION: &str = "2.1.0";
+const LEGOLAS_INFO_URL: &str = "https://github.com/JeremyDev87/legolas";
+
+pub fn scan_sarif_output(analysis: &Analysis) -> Value {
+    sarif_output(
+        collect_scan_records(analysis),
+        base_run_properties("scan", analysis),
+    )
+}
+
+pub fn ci_sarif_output(
+    analysis: &Analysis,
+    evaluation: &BudgetEvaluation,
+    regression_diff: Option<&BaselineDiff>,
+) -> Value {
+    let triggered_finding_ids = evaluation
+        .rules
+        .iter()
+        .flat_map(|rule| {
+            rule.triggered_findings
+                .iter()
+                .map(|finding| finding.finding_id.clone())
+        })
+        .collect::<BTreeSet<_>>();
+
+    let records = collect_scan_records(analysis)
+        .into_iter()
+        .filter(|record| triggered_finding_ids.contains(&record.rule_id))
+        .collect::<Vec<_>>();
+
+    sarif_output(
+        records,
+        ci_run_properties(analysis, evaluation, regression_diff),
+    )
+}
+
+#[derive(Debug, Clone)]
+struct SarifRecord {
+    rule_id: String,
+    message: String,
+    short_description: String,
+    level: &'static str,
+    locations: Vec<Value>,
+    properties: Map<String, Value>,
+}
+
+fn collect_scan_records(analysis: &Analysis) -> Vec<SarifRecord> {
+    let mut records = Vec::new();
+
+    records.extend(
+        analysis
+            .boundary_warnings
+            .iter()
+            .filter_map(boundary_warning_record),
+    );
+    records.extend(
+        analysis
+            .heavy_dependencies
+            .iter()
+            .filter_map(heavy_dependency_record),
+    );
+    records.extend(
+        analysis
+            .duplicate_packages
+            .iter()
+            .filter_map(duplicate_package_record),
+    );
+    records.extend(
+        analysis
+            .lazy_load_candidates
+            .iter()
+            .filter_map(lazy_load_candidate_record),
+    );
+    records.extend(
+        analysis
+            .tree_shaking_warnings
+            .iter()
+            .filter_map(tree_shaking_warning_record),
+    );
+
+    records
+}
+
+fn boundary_warning_record(item: &BoundaryWarning) -> Option<SarifRecord> {
+    finding_record(
+        &item.finding,
+        item.message.clone(),
+        item.message.clone(),
+        Some(item.recommendation.as_str()),
+        [],
+    )
+}
+
+fn heavy_dependency_record(item: &HeavyDependency) -> Option<SarifRecord> {
+    finding_record(
+        &item.finding,
+        format!(
+            "{} ({} KB): {}",
+            item.name, item.estimated_kb, item.rationale
+        ),
+        format!("Review {} upfront bundle weight", item.name),
+        Some(item.recommendation.as_str()),
+        [
+            ("name", json!(item.name)),
+            ("versionRange", json!(item.version_range)),
+            ("estimatedKb", json!(item.estimated_kb)),
+            ("category", json!(item.category)),
+            ("importCount", json!(item.import_count)),
+            ("importedBy", json!(item.imported_by)),
+            ("dynamicImportedBy", json!(item.dynamic_imported_by)),
+        ],
+    )
+}
+
+fn duplicate_package_record(item: &DuplicatePackage) -> Option<SarifRecord> {
+    finding_record(
+        &item.finding,
+        format!(
+            "{} duplicated across {} ({} KB avoidable)",
+            item.name,
+            item.versions.join(", "),
+            item.estimated_extra_kb
+        ),
+        format!("Deduplicate {}", item.name),
+        None,
+        [
+            ("name", json!(item.name)),
+            ("versions", json!(item.versions)),
+            ("count", json!(item.count)),
+            ("estimatedExtraKb", json!(item.estimated_extra_kb)),
+            ("origins", json!(item.origins)),
+        ],
+    )
+}
+
+fn lazy_load_candidate_record(item: &LazyLoadCandidate) -> Option<SarifRecord> {
+    finding_record(
+        &item.finding,
+        format!(
+            "{} can be lazy loaded ({} KB): {}",
+            item.name, item.estimated_savings_kb, item.reason
+        ),
+        format!("Lazy load {}", item.name),
+        Some(item.recommendation.as_str()),
+        [
+            ("name", json!(item.name)),
+            ("estimatedSavingsKb", json!(item.estimated_savings_kb)),
+            ("files", json!(item.files)),
+            ("reason", json!(item.reason)),
+        ],
+    )
+}
+
+fn tree_shaking_warning_record(item: &TreeShakingWarning) -> Option<SarifRecord> {
+    finding_record(
+        &item.finding,
+        format!("{}: {}", item.package_name, item.message),
+        format!("Review {} tree shaking", item.package_name),
+        Some(item.recommendation.as_str()),
+        [
+            ("key", json!(item.key)),
+            ("packageName", json!(item.package_name)),
+            ("estimatedKb", json!(item.estimated_kb)),
+            ("files", json!(item.files)),
+        ],
+    )
+}
+
+fn finding_record<I>(
+    finding: &FindingMetadata,
+    message: String,
+    short_description: String,
+    recommendation: Option<&str>,
+    extra_properties: I,
+) -> Option<SarifRecord>
+where
+    I: IntoIterator<Item = (&'static str, Value)>,
+{
+    let rule_id = finding.finding_id.clone()?;
+    let mut properties = base_properties(finding);
+
+    if let Some(recommendation) = recommendation {
+        properties.insert("recommendation".to_string(), json!(recommendation));
+    }
+
+    for (key, value) in extra_properties {
+        properties.insert(key.to_string(), value);
+    }
+
+    Some(SarifRecord {
+        rule_id,
+        message,
+        short_description,
+        level: sarif_level(finding.confidence),
+        locations: locations_from_evidence(&finding.evidence),
+        properties,
+    })
+}
+
+fn base_properties(finding: &FindingMetadata) -> Map<String, Value> {
+    let mut properties = Map::new();
+
+    if let Some(analysis_source) = finding.analysis_source {
+        properties.insert("analysisSource".to_string(), json!(analysis_source));
+    }
+    if let Some(confidence) = finding.confidence {
+        properties.insert("confidence".to_string(), json!(confidence));
+    }
+    if let Some(action_priority) = finding.action_priority {
+        properties.insert("actionPriority".to_string(), json!(action_priority));
+    }
+    if let Some(recommended_fix) = &finding.recommended_fix {
+        properties.insert("recommendedFix".to_string(), json!(recommended_fix));
+    }
+
+    properties.insert("evidence".to_string(), json!(finding.evidence));
+    properties
+}
+
+fn locations_from_evidence(evidence: &[FindingEvidence]) -> Vec<Value> {
+    let mut seen = BTreeSet::new();
+    let mut locations = Vec::new();
+
+    for item in evidence {
+        let Some(file) = item.file.as_ref() else {
+            continue;
+        };
+
+        if seen.insert(file.clone()) {
+            locations.push(json!({
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": file
+                    }
+                }
+            }));
+        }
+    }
+
+    locations
+}
+
+fn sarif_level(confidence: Option<FindingConfidence>) -> &'static str {
+    match confidence {
+        Some(FindingConfidence::High) => "warning",
+        Some(FindingConfidence::Medium) | Some(FindingConfidence::Low) | None => "note",
+    }
+}
+
+fn base_run_properties(command: &str, analysis: &Analysis) -> Map<String, Value> {
+    let mut properties = Map::new();
+    properties.insert("command".to_string(), json!(command));
+
+    if !analysis.warnings.is_empty() {
+        properties.insert("warnings".to_string(), json!(analysis.warnings));
+    }
+
+    properties
+}
+
+fn ci_run_properties(
+    analysis: &Analysis,
+    evaluation: &BudgetEvaluation,
+    regression_diff: Option<&BaselineDiff>,
+) -> Map<String, Value> {
+    let mut properties = base_run_properties("ci", analysis);
+    properties.insert("passed".to_string(), json!(!evaluation.has_failures()));
+    properties.insert(
+        "overallStatus".to_string(),
+        json!(evaluation.overall_status),
+    );
+    properties.insert("rules".to_string(), json!(evaluation.rules));
+
+    if let Some(diff) = regression_diff {
+        properties.insert(
+            "regression".to_string(),
+            json!({
+                "mode": "regression-only",
+                "baselineDiff": diff,
+            }),
+        );
+    }
+
+    properties
+}
+
+fn sarif_output(records: Vec<SarifRecord>, run_properties: Map<String, Value>) -> Value {
+    let mut rules = BTreeMap::new();
+    let results = records
+        .iter()
+        .map(|record| {
+            rules.entry(record.rule_id.clone()).or_insert_with(|| {
+                json!({
+                    "id": record.rule_id,
+                    "shortDescription": {
+                        "text": record.short_description
+                    }
+                })
+            });
+
+            let mut result = Map::new();
+            result.insert("ruleId".to_string(), json!(record.rule_id));
+            result.insert("level".to_string(), json!(record.level));
+            result.insert(
+                "message".to_string(),
+                json!({
+                    "text": record.message
+                }),
+            );
+            result.insert(
+                "properties".to_string(),
+                Value::Object(record.properties.clone()),
+            );
+            if !record.locations.is_empty() {
+                result.insert(
+                    "locations".to_string(),
+                    Value::Array(record.locations.clone()),
+                );
+            }
+
+            Value::Object(result)
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "$schema": SARIF_SCHEMA_URL,
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "legolas",
+                        "informationUri": LEGOLAS_INFO_URL,
+                        "rules": rules.into_values().collect::<Vec<_>>()
+                    }
+                },
+                "properties": run_properties,
+                "results": results
+            }
+        ]
+    })
+}

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -454,6 +454,23 @@ fn matches_missing_number_and_unknown_flag_contracts() {
             ],
             "legolas: unknown flag \"--regression-only\"\n",
         ),
+        (
+            vec![
+                "visualize".to_string(),
+                fixture.display().to_string(),
+                "--sarif".to_string(),
+            ],
+            "legolas: unknown flag \"--sarif\"\n",
+        ),
+        (
+            vec![
+                "scan".to_string(),
+                fixture.display().to_string(),
+                "--json".to_string(),
+                "--sarif".to_string(),
+            ],
+            "legolas: --json and --sarif cannot be used together\n",
+        ),
     ];
 
     for (args, expected_stderr) in cases {

--- a/crates/legolas-cli/tests/config_contract.rs
+++ b/crates/legolas-cli/tests/config_contract.rs
@@ -214,3 +214,38 @@ fn json_mode_suppresses_config_warnings_to_keep_machine_output_clean() {
     );
     assert_eq!(stderr(&output), "");
 }
+
+#[test]
+fn sarif_mode_suppresses_config_warnings_to_keep_machine_output_clean() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let config_path = temp_dir.path().join("legolas.config.json");
+    let basic_app = support::fixture_path("tests/fixtures/parity/basic-app");
+    fs::write(
+        &config_path,
+        format!(
+            r#"{{
+  "scan": {{ "path": "{}" }},
+  "visualize": {{ "limit": 2, "theme": "wide" }},
+  "extra": true
+}}
+"#,
+            normalize(&basic_app.display().to_string())
+        ),
+    )
+    .expect("write config");
+
+    let output = run_cli(&[
+        "scan",
+        "--config",
+        &config_path.display().to_string(),
+        "--sarif",
+    ]);
+    let expected = run_cli(&["scan", &basic_app.display().to_string(), "--sarif"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        support::normalize_sarif_output(&stdout(&output)),
+        support::normalize_sarif_output(&stdout(&expected))
+    );
+    assert_eq!(stderr(&output), "");
+}

--- a/crates/legolas-cli/tests/json_schema_contract.rs
+++ b/crates/legolas-cli/tests/json_schema_contract.rs
@@ -6,6 +6,8 @@ use serde_json::{json, Value};
 const ANALYSIS_SCHEMA_VERSION: &str = "legolas.analysis.v1";
 const BUDGET_SCHEMA_VERSION: &str = "legolas.budget.v1";
 const CI_SCHEMA_VERSION: &str = "legolas.ci.v1";
+const SARIF_SCHEMA_URL: &str = "https://json.schemastore.org/sarif-2.1.0.json";
+const SARIF_VERSION: &str = "2.1.0";
 
 #[test]
 fn scan_json_matches_analysis_schema_doc() {
@@ -102,6 +104,71 @@ fn regression_only_ci_json_matches_ci_schema_doc() {
     let schema = read_schema("ci.v1.schema.json");
 
     assert_eq!(value["schemaVersion"], json!(CI_SCHEMA_VERSION));
+    assert_matches_schema(&value, &schema, "$");
+}
+
+#[test]
+fn scan_sarif_matches_schema_doc() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string(), "--sarif"])
+        .output()
+        .expect("run scan --sarif");
+
+    assert!(output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse scan sarif");
+    let schema = read_schema("sarif.v1.json");
+
+    assert_eq!(value["$schema"], json!(SARIF_SCHEMA_URL));
+    assert_eq!(value["version"], json!(SARIF_VERSION));
+    assert_matches_schema(&value, &schema, "$");
+}
+
+#[test]
+fn ci_sarif_matches_schema_doc() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["ci", &fixture.display().to_string(), "--sarif"])
+        .output()
+        .expect("run ci --sarif");
+
+    assert!(!output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse ci sarif");
+    let schema = read_schema("sarif.v1.json");
+
+    assert_eq!(value["$schema"], json!(SARIF_SCHEMA_URL));
+    assert_eq!(value["version"], json!(SARIF_VERSION));
+    assert_matches_schema(&value, &schema, "$");
+}
+
+#[test]
+fn regression_only_ci_sarif_matches_schema_doc() {
+    let fixture = support::fixture_path("tests/fixtures/baseline/current-app");
+    let baseline = support::fixture_path("tests/fixtures/baseline/previous-scan.json");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args([
+            "ci",
+            &fixture.display().to_string(),
+            "--baseline",
+            &baseline.display().to_string(),
+            "--regression-only",
+            "--sarif",
+        ])
+        .output()
+        .expect("run regression ci --sarif");
+
+    assert!(output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse regression ci sarif");
+    let schema = read_schema("sarif.v1.json");
+
+    assert_eq!(value["$schema"], json!(SARIF_SCHEMA_URL));
+    assert_eq!(value["version"], json!(SARIF_VERSION));
     assert_matches_schema(&value, &schema, "$");
 }
 

--- a/crates/legolas-cli/tests/sarif_contract.rs
+++ b/crates/legolas-cli/tests/sarif_contract.rs
@@ -1,0 +1,225 @@
+mod support;
+
+use std::collections::BTreeSet;
+
+use assert_cmd::Command;
+use serde_json::json;
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(args)
+        .output()
+        .expect("run command")
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout")
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr")
+}
+
+#[test]
+fn scan_sarif_preserves_rule_ids_locations_and_metadata() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = run_cli(&["scan", &fixture.display().to_string(), "--sarif"]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let sarif = support::normalize_sarif_output(&stdout(&output));
+    assert_eq!(
+        sarif["$schema"],
+        json!("https://json.schemastore.org/sarif-2.1.0.json")
+    );
+    assert_eq!(sarif["version"], json!("2.1.0"));
+    assert_eq!(sarif["runs"][0]["properties"]["command"], json!("scan"));
+
+    let results = sarif["runs"][0]["results"]
+        .as_array()
+        .expect("results array");
+    assert_eq!(results.len(), 9);
+
+    let rule_ids_from_results = results
+        .iter()
+        .map(|result| result["ruleId"].as_str().expect("rule id").to_string())
+        .collect::<BTreeSet<_>>();
+    let rule_ids_from_driver = sarif["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("driver rules")
+        .iter()
+        .map(|rule| rule["id"].as_str().expect("rule id").to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(rule_ids_from_results, rule_ids_from_driver);
+
+    let chart_js = results
+        .iter()
+        .find(|result| result["ruleId"] == "heavy-dependency:chart.js")
+        .expect("chart.js result");
+    assert_eq!(chart_js["level"], json!("warning"));
+    assert_eq!(
+        chart_js["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+        json!("src/Dashboard.tsx")
+    );
+    assert_eq!(
+        chart_js["properties"]["analysisSource"],
+        json!("source-import")
+    );
+    assert_eq!(chart_js["properties"]["confidence"], json!("high"));
+    assert_eq!(chart_js["properties"]["actionPriority"], json!(1));
+    assert_eq!(
+        chart_js["properties"]["recommendedFix"]["kind"],
+        json!("lazy-load")
+    );
+    assert_eq!(
+        chart_js["properties"]["evidence"][0],
+        json!({
+            "kind": "source-file",
+            "file": "src/Dashboard.tsx",
+            "specifier": "chart.js",
+            "detail": "static import; Charting code is often only needed on a subset of screens."
+        })
+    );
+
+    let duplicate = results
+        .iter()
+        .find(|result| result["ruleId"] == "duplicate-package:lodash")
+        .expect("duplicate result");
+    assert!(duplicate.get("locations").is_none());
+    assert_eq!(
+        duplicate["properties"]["analysisSource"],
+        json!("lockfile-trace")
+    );
+    assert_eq!(duplicate["properties"]["confidence"], json!("high"));
+    assert_eq!(duplicate["properties"]["evidence"], json!([]));
+    assert_eq!(
+        duplicate["properties"]["recommendedFix"]["kind"],
+        json!("dedupe-package")
+    );
+}
+
+#[test]
+fn ci_sarif_uses_triggered_findings_and_preserves_failure_exit_code() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = run_cli(&["ci", &fixture.display().to_string(), "--sarif"]);
+
+    assert!(!output.status.success());
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        stderr(&output),
+        "CI gate failed: overall status Fail (failing rules: potentialKbSaved, dynamicImportCount)\n"
+    );
+
+    let sarif = support::normalize_sarif_output(&stdout(&output));
+    assert_eq!(sarif["runs"][0]["properties"]["command"], json!("ci"));
+    assert_eq!(sarif["runs"][0]["properties"]["passed"], json!(false));
+    assert_eq!(
+        sarif["runs"][0]["properties"]["overallStatus"],
+        json!("Fail")
+    );
+    assert_eq!(
+        sarif["runs"][0]["properties"]["rules"][0]["key"],
+        json!("potentialKbSaved")
+    );
+
+    let rule_ids = sarif["runs"][0]["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|result| result["ruleId"].as_str().expect("rule id").to_string())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        rule_ids,
+        BTreeSet::from([
+            "duplicate-package:lodash".to_string(),
+            "heavy-dependency:chart.js".to_string(),
+            "heavy-dependency:lodash".to_string(),
+            "heavy-dependency:react-icons".to_string(),
+            "lazy-load:chart.js".to_string(),
+            "lazy-load:lodash".to_string(),
+            "lazy-load:react-icons".to_string(),
+            "tree-shaking:lodash-root-import".to_string(),
+            "tree-shaking:react-icons-root-import".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn ci_sarif_excludes_non_budget_findings() {
+    let fixture = support::fixture_path("tests/fixtures/boundaries/rsc-server-only");
+
+    let scan_output = run_cli(&["scan", &fixture.display().to_string(), "--sarif"]);
+    assert!(scan_output.status.success());
+    let scan = support::normalize_sarif_output(&stdout(&scan_output));
+    let scan_results = scan["runs"][0]["results"].as_array().expect("scan results");
+    assert_eq!(scan_results.len(), 1);
+    assert_eq!(scan_results[0]["ruleId"], json!("boundary:rsc-server-only"));
+
+    let ci_output = run_cli(&["ci", &fixture.display().to_string(), "--sarif"]);
+    assert!(!ci_output.status.success());
+    assert_eq!(ci_output.status.code(), Some(1));
+    assert_eq!(
+        stderr(&ci_output),
+        "CI gate failed: overall status Fail (failing rules: dynamicImportCount)\n"
+    );
+    let ci = support::normalize_sarif_output(&stdout(&ci_output));
+    assert_eq!(ci["runs"][0]["results"], json!([]));
+    assert_eq!(ci["runs"][0]["properties"]["passed"], json!(false));
+    assert_eq!(ci["runs"][0]["properties"]["overallStatus"], json!("Fail"));
+    assert_eq!(
+        ci["runs"][0]["properties"]["rules"][2]["key"],
+        json!("dynamicImportCount")
+    );
+}
+
+#[test]
+fn scan_sarif_exposes_analysis_warnings_even_without_findings() {
+    let fixture = support::fixture_path("tests/fixtures/workspace/multi-lockfiles");
+    let output = run_cli(&["scan", &fixture.display().to_string(), "--sarif"]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let sarif = support::normalize_sarif_output(&stdout(&output));
+    assert_eq!(sarif["runs"][0]["results"], json!([]));
+    assert_eq!(
+        sarif["runs"][0]["properties"]["warnings"],
+        json!([
+            "Multiple lockfiles detected. Duplicate analysis used pnpm-lock.yaml based on package manager \"pnpm@9.0.0\" and ignored package-lock.json."
+        ])
+    );
+}
+
+#[test]
+fn regression_only_ci_sarif_includes_regression_envelope() {
+    let current_app = support::fixture_path("tests/fixtures/baseline/current-app");
+    let baseline_path = support::fixture_path("tests/fixtures/baseline/previous-scan.json");
+    let output = run_cli(&[
+        "ci",
+        &current_app.display().to_string(),
+        "--baseline",
+        &baseline_path.display().to_string(),
+        "--regression-only",
+        "--sarif",
+    ]);
+
+    assert!(output.status.success());
+    assert_eq!(stderr(&output), "");
+
+    let sarif = support::normalize_sarif_output(&stdout(&output));
+    assert_eq!(sarif["runs"][0]["properties"]["passed"], json!(true));
+    assert_eq!(
+        sarif["runs"][0]["properties"]["overallStatus"],
+        json!("Warn")
+    );
+    assert_eq!(
+        sarif["runs"][0]["properties"]["regression"]["mode"],
+        json!("regression-only")
+    );
+    assert!(
+        sarif["runs"][0]["properties"]["regression"]["baselineDiff"]["schemaVersion"].is_number()
+    );
+}

--- a/crates/legolas-cli/tests/support/mod.rs
+++ b/crates/legolas-cli/tests/support/mod.rs
@@ -51,6 +51,13 @@ pub fn normalize_ci_json_output(output: &str) -> Value {
 }
 
 #[allow(dead_code)]
+pub fn normalize_sarif_output(output: &str) -> Value {
+    let mut sarif = serde_json::from_str::<Value>(output).expect("parse sarif json");
+    normalize_sarif_value(&mut sarif);
+    sarif
+}
+
+#[allow(dead_code)]
 fn normalize_analysis_value(analysis: &mut Value) {
     replace_string_field(analysis, &["projectRoot"], "<PROJECT_ROOT>");
     replace_string_field(analysis, &["metadata", "generatedAt"], "<GENERATED_AT>");
@@ -85,6 +92,50 @@ fn normalize_analysis_value(analysis: &mut Value) {
         "recommendedFix",
         "targetFiles",
     );
+}
+
+#[allow(dead_code)]
+fn normalize_sarif_value(sarif: &mut Value) {
+    let Some(Value::Array(runs)) = get_path_mut(sarif, &["runs"]) else {
+        return;
+    };
+
+    for run in runs {
+        let Some(results) = run.get_mut("results").and_then(Value::as_array_mut) else {
+            continue;
+        };
+
+        for result in results {
+            if let Some(locations) = result.get_mut("locations").and_then(Value::as_array_mut) {
+                for location in locations {
+                    let Some(uri_value) = location
+                        .get_mut("physicalLocation")
+                        .and_then(|value| value.get_mut("artifactLocation"))
+                        .and_then(|value| value.get_mut("uri"))
+                    else {
+                        continue;
+                    };
+                    let Some(uri) = uri_value.as_str().map(str::to_string) else {
+                        continue;
+                    };
+
+                    location["physicalLocation"]["artifactLocation"]["uri"] =
+                        Value::String(to_posix(uri));
+                }
+            }
+
+            let Some(properties) = result.get_mut("properties") else {
+                continue;
+            };
+            normalize_object_array_string_field(properties, &["evidence"], "file");
+            normalize_object_array_object_array_string_field(
+                properties,
+                &[],
+                "recommendedFix",
+                "targetFiles",
+            );
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/docs/schema/sarif.v1.json
+++ b/docs/schema/sarif.v1.json
@@ -1,0 +1,355 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/JeremyDev87/legolas/blob/master/docs/schema/sarif.v1.json",
+  "title": "Legolas SARIF v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "version",
+    "runs"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://json.schemastore.org/sarif-2.1.0.json"
+    },
+    "version": {
+      "type": "string",
+      "const": "2.1.0"
+    },
+    "runs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "tool",
+          "properties",
+          "results"
+        ],
+        "properties": {
+          "tool": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "driver"
+            ],
+            "properties": {
+              "driver": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "informationUri",
+                  "rules"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "const": "legolas"
+                  },
+                  "informationUri": {
+                    "type": "string",
+                    "const": "https://github.com/JeremyDev87/legolas"
+                  },
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "id",
+                        "shortDescription"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "shortDescription": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "required": [
+                            "text"
+                          ],
+                          "properties": {
+                            "text": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "command"
+            ],
+            "properties": {
+              "command": {
+                "type": "string",
+                "enum": [
+                  "scan",
+                  "ci"
+                ]
+              },
+              "warnings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "passed": {
+                "type": "boolean"
+              },
+              "overallStatus": {
+                "type": "string",
+                "enum": [
+                  "Pass",
+                  "Warn",
+                  "Fail"
+                ]
+              },
+              "rules": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "key",
+                    "actual",
+                    "warnAt",
+                    "failAt",
+                    "status",
+                    "triggeredFindings"
+                  ],
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "actual": {
+                      "type": "integer"
+                    },
+                    "warnAt": {
+                      "type": "integer"
+                    },
+                    "failAt": {
+                      "type": "integer"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "Pass",
+                        "Warn",
+                        "Fail"
+                      ]
+                    },
+                    "triggeredFindings": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "findingId",
+                          "analysisSource",
+                          "confidence"
+                        ],
+                        "properties": {
+                          "findingId": {
+                            "type": "string"
+                          },
+                          "analysisSource": {
+                            "type": "string"
+                          },
+                          "confidence": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "regression": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "mode",
+                  "baselineDiff"
+                ],
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "const": "regression-only"
+                  },
+                  "baselineDiff": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "required": [
+                      "schemaVersion"
+                    ],
+                    "properties": {
+                      "schemaVersion": {
+                        "type": "integer",
+                        "const": 5
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ruleId",
+                "level",
+                "message",
+                "properties"
+              ],
+              "properties": {
+                "ruleId": {
+                  "type": "string"
+                },
+                "level": {
+                  "type": "string",
+                  "enum": [
+                    "warning",
+                    "note"
+                  ]
+                },
+                "message": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "text"
+                  ],
+                  "properties": {
+                    "text": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "locations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "physicalLocation"
+                    ],
+                    "properties": {
+                      "physicalLocation": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "artifactLocation"
+                        ],
+                        "properties": {
+                          "artifactLocation": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "uri"
+                            ],
+                            "properties": {
+                              "uri": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "required": [
+                    "analysisSource",
+                    "confidence",
+                    "evidence"
+                  ],
+                  "properties": {
+                    "analysisSource": {
+                      "type": "string"
+                    },
+                    "confidence": {
+                      "type": "string"
+                    },
+                    "actionPriority": {
+                      "type": "integer"
+                    },
+                    "recommendation": {
+                      "type": "string"
+                    },
+                    "recommendedFix": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "kind",
+                        "title",
+                        "targetFiles"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "targetFiles": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "replacement": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "evidence": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "kind"
+                        ],
+                        "properties": {
+                          "kind": {
+                            "type": "string"
+                          },
+                          "file": {
+                            "type": "string"
+                          },
+                          "specifier": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/oracles/cli/help.txt
+++ b/tests/oracles/cli/help.txt
@@ -2,19 +2,20 @@ Legolas
 Slim bundles with precision.
 
 Usage:
-  legolas scan [path] [--config file] [--json] [--write-baseline file] [--baseline file --regression-only]
+  legolas scan [path] [--config file] [--json | --sarif] [--write-baseline file] [--baseline file --regression-only]
   legolas visualize [path] [--config file] [--limit 10]
   legolas optimize [path] [--config file] [--top 5] [--baseline file --regression-only]
   legolas budget [path] [--config file] [--json] [--baseline file --regression-only]
-  legolas ci [path] [--config file] [--json] [--baseline file --regression-only]
+  legolas ci [path] [--config file] [--json | --sarif] [--baseline file --regression-only]
   legolas help
 
 Examples:
   legolas scan .
+  legolas scan ./apps/storefront --sarif
   legolas scan ./apps/storefront --write-baseline ./baseline.json --json
   legolas scan ./apps/storefront --baseline ./baseline.json --regression-only --json
   legolas scan --config ./legolas.config.json
   legolas visualize ./apps/storefront --limit 12
   legolas optimize ./apps/storefront --top 7 --baseline ./baseline.json --regression-only
   legolas budget ./apps/storefront --baseline ./baseline.json --regression-only --json
-  legolas ci ./apps/storefront --baseline ./baseline.json --regression-only
+  legolas ci ./apps/storefront --baseline ./baseline.json --regression-only --sarif


### PR DESCRIPTION
## 배경

Refs #49

structured finding metadata와 evidence를 잃지 않는 SARIF 출력 경로를 추가합니다. 계획 문서 기준으로 `scan`과 `ci`에서 `--sarif`를 지원하고, 기존 text/JSON 출력은 유지합니다.

## 변경 사항

- `scan`/`ci` 전용 `--sarif` 플래그를 추가하고 `--json`과의 동시 사용을 usage error로 고정했습니다.
- `crates/legolas-cli/src/reporters/sarif.rs`를 추가해 finding id, location, evidence, confidence, action priority, recommended fix를 SARIF result에 보존합니다.
- `ci --sarif`는 stdout만으로 gate 상태를 읽을 수 있도록 `passed`, `overallStatus`, `rules`, optional `regression` envelope를 run properties에 포함합니다.
- `scan --sarif`/`ci --sarif`는 분석 warning을 run properties에 포함해 degraded analysis 상태를 숨기지 않습니다.
- `docs/schema/sarif.v1.json`과 SARIF/schema/CLI/config 계약 테스트를 추가했습니다.

## 검증

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p legolas-cli --test sarif_contract --test json_schema_contract --test cli_contract --test config_contract`
- `cargo test --workspace`
- `cargo run -q -p legolas-cli -- scan tests/fixtures/workspace/multi-lockfiles --sarif`
- `cargo run -q -p legolas-cli -- ci tests/fixtures/boundaries/rsc-server-only --sarif`
- `cargo run -q -p legolas-cli -- ci tests/fixtures/baseline/current-app --baseline tests/fixtures/baseline/previous-scan.json --regression-only --sarif`
- `npm pack --dry-run --json --cache ./.npm-cache`

## 브랜치 / 워크트리

- branch: `codex/pr-fit-014b-sarif-reporter`
- worktree: `/Users/pjw/workspace/legolas`
- base: `master`

## 참고

- `node scripts/check-pack.mjs`는 이 checkout에 `vendor/<triple>/legolas[.exe]` 바이너리가 없어 실행하지 않았습니다. 대신 `npm pack --dry-run --json --cache ./.npm-cache`로 `docs/schema/sarif.v1.json` 패키징 포함 여부를 확인했습니다.
- local-only `.taskmaestro/` 상태 파일은 staging 대상에서 제외했습니다.
