### PR TITLE
fix(ci): release publish id 조회 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
           TAG_NAME: ${{ needs.validate-release-context.outputs.release_tag }}
           IS_PRERELEASE: ${{ needs.validate-release-context.outputs.is_prerelease }}
         run: |
-          RELEASE_ID="$(gh release view "$TAG_NAME" --json id --jq .id)"
+          RELEASE_ID="$(gh release view "$TAG_NAME" --json databaseId --jq .databaseId)"
 
           if [ "$IS_PRERELEASE" = "true" ]; then
             gh api \

--- a/scripts/validate-release-wiring.mjs
+++ b/scripts/validate-release-wiring.mjs
@@ -102,6 +102,11 @@ function validateReleaseWorkflow(releaseText) {
   assertContains(releaseText, "npm run pack:smoke", "release packed install smoke");
   assertContains(releaseText, '--tag "$RELEASE_DIST_TAG"', "release npm dist-tag publish");
   assertContains(releaseText, "gh release upload", "release asset upload");
+  assertContains(releaseText, "gh release view \"$TAG_NAME\" --json databaseId --jq .databaseId", "release REST release id lookup");
+  assert.ok(
+    !releaseText.includes("gh release view \"$TAG_NAME\" --json id --jq .id"),
+    "release workflow must not pass GraphQL release node IDs to REST release endpoints",
+  );
   assert.ok(!releaseText.includes("fetch-depth: 0"), "release workflow should not use full-history checkout");
 }
 

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -62,3 +62,11 @@ test("release workflow rejects tags whose commit is outside master", async () =>
   assert.match(workflow, /compare\/\$\{RELEASE_COMMIT_SHA\}\.\.\.master/);
   assert.match(workflow, /assertReleaseCommitReachableFromMaster/);
 });
+
+test("release workflow publishes releases with the REST database id", async () => {
+  const workflow = await readFile(".github/workflows/release.yml", "utf8");
+
+  assert.match(workflow, /gh release view "\$TAG_NAME" --json databaseId --jq \.databaseId/);
+  assert.doesNotMatch(workflow, /gh release view "\$TAG_NAME" --json id --jq \.id/);
+  assert.match(workflow, /repos\/\$\{GITHUB_REPOSITORY\}\/releases\/\$\{RELEASE_ID\}/);
+});


### PR DESCRIPTION
## 배경
- v0.1.0 release run의 `Publish GitHub release` 단계가 REST 404로 실패했습니다.
- `gh release view --json id`는 GraphQL node id를 반환하지만, REST `releases/{release_id}` 엔드포인트는 numeric database id를 요구합니다.

## 변경 사항
- release publish 단계에서 `id` 대신 `databaseId`를 조회하도록 수정했습니다.
- release wiring validator에 REST id 조회 계약을 추가했습니다.
- GitHub Actions wiring 테스트에 같은 회귀를 막는 검증을 추가했습니다.

## 검증
- `node ./scripts/validate-release-wiring.mjs`
- `npm run test:release-contract` (18/18)
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `$devils-advocate-review-loop` Round 1: Critical/High findings 없음

## 브랜치 / 워크트리
- base: `master`
- head: `codex/fix-release-publish-id`
- worktree: `/Users/pjw/workspace/legolas`

## 비고
- release rerun/publish automation은 명시 확인 없이 실행하지 않았습니다.