### PR TITLE
fix(ci): release 설치 smoke 보강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Verify package tarball
         run: npm run pack:check
 
+      - name: Smoke test packed install
+        run: npm run pack:smoke
+
   pack-check-windows:
     name: Pack Check Windows
     runs-on: windows-latest
@@ -181,3 +184,6 @@ jobs:
 
       - name: Verify package tarball
         run: npm run pack:check
+
+      - name: Smoke test packed install
+        run: npm run pack:smoke

--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -51,8 +51,10 @@ jobs:
       - name: Resolve bump metadata
         id: meta
         shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          tag="${{ inputs.tag }}"
+          tag="$INPUT_TAG"
           if [[ "$tag" != v* ]]; then
             tag="v$tag"
           fi
@@ -81,7 +83,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Apply version bump
-        run: node ./scripts/bump-release-version.mjs "${{ steps.meta.outputs.tag }}"
+        env:
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+        run: node ./scripts/bump-release-version.mjs "$RELEASE_TAG"
 
       - name: Verify changed files before validation
         shell: bash
@@ -156,10 +160,11 @@ jobs:
         id: existing_pr
         shell: bash
         env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
           EXPECTED_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           pr_json=$(gh pr list \
-            --head "${{ steps.meta.outputs.branch }}" \
+            --head "$BUMP_BRANCH" \
             --state open \
             --json number,url,baseRefName,labels)
 
@@ -176,7 +181,7 @@ jobs:
           if [ -n "$pr_number" ]; then
             git fetch origin \
               "refs/heads/master:refs/remotes/origin/master" \
-              "refs/heads/${{ steps.meta.outputs.branch }}:refs/remotes/origin/${{ steps.meta.outputs.branch }}"
+              "refs/heads/${BUMP_BRANCH}:refs/remotes/origin/${BUMP_BRANCH}"
 
             # shellcheck disable=SC2016
             node --input-type=module -e '
@@ -221,7 +226,7 @@ jobs:
               if (cargoMatch[1] !== expectedVersion) {
                 throw new Error(`crates/legolas-cli/Cargo.toml version mismatch: ${cargoMatch[1]}`);
               }
-            ' "${{ steps.meta.outputs.branch }}" "$EXPECTED_VERSION"
+            ' "$BUMP_BRANCH" "$EXPECTED_VERSION"
           fi
 
           if [ -n "$pr_number" ] && [ "$has_skip_changelog" != "true" ]; then
@@ -236,33 +241,41 @@ jobs:
       - name: Prepare bump branch
         if: ${{ !inputs.dry_run && steps.existing_pr.outputs.number == '' }}
         shell: bash
+        env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
+          BUMP_TITLE: ${{ steps.meta.outputs.title }}
         run: |
           lease_args=()
 
-          if git ls-remote --exit-code --heads origin "${{ steps.meta.outputs.branch }}" >/dev/null 2>&1; then
-            echo "Remote branch ${{ steps.meta.outputs.branch }} already exists; refreshing it with the verified bump commit."
-            git fetch origin "refs/heads/${{ steps.meta.outputs.branch }}:refs/remotes/origin/${{ steps.meta.outputs.branch }}"
-            lease_args+=(--force-with-lease="refs/heads/${{ steps.meta.outputs.branch }}:$(git rev-parse "refs/remotes/origin/${{ steps.meta.outputs.branch }}")")
+          if git ls-remote --exit-code --heads origin "$BUMP_BRANCH" >/dev/null 2>&1; then
+            echo "Remote branch $BUMP_BRANCH already exists; refreshing it with the verified bump commit."
+            git fetch origin "refs/heads/${BUMP_BRANCH}:refs/remotes/origin/${BUMP_BRANCH}"
+            lease_args+=(--force-with-lease="refs/heads/${BUMP_BRANCH}:$(git rev-parse "refs/remotes/origin/${BUMP_BRANCH}")")
           fi
 
-          git switch -C "${{ steps.meta.outputs.branch }}"
+          git switch -C "$BUMP_BRANCH"
           git add package.json crates/legolas-cli/Cargo.toml
-          git commit -m "${{ steps.meta.outputs.title }}"
-          git push "${lease_args[@]}" -u origin "${{ steps.meta.outputs.branch }}"
+          git commit -m "$BUMP_TITLE"
+          git push "${lease_args[@]}" -u origin "$BUMP_BRANCH"
 
       - name: Dispatch CI for bump branch
         if: ${{ !inputs.dry_run }}
         shell: bash
-        run: gh workflow run ci.yml --ref "${{ steps.meta.outputs.branch }}"
+        env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
+        run: gh workflow run ci.yml --ref "$BUMP_BRANCH"
 
       - name: Resolve release candidate target
         if: ${{ !inputs.dry_run }}
         id: candidate_target
         shell: bash
+        env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
+          EXISTING_PR_NUMBER: ${{ steps.existing_pr.outputs.number }}
         run: |
-          if [ -n "${{ steps.existing_pr.outputs.number }}" ]; then
-            git fetch origin "refs/heads/${{ steps.meta.outputs.branch }}:refs/remotes/origin/${{ steps.meta.outputs.branch }}"
-            target_sha="$(git rev-parse "refs/remotes/origin/${{ steps.meta.outputs.branch }}")"
+          if [ -n "$EXISTING_PR_NUMBER" ]; then
+            git fetch origin "refs/heads/${BUMP_BRANCH}:refs/remotes/origin/${BUMP_BRANCH}"
+            target_sha="$(git rev-parse "refs/remotes/origin/${BUMP_BRANCH}")"
           else
             target_sha="$(git rev-parse HEAD)"
           fi
@@ -272,28 +285,36 @@ jobs:
       - name: Dispatch release candidate verification
         if: ${{ !inputs.dry_run }}
         shell: bash
-        run: gh workflow run release-candidate.yml --ref master -f target_sha="${{ steps.candidate_target.outputs.sha }}"
+        env:
+          CANDIDATE_SHA: ${{ steps.candidate_target.outputs.sha }}
+        run: gh workflow run release-candidate.yml --ref master -f target_sha="$CANDIDATE_SHA"
 
       - name: Create or reuse draft PR
         if: ${{ !inputs.dry_run }}
         shell: bash
         env:
+          BUMP_BRANCH: ${{ steps.meta.outputs.branch }}
+          BUMP_TITLE: ${{ steps.meta.outputs.title }}
+          CURRENT_VERSION: ${{ steps.meta.outputs.currentVersion }}
           DEFAULT_GH_TOKEN: ${{ github.token }}
+          EXISTING_PR_URL: ${{ steps.existing_pr.outputs.url }}
           PR_CREATE_TOKEN: ${{ secrets.LEGOLAS_RELEASE_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           printf '%s\n' \
             "## 배경 / Background" \
             "" \
-            "- manual release bump workflow로 \`${{ steps.meta.outputs.currentVersion }}\`에서 \`${{ steps.meta.outputs.version }}\`으로 승격합니다." \
+            "- manual release bump workflow로 \`${CURRENT_VERSION}\`에서 \`${RELEASE_VERSION}\`으로 승격합니다." \
             "- 실제 tag / publish는 이 PR merge 이후 별도 \`release.yml\` workflow에서 진행합니다." \
             "" \
             "## 변경 사항 / Changes" \
             "" \
-            "- \`package.json\` 과 \`crates/legolas-cli/Cargo.toml\` version을 \`${{ steps.meta.outputs.version }}\`으로 맞췄습니다." \
+            "- \`package.json\` 과 \`crates/legolas-cli/Cargo.toml\` version을 \`${RELEASE_VERSION}\`으로 맞췄습니다." \
             "" \
             "## 검증 / Verification" \
             "" \
-            "- \`node ./scripts/bump-release-version.mjs ${{ steps.meta.outputs.tag }}\`" \
+            "- \`node ./scripts/bump-release-version.mjs ${RELEASE_TAG}\`" \
             "- \`npm run test:release-contract\`" \
             "- \`npm test\`" \
             "- bump branch에 대해 \`legolas-ci\` 와 \`Release Candidate Core Verification\` workflow를 dispatch했습니다." \
@@ -312,31 +333,31 @@ jobs:
             token_source="github.token"
           fi
 
-          if [ -n "${{ steps.existing_pr.outputs.url }}" ]; then
-            echo "Reusing existing PR: ${{ steps.existing_pr.outputs.url }}"
+          if [ -n "$EXISTING_PR_URL" ]; then
+            echo "Reusing existing PR: $EXISTING_PR_URL"
             exit 0
           fi
 
           if pr_url=$(gh pr create \
             --draft \
             --base master \
-            --head "${{ steps.meta.outputs.branch }}" \
-            --title "${{ steps.meta.outputs.title }}" \
+            --head "$BUMP_BRANCH" \
+            --title "$BUMP_TITLE" \
             --body-file pr-body.md \
             --label skip-changelog 2>/tmp/legolas-gh-pr-create-error.txt); then
             echo "Created draft PR: $pr_url"
             exit 0
           fi
 
-          compare_url="https://github.com/${GITHUB_REPOSITORY}/compare/master...${{ steps.meta.outputs.branch }}?expand=1"
+          compare_url="https://github.com/${GITHUB_REPOSITORY}/compare/master...${BUMP_BRANCH}?expand=1"
 
           {
             echo "### Manual release bump failed to create a PR"
             echo
             echo "The bump branch was pushed, but the workflow could not open a draft PR."
             echo
-            echo "- branch: \`${{ steps.meta.outputs.branch }}\`"
-            echo "- title: \`${{ steps.meta.outputs.title }}\`"
+            echo "- branch: \`${BUMP_BRANCH}\`"
+            echo "- title: \`${BUMP_TITLE}\`"
             echo "- token source: \`$token_source\`"
             echo "- compare URL: $compare_url"
             echo
@@ -344,5 +365,5 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           cat /tmp/legolas-gh-pr-create-error.txt
-          echo "::error::Unable to create a draft PR for ${{ steps.meta.outputs.branch }}. See the step summary for required repository or token changes."
+          echo "::error::Unable to create a draft PR for $BUMP_BRANCH. See the step summary for required repository or token changes."
           exit 1

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -31,11 +31,19 @@ jobs:
       - name: Resolve verification target
         id: target
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_SHA: ${{ github.sha }}
+          TARGET_SHA_INPUT: ${{ inputs.target_sha }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "sha=${{ inputs.target_sha }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if ! [[ "$TARGET_SHA_INPUT" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+              echo "target_sha must be a full 40-character commit SHA."
+              exit 1
+            fi
+            echo "sha=$TARGET_SHA_INPUT" >> "$GITHUB_OUTPUT"
           else
-            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "sha=$PUSH_SHA" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check out candidate commit
@@ -79,9 +87,11 @@ jobs:
 
       - name: Ensure release tag does not already exist
         shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.meta.outputs.release_tag }}
         run: |
-          if git ls-remote --exit-code --tags origin "${{ steps.meta.outputs.release_tag }}" >/dev/null 2>&1; then
-            echo "Release tag ${{ steps.meta.outputs.release_tag }} already exists on origin."
+          if git ls-remote --exit-code --tags origin "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release tag $RELEASE_TAG already exists on origin."
             exit 1
           fi
 
@@ -106,6 +116,9 @@ jobs:
       - name: Verify package tarball
         run: npm run pack:check
 
+      - name: Smoke test packed install
+        run: npm run pack:smoke
+
       - name: Smoke test packaged launcher
         run: |
           node ./bin/legolas.js --version
@@ -116,13 +129,17 @@ jobs:
       - name: Summarize verification
         if: always()
         shell: bash
+        env:
+          PACKAGE_VERSION: ${{ steps.meta.outputs.package_version }}
+          RELEASE_TAG: ${{ steps.meta.outputs.release_tag }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
         run: |
           {
             echo "### Release candidate verification"
             echo
-            echo "- target sha: \`${{ steps.target.outputs.sha }}\`"
-            echo "- candidate tag: \`${{ steps.meta.outputs.release_tag }}\`"
-            echo "- package version: \`${{ steps.meta.outputs.package_version }}\`"
+            echo "- target sha: \`${TARGET_SHA}\`"
+            echo "- candidate tag: \`${RELEASE_TAG}\`"
+            echo "- package version: \`${PACKAGE_VERSION}\`"
             echo
             echo "Confirm the matching \`legolas-ci\` run for the same commit before creating the tag."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,9 @@ jobs:
       - name: Verify package tarball
         run: npm run pack:check
 
+      - name: Smoke test packed install
+        run: npm run pack:smoke
+
       - name: Read package tarball identity
         id: package_artifact
         run: |

--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -342,22 +342,7 @@ fn analysis_value_to_object(analysis: &legolas_core::Analysis) -> Result<Map<Str
 }
 
 fn read_package_version() -> Result<String> {
-    let package_json = fs::read_to_string(workspace_root().join("package.json"))?;
-    let value = serde_json::from_str::<serde_json::Value>(&package_json)?;
-
-    Ok(value
-        .get("version")
-        .and_then(|version| version.as_str())
-        .unwrap_or("0.0.0")
-        .to_string())
-}
-
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|path| path.parent())
-        .expect("workspace root")
-        .to_path_buf()
+    Ok(env!("CARGO_PKG_VERSION").to_string())
 }
 
 fn resolve_loaded_config(parsed: &argv::CliArgs) -> Result<Option<LoadedConfig>> {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "optimize": "cargo run -p legolas-cli -- optimize",
     "smoke": "cargo run -p legolas-cli -- --version && cargo run -p legolas-cli -- help && cargo run -p legolas-cli -- scan . && cargo run -p legolas-cli -- visualize . && cargo run -p legolas-cli -- optimize . && node ./scripts/smoke-ci-command.mjs cargo",
     "pack:check": "node ./scripts/check-pack.mjs",
+    "pack:smoke": "node ./scripts/smoke-packed-install.mjs",
     "test": "cargo test --workspace",
     "test:release-contract": "node --test test/release-workflow-context.test.js test/release-plan.test.js test/bump-release-version.test.js test/github-action-wiring.test.js"
   },

--- a/scripts/bump-release-version.mjs
+++ b/scripts/bump-release-version.mjs
@@ -114,10 +114,14 @@ function isDirectExecutionEntry() {
     return false;
   }
 
-  return (
-    realpathSync(fileURLToPath(import.meta.url))
-    === realpathSync(path.resolve(process.argv[1]))
-  );
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url))
+      === realpathSync(path.resolve(process.argv[1]))
+    );
+  } catch {
+    return false;
+  }
 }
 
 const isDirectExecution = isDirectExecutionEntry();

--- a/scripts/smoke-packed-install.mjs
+++ b/scripts/smoke-packed-install.mjs
@@ -1,0 +1,103 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+const packageManifest = JSON.parse(
+  await readFile(path.join(projectRoot, "package.json"), "utf8"),
+);
+const smokeRoot = await mkdtemp(path.join(os.tmpdir(), "legolas-packed-install-"));
+const packDir = path.join(smokeRoot, "pack");
+const installDir = path.join(smokeRoot, "install");
+const cacheDir = path.join(smokeRoot, "npm-cache");
+
+await mkdir(packDir, { recursive: true });
+await mkdir(installDir, { recursive: true });
+await writeFile(
+  path.join(installDir, "package.json"),
+  `${JSON.stringify({ private: true, name: "legolas-packed-install-smoke" }, null, 2)}\n`,
+);
+
+const pack = run(npmCommand(), [
+  "pack",
+  "--json",
+  "--pack-destination",
+  packDir,
+  "--cache",
+  cacheDir,
+]);
+const [packResult] = JSON.parse(pack.stdout);
+const tarballPath = path.isAbsolute(packResult.filename)
+  ? packResult.filename
+  : path.join(packDir, packResult.filename);
+
+await assertFile(tarballPath, "npm pack did not produce a tarball");
+
+run(npmCommand(), [
+  "install",
+  "--no-audit",
+  "--no-fund",
+  "--cache",
+  cacheDir,
+  tarballPath,
+], { cwd: installDir });
+
+const binPath = path.join(
+  installDir,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "legolas.cmd" : "legolas",
+);
+await assertFile(binPath, "installed package did not expose node_modules/.bin/legolas");
+
+const version = runInstalledBinary(binPath, ["--version"], { cwd: installDir });
+const actualVersion = version.stdout.trim();
+
+if (actualVersion !== packageManifest.version) {
+  throw new Error(
+    `installed legolas --version returned ${actualVersion}, expected ${packageManifest.version}`,
+  );
+}
+
+console.log(`Verified packed install legolas --version ${actualVersion}.`);
+
+async function assertFile(filePath, message) {
+  const fileStat = await stat(filePath).catch(() => null);
+
+  if (!fileStat?.isFile()) {
+    throw new Error(`${message}: ${filePath}`);
+  }
+}
+
+function npmCommand() {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? projectRoot,
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed with ${result.status}\n${result.stdout}${result.stderr}`,
+    );
+  }
+
+  return result;
+}
+
+function runInstalledBinary(binPath, args, options = {}) {
+  if (process.platform !== "win32") {
+    return run(binPath, args, options);
+  }
+
+  return run(npmCommand(), ["exec", "--", "legolas", ...args], options);
+}

--- a/scripts/validate-release-wiring.mjs
+++ b/scripts/validate-release-wiring.mjs
@@ -14,6 +14,7 @@ export const releaseWiringRequiredFiles = {
   releasePlan: "scripts/release-plan.mjs",
   releaseHelpers: "scripts/lib/release.mjs",
   releaseBumpScript: "scripts/bump-release-version.mjs",
+  packedInstallSmoke: "scripts/smoke-packed-install.mjs",
   releaseContextTest: "test/release-workflow-context.test.js",
   releasePlanTest: "test/release-plan.test.js",
   releaseBumpTest: "test/bump-release-version.test.js",
@@ -33,6 +34,7 @@ export async function validateReleaseWiring(repoRoot = process.cwd()) {
   validateReleasePlanScript(fileContents.releasePlan);
   validateReleaseHelpers(fileContents.releaseHelpers);
   validateReleaseBumpScript(fileContents.releaseBumpScript);
+  validatePackedInstallSmoke(fileContents.packedInstallSmoke);
   validateTests(fileContents.releaseContextTest, fileContents.releasePlanTest, fileContents.releaseBumpTest, fileContents.githubActionWiringTest);
 
   return {
@@ -58,6 +60,7 @@ function validatePackageManifest(packageManifest) {
     packageManifest.scripts?.["test:release-contract"],
     "node --test test/release-workflow-context.test.js test/release-plan.test.js test/bump-release-version.test.js test/github-action-wiring.test.js",
   );
+  assert.equal(packageManifest.scripts?.["pack:smoke"], "node ./scripts/smoke-packed-install.mjs");
 }
 
 function validateCargoManifest(cargoManifestText, expectedVersion) {
@@ -77,6 +80,7 @@ function validateCiWorkflow(ciWorkflowText) {
   assertContains(ciWorkflowText, "Release Contract", "ci release contract job");
   assertContains(ciWorkflowText, "node ./scripts/validate-release-wiring.mjs", "ci release wiring validation");
   assertContains(ciWorkflowText, "npm run test:release-contract", "ci release contract tests");
+  assertContains(ciWorkflowText, "npm run pack:smoke", "ci packed install smoke");
 }
 
 function validateReleaseWorkflow(releaseText) {
@@ -95,6 +99,7 @@ function validateReleaseWorkflow(releaseText) {
   assertContains(releaseText, "ref: ${{ needs.validate-release-context.outputs.release_commit_sha }}", "release downstream sha checkout");
   assertContains(releaseText, "actions/upload-artifact@v4", "release binary artifact upload");
   assertContains(releaseText, "actions/download-artifact@v4", "release binary artifact download");
+  assertContains(releaseText, "npm run pack:smoke", "release packed install smoke");
   assertContains(releaseText, '--tag "$RELEASE_DIST_TAG"', "release npm dist-tag publish");
   assertContains(releaseText, "gh release upload", "release asset upload");
   assert.ok(!releaseText.includes("fetch-depth: 0"), "release workflow should not use full-history checkout");
@@ -103,18 +108,27 @@ function validateReleaseWorkflow(releaseText) {
 function validateReleaseCandidateWorkflow(releaseCandidateText) {
   assertContains(releaseCandidateText, "workflow_dispatch:", "release candidate manual trigger");
   assertContains(releaseCandidateText, "target_sha:", "release candidate target sha input");
+  assertContains(releaseCandidateText, "TARGET_SHA_INPUT: ${{ inputs.target_sha }}", "release candidate target sha env handoff");
+  assertContains(releaseCandidateText, "target_sha must be a full 40-character commit SHA", "release candidate target sha validation");
   assertContains(releaseCandidateText, "Ensure release tag does not already exist", "release candidate tag guard");
   assertContains(releaseCandidateText, "node ./scripts/validate-release-wiring.mjs", "release candidate release wiring validation");
   assertContains(releaseCandidateText, "npm run test:release-contract", "release candidate release tests");
   assertContains(releaseCandidateText, "cargo build --release -p legolas-cli", "release candidate release build");
   assertContains(releaseCandidateText, "node ./scripts/verify-vendor-layout.mjs", "release candidate vendor verification");
   assertContains(releaseCandidateText, "npm run pack:check", "release candidate pack check");
+  assertContains(releaseCandidateText, "npm run pack:smoke", "release candidate packed install smoke");
   assertContains(releaseCandidateText, "node ./scripts/smoke-ci-command.mjs launcher", "release candidate packaged launcher smoke");
+  assert.ok(
+    !releaseCandidateText.includes('"${{ inputs.target_sha }}"'),
+    "release candidate workflow should not interpolate target_sha directly inside bash",
+  );
 }
 
 function validateManualReleaseBumpWorkflow(manualReleaseBumpText) {
   assertContains(manualReleaseBumpText, "workflow_dispatch:", "manual bump workflow trigger");
   assertContains(manualReleaseBumpText, "dry_run:", "manual bump dry-run input");
+  assertContains(manualReleaseBumpText, "INPUT_TAG: ${{ inputs.tag }}", "manual bump tag env handoff");
+  assertContains(manualReleaseBumpText, 'tag="$INPUT_TAG"', "manual bump tag shell variable usage");
   assertContains(manualReleaseBumpText, "node ./scripts/bump-release-version.mjs", "manual bump script usage");
   assertContains(manualReleaseBumpText, "npm run test:release-contract", "manual bump release contract tests");
   assertContains(manualReleaseBumpText, "gh workflow run ci.yml --ref", "manual bump CI dispatch");
@@ -124,6 +138,10 @@ function validateManualReleaseBumpWorkflow(manualReleaseBumpText) {
   assertContains(manualReleaseBumpText, "skip-changelog", "manual bump skip-changelog label");
   assertContains(manualReleaseBumpText, "LEGOLAS_RELEASE_BOT_TOKEN", "manual bump dedicated PR token");
   assertContains(manualReleaseBumpText, "Unable to create a draft PR", "manual bump hard-fail PR creation");
+  assert.ok(
+    !manualReleaseBumpText.includes('tag="${{ inputs.tag }}"'),
+    "manual bump workflow should not interpolate input tag directly inside bash",
+  );
 }
 
 function validateReleaseContextAssertion(releaseContextAssertionText) {
@@ -153,6 +171,15 @@ function validateReleaseBumpScript(releaseBumpScriptText) {
   assertContains(releaseBumpScriptText, "createManualBumpBranchName", "release bump branch naming");
   assertContains(releaseBumpScriptText, "crates/legolas-cli/Cargo.toml", "release bump cargo manifest update");
   assertContains(releaseBumpScriptText, "assertReleaseUpgrade", "release bump upgrade guard");
+}
+
+function validatePackedInstallSmoke(packedInstallSmokeText) {
+  assertContains(packedInstallSmokeText, "npm", "packed install smoke npm usage");
+  assertContains(packedInstallSmokeText, "pack", "packed install smoke pack command");
+  assertContains(packedInstallSmokeText, "install", "packed install smoke install command");
+  assertContains(packedInstallSmokeText, "node_modules", "packed install smoke installed bin path");
+  assertContains(packedInstallSmokeText, "--version", "packed install smoke version command");
+  assertContains(packedInstallSmokeText, "exec", "packed install smoke Windows npm exec invocation");
 }
 
 function validateTests(releaseContextTest, releasePlanTest, releaseBumpTest, githubActionWiringTest) {

--- a/test/bump-release-version.test.js
+++ b/test/bump-release-version.test.js
@@ -1,13 +1,17 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   bumpReleaseVersion,
   createManualBumpBranchName,
 } from "../scripts/bump-release-version.mjs";
 import { createReleaseFixture } from "./helpers/release-fixture.mjs";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
 
 test("bumpReleaseVersion updates package.json and cargo manifest together", async () => {
   const repoRoot = await createReleaseFixture();
@@ -35,4 +39,19 @@ test("createManualBumpBranchName is deterministic per tag and base", () => {
     createManualBumpBranchName("v0.1.1", "master"),
     createManualBumpBranchName("v0.1.1-beta.1", "master"),
   );
+});
+
+test("bump module can be imported from node eval with tag argv", () => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      "import { createManualBumpBranchName } from './scripts/bump-release-version.mjs'; console.log(createManualBumpBranchName(process.argv[1]));",
+      "v0.1.1",
+    ],
+    { cwd: projectRoot, encoding: "utf8" },
+  );
+
+  assert.match(output, /^codex\/manual-bump-master-v0-1-1-[0-9a-f]{8}\n$/);
 });

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -24,7 +24,7 @@ async function copyReleaseWiringSupportFiles(repoRoot) {
 test("release wiring validation passes for the checked-in GitHub automation files", async () => {
   const summary = await validateReleaseWiring(process.cwd());
 
-  assert.equal(summary.checkedFiles.length, 14);
+  assert.equal(summary.checkedFiles.length, 15);
   assert.equal(summary.packageName, "@jeremyfellaz/legolas");
 });
 
@@ -34,7 +34,7 @@ test("release wiring validation accepts bumped manifest versions", async () => {
 
   const summary = await validateReleaseWiring(repoRoot);
 
-  assert.equal(summary.checkedFiles.length, 14);
+  assert.equal(summary.checkedFiles.length, 15);
   assert.equal(summary.packageName, "@jeremyfellaz/legolas");
 });
 
@@ -42,8 +42,9 @@ test("manual bump workflow validates the actual bump PR head for release candida
   const workflow = await readFile(".github/workflows/manual-release-bump.yml", "utf8");
 
   assert.match(workflow, /name: Resolve release candidate target/);
-  assert.match(workflow, /refs\/remotes\/origin\/\$\{\{ steps\.meta\.outputs\.branch \}\}/);
-  assert.match(workflow, /target_sha="\$\{\{ steps\.candidate_target\.outputs\.sha \}\}"/);
+  assert.match(workflow, /refs\/remotes\/origin\/\$\{BUMP_BRANCH\}/);
+  assert.match(workflow, /CANDIDATE_SHA: \$\{\{ steps\.candidate_target\.outputs\.sha \}\}/);
+  assert.match(workflow, /target_sha="\$CANDIDATE_SHA"/);
 });
 
 test("manual bump workflow dispatches a dispatch-enabled CI workflow", async () => {


### PR DESCRIPTION
## 배경

- PR #61 merge 후 independent review에서 실제 npm tarball 설치 환경의 `legolas --version` 실패가 확인되었습니다.
- 원인은 Rust CLI가 런타임에 build checkout의 `package.json`을 읽는 구조였고, 설치된 tarball 환경에서는 그 checkout 경로가 보장되지 않는다는 점입니다.

## 변경 사항

- `--version` 출력이 런타임 파일시스템 대신 `CARGO_PKG_VERSION`을 사용하도록 변경했습니다.
- manual bump workflow의 `node --input-type=module -e ... <tag>` import 경로가 direct-exec 판별에서 깨지지 않도록 방어했습니다.
- 실제 `npm pack` 결과물을 임시 프로젝트에 설치하고 `node_modules/.bin/legolas --version`을 실행하는 `pack:smoke` 검증을 추가했습니다.
- CI, release-candidate, release workflow가 packed install smoke를 실행하도록 연결했습니다.

## 검증

- `git diff --check`
- `cargo fmt --check`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/release-candidate.yml .github/workflows/manual-release-bump.yml`
- `node ./scripts/validate-release-wiring.mjs`
- `npm run test:release-contract`
- `cargo test -p legolas-cli prints_version_without_a_command`
- `cargo build --release -p legolas-cli`
- `node ./scripts/stage-local-vendor-binary.mjs`
- `node ./bin/legolas.js --version`
- `npm run pack:check`
- `npm run pack:smoke`
- `node ./scripts/bump-release-version.mjs v0.1.1` in clean `/tmp` copy, then `npm run test:release-contract`
- `npm test`

## 리스크

- 실제 tag 생성 및 publish는 실행하지 않았습니다.
- `vendor/aarch64-apple-darwin/`는 로컬 smoke 산출물이라 PR에 포함하지 않았습니다.
