### PR TITLE
docs(readme): 현재 CLI 사용법 문서화

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -8,67 +8,189 @@
   <a href="./README.ja.md">日本語</a>
 </p>
 
-Slim bundles with precision.
+**Slim bundles with precision.**
 
-Legolas is a Rust-powered CLI, shipped through npm with native binaries, that inspects modern web projects for bundle weight, duplicate packages, tree-shaking misses, and lazy-loading opportunities.
+Legolas is a Rust-powered CLI, distributed through npm with native binaries, for finding bundle-weight problems in modern web projects. It combines source-import analysis, lockfile inspection, optional bundle-artifact evidence, budget gates, and machine-readable output so optimization work can move from local triage to CI.
 
-## Why Legolas
+## What It Checks
 
-Modern web apps rarely slow down because of one big mistake. They usually get slower as small sources of bundle weight accumulate:
+- Framework and project shape for Next.js, Vite, Webpack, Rollup, Astro, Nuxt, React, Vue, and Svelte projects
+- Static and dynamic imports in JavaScript, TypeScript, JSX, TSX, Vue, and Svelte files
+- Heavy client dependencies such as charting, editor, icon, SDK, animation, map, monitoring, and UI packages
+- Duplicate package versions from npm, pnpm, and Yarn lockfiles
+- Tree-shaking risks, including broad icon imports, root utility imports, and repeated locale subpath imports
+- Lazy-loading opportunities on route-like, dashboard, modal, editor, map, and chart surfaces
+- Server/client boundary warnings for patterns such as browser surfaces importing Node-only modules
+- Bundle artifacts when present, including Webpack `stats.json` and esbuild/Rollup `meta.json` files in known locations
 
-- oversized client-side dependencies
-- duplicated package versions
-- static imports that should be deferred
-- icon and utility imports that weaken tree shaking
+Legolas estimates savings directionally. Treat the numbers as prioritization signals, then confirm production impact with your own bundle analyzer and performance telemetry.
 
-Legolas scans those signals and turns them into an optimization report that humans can read and act on quickly.
+## Install and Run
+
+Run without adding a dependency:
+
+```bash
+npx @jeremyfellaz/legolas scan .
+npx @jeremyfellaz/legolas visualize .
+npx @jeremyfellaz/legolas optimize .
+```
+
+Or install it in a project:
+
+```bash
+npm install -D @jeremyfellaz/legolas
+npx legolas scan .
+```
+
+The npm package requires Node.js `>=18.17` and ships prebuilt Rust binaries for macOS `arm64/x64`, Linux `x64` with glibc, and Windows `x64`.
 
 ## Commands
 
+| Command | Purpose | Common options |
+| --- | --- | --- |
+| `scan` | Full analysis report with dependency, lockfile, import, artifact, and boundary findings | `[path]`, `--config`, `--json`, `--sarif`, `--write-baseline`, `--baseline`, `--regression-only` |
+| `visualize` | Text bars for estimated dependency weight and duplicate package pressure | `[path]`, `--config`, `--limit` |
+| `optimize` | Ranked action list with difficulty, confidence, target files, and suggested fixes | `[path]`, `--config`, `--top`, `--json`, `--baseline`, `--regression-only` |
+| `budget` | Evaluates bundle-health budget rules | `[path]`, `--config`, `--json`, `--baseline`, `--regression-only` |
+| `ci` | CI-oriented budget gate that exits with code `1` on failures | `[path]`, `--config`, `--json`, `--sarif`, `--baseline`, `--regression-only` |
+
+Use `legolas help` for the exact CLI contract.
+
 ```bash
-npx @jeremyfellaz/legolas scan
-npx @jeremyfellaz/legolas visualize
-npx @jeremyfellaz/legolas optimize
+npx @jeremyfellaz/legolas help
 ```
 
-You can also point Legolas at a specific project path:
+## Common Workflows
+
+Scan an app:
 
 ```bash
-cargo run -p legolas-cli -- scan ./apps/storefront
-cargo run -p legolas-cli -- visualize . --limit 12
-cargo run -p legolas-cli -- optimize . --top 7
+npx @jeremyfellaz/legolas scan ./apps/storefront
 ```
 
-## What The Current MVP Does
+Get JSON for automation:
 
-- detects frameworks such as Next.js, Vite, Webpack, Astro, Nuxt, React, Vue, and Svelte
-- identifies heavyweight frontend dependencies from a curated knowledge base
-- parses `package-lock.json`, `pnpm-lock.yaml`, and `yarn.lock` to spot duplicate package versions
-- scans source files for static imports, dynamic imports, and tree-shaking anti-patterns
-- recommends lazy-loading candidates for chart, editor, map, dashboard, modal, and route-like surfaces
-- estimates directional payload savings and LCP improvement
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --json
+```
 
-## Example
+Upload SARIF from a scan-capable workflow:
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --sarif
+```
+
+Create and compare a baseline:
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --write-baseline ./legolas-baseline.json --json
+npx @jeremyfellaz/legolas scan ./apps/storefront --baseline ./legolas-baseline.json --regression-only --json
+```
+
+Fail CI on budget regressions:
+
+```bash
+npx @jeremyfellaz/legolas ci ./apps/storefront --baseline ./legolas-baseline.json --regression-only --sarif
+```
+
+## Configuration
+
+Legolas automatically discovers `legolas.config.json` from the project root. You can also pass a file explicitly with `--config`.
+
+```json
+{
+  "scan": {
+    "path": "src"
+  },
+  "visualize": {
+    "limit": 12
+  },
+  "optimize": {
+    "top": 7
+  },
+  "budget": {
+    "rules": {
+      "potentialKbSaved": {
+        "warnAt": 40,
+        "failAt": 80
+      },
+      "duplicatePackageCount": {
+        "warnAt": 2,
+        "failAt": 4
+      },
+      "dynamicImportCount": {
+        "warnAt": 1,
+        "failAt": 0
+      }
+    }
+  }
+}
+```
+
+`potentialKbSaved` and `duplicatePackageCount` are maximum-style rules: higher actual values are worse. `dynamicImportCount` is a minimum-style rule: too few dynamic imports can warn or fail.
+
+## Output Formats
+
+- `scan --json` and `optimize --json` emit `legolas.analysis.v1`, documented by [docs/schema/analysis.v1.schema.json](./docs/schema/analysis.v1.schema.json).
+- `budget --json` emits `legolas.budget.v1`, documented by [docs/schema/budget.v1.schema.json](./docs/schema/budget.v1.schema.json).
+- `ci --json` emits `legolas.ci.v1`, documented by [docs/schema/ci.v1.schema.json](./docs/schema/ci.v1.schema.json).
+- `scan --sarif` and `ci --sarif` emit SARIF `2.1.0`, documented by [docs/schema/sarif.v1.json](./docs/schema/sarif.v1.json).
+
+`--json` and `--sarif` are mutually exclusive. `ci` returns a non-zero exit code when budget rules fail.
+
+## Example Output
+
+`scan` summarizes the project, impact estimate, evidence, and finding groups:
 
 ```text
-Legolas scan for storefront
-Project root: /workspace/storefront
+Legolas scan for basic-parity-app
+Project root: <PROJECT_ROOT>
 Mode: heuristic
-Frameworks: Next.js, React
+Frameworks: Vite, React
 Package manager: pnpm
-Scanned 84 source files and 53 imported packages
+Scanned 1 source files and 4 imported packages
 
-Potential payload reduction: ~246 KB
-Estimated LCP improvement: ~517 ms
-Medium impact: there are several meaningful bundle wins available.
+Potential payload reduction: ~366 KB
+Estimated LCP improvement: ~769 ms
+High impact: the project has clear opportunities to reduce initial payload size.
+
+Heaviest known dependencies:
+- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s).
+  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`optimize` turns findings into ranked actions:
+
+```text
+Legolas optimize for basic-parity-app
+
+1. Review chart.js upfront bundle weight [hard | high confidence | ~160 KB]
+   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
+   targets: src/Dashboard.tsx
+   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`budget` reports pass, warn, or fail for each rule:
+
+```text
+Legolas budget for basic-parity-app
+
+Overall status: Fail
+
+Rule results:
+- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
+- dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)
 ```
 
 ## Development
 
 ```bash
-cargo test --workspace
 cargo run -p legolas-cli -- help
+cargo test --workspace
 ```
+
+Contributor workflows use `cargo run -p legolas-cli -- ...` as the source of truth. The npm package wraps the compiled Rust binary from `vendor/<triple>/legolas[.exe]`. When release packaging has staged those vendor binaries, validate the package layout with `npm run pack:check`.
 
 ## Open Source
 
@@ -77,9 +199,3 @@ cargo run -p legolas-cli -- help
 - Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
 - Security policy: [SECURITY.md](./SECURITY.md)
 - Sponsor: [GitHub Sponsors](https://github.com/sponsors/JeremyDev87)
-
-## Notes
-
-- The current release is heuristic-first. If bundle artifacts such as `stats.json` or `meta.json` exist, Legolas detects them, but full artifact-native analysis is still the next natural step.
-- The current npm package ships prebuilt binaries for macOS `x64/arm64`, Linux `x64` glibc, and Windows `x64`.
-- The npm package ships platform-specific Rust binaries under `vendor/<triple>/legolas[.exe]`, while contributor workflows use `cargo run -p legolas-cli -- ...` as the source of truth.

--- a/README.es.md
+++ b/README.es.md
@@ -8,78 +8,196 @@
   <a href="./README.ja.md">日本語</a>
 </p>
 
-Slim bundles with precision.
+**Paquetes más ligeros, con precisión.**
 
-Legolas es una CLI impulsada por Rust, distribuida por npm con binarios nativos, que inspecciona proyectos web modernos para detectar peso de bundle, paquetes duplicados, fallos de tree-shaking y oportunidades de lazy loading.
+Legolas es una CLI impulsada por Rust y distribuida por npm con binarios nativos. Sirve para encontrar problemas de peso del paquete generado en proyectos web modernos mediante análisis de importaciones de código fuente, revisión de archivos de bloqueo, evidencia opcional de artefactos de empaquetado, reglas de presupuesto y salidas legibles por máquinas.
 
-## Por Qué Legolas
+## Qué analiza
 
-Las aplicaciones web modernas rara vez se vuelven lentas por un solo gran error. Normalmente se degradan cuando se acumulan pequeñas fuentes de peso:
+- Forma del proyecto y marcos de trabajo como Next.js, Vite, Webpack, Rollup, Astro, Nuxt, React, Vue y Svelte
+- Importaciones estáticas y dinámicas en archivos JavaScript, TypeScript, JSX, TSX, Vue y Svelte
+- Dependencias cliente pesadas de gráficos, editores, iconos, SDK, animación, mapas, monitoreo e interfaces
+- Versiones duplicadas de paquetes en archivos de bloqueo de npm, pnpm y Yarn
+- Riesgos para la eliminación de código no usado, como importaciones amplias de iconos, importaciones raíz de utilidades e importaciones repetidas de subrutas de localización
+- Oportunidades de carga diferida en rutas, paneles, modales, editores, mapas y gráficos
+- Advertencias de frontera servidor/cliente, por ejemplo superficies de navegador que importan módulos exclusivos de Node
+- Artefactos de empaquetado cuando existen, incluidos `stats.json` de Webpack y `meta.json` de esbuild/Rollup en ubicaciones conocidas
 
-- dependencias cliente demasiado grandes
-- versiones duplicadas del mismo paquete
-- imports estáticos que deberían cargarse más tarde
-- imports de iconos y utilidades que debilitan el tree shaking
+Las estimaciones de ahorro de Legolas son señales de priorización. Confirma el impacto real con el analizador de paquetes y la telemetría de rendimiento de tu proyecto.
 
-Legolas analiza esas señales y las convierte en un informe de optimización fácil de leer y accionar.
+## Instalación y ejecución
+
+Puedes ejecutarlo sin añadir una dependencia:
+
+```bash
+npx @jeremyfellaz/legolas scan .
+npx @jeremyfellaz/legolas visualize .
+npx @jeremyfellaz/legolas optimize .
+```
+
+También puedes instalarlo en el proyecto:
+
+```bash
+npm install -D @jeremyfellaz/legolas
+npx legolas scan .
+```
+
+El paquete npm requiere Node.js `>=18.17` e incluye binarios Rust precompilados para macOS `arm64/x64`, Linux `x64` con glibc y Windows `x64`.
 
 ## Comandos
 
+| Comando | Propósito | Opciones comunes |
+| --- | --- | --- |
+| `scan` | Informe completo con hallazgos de dependencias, archivos de bloqueo, importaciones, artefactos y fronteras | `[path]`, `--config`, `--json`, `--sarif`, `--write-baseline`, `--baseline`, `--regression-only` |
+| `visualize` | Barras de texto para peso estimado de dependencias y presión de paquetes duplicados | `[path]`, `--config`, `--limit` |
+| `optimize` | Lista priorizada de acciones con dificultad, confianza, archivos objetivo y correcciones sugeridas | `[path]`, `--config`, `--top`, `--json`, `--baseline`, `--regression-only` |
+| `budget` | Evalúa reglas de presupuesto de salud del paquete generado | `[path]`, `--config`, `--json`, `--baseline`, `--regression-only` |
+| `ci` | Puerta para CI que devuelve código de salida `1` cuando fallan las reglas | `[path]`, `--config`, `--json`, `--sarif`, `--baseline`, `--regression-only` |
+
+Usa `legolas help` para ver el contrato exacto de la CLI.
+
 ```bash
-npx @jeremyfellaz/legolas scan
-npx @jeremyfellaz/legolas visualize
-npx @jeremyfellaz/legolas optimize
+npx @jeremyfellaz/legolas help
 ```
 
-También puedes analizar una ruta de proyecto específica:
+## Flujos comunes
+
+Analizar una aplicación:
 
 ```bash
-cargo run -p legolas-cli -- scan ./apps/storefront
-cargo run -p legolas-cli -- visualize . --limit 12
-cargo run -p legolas-cli -- optimize . --top 7
+npx @jeremyfellaz/legolas scan ./apps/storefront
 ```
 
-## Qué Hace El MVP Actual
+Obtener JSON para automatización:
 
-- detecta frameworks como Next.js, Vite, Webpack, Astro, Nuxt, React, Vue y Svelte
-- identifica dependencias frontend pesadas usando una base de conocimiento curada
-- analiza `package-lock.json`, `pnpm-lock.yaml` y `yarn.lock` para encontrar versiones duplicadas
-- escanea archivos fuente para detectar imports estáticos, dinámicos y anti-patrones de tree-shaking
-- recomienda candidatos para lazy loading en superficies como chart, editor, map, dashboard, modal y routes
-- estima de forma orientativa el ahorro de payload y la mejora de LCP
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --json
+```
 
-## Ejemplo
+Emitir SARIF desde un análisis:
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --sarif
+```
+
+Crear y comparar una línea base:
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --write-baseline ./legolas-baseline.json --json
+npx @jeremyfellaz/legolas scan ./apps/storefront --baseline ./legolas-baseline.json --regression-only --json
+```
+
+Fallar CI cuando haya regresiones de presupuesto:
+
+```bash
+npx @jeremyfellaz/legolas ci ./apps/storefront --baseline ./legolas-baseline.json --regression-only --sarif
+```
+
+## Configuración
+
+Legolas descubre automáticamente `legolas.config.json` desde la raíz del proyecto. También puedes pasar un archivo de forma explícita con `--config`.
+
+```json
+{
+  "scan": {
+    "path": "src"
+  },
+  "visualize": {
+    "limit": 12
+  },
+  "optimize": {
+    "top": 7
+  },
+  "budget": {
+    "rules": {
+      "potentialKbSaved": {
+        "warnAt": 40,
+        "failAt": 80
+      },
+      "duplicatePackageCount": {
+        "warnAt": 2,
+        "failAt": 4
+      },
+      "dynamicImportCount": {
+        "warnAt": 1,
+        "failAt": 0
+      }
+    }
+  }
+}
+```
+
+`potentialKbSaved` y `duplicatePackageCount` son reglas de máximo: valores reales más altos son peores. `dynamicImportCount` es una regla de mínimo: muy pocas importaciones dinámicas pueden producir advertencia o fallo.
+
+## Formatos de salida
+
+- `scan --json` y `optimize --json` emiten `legolas.analysis.v1`, documentado en [docs/schema/analysis.v1.schema.json](./docs/schema/analysis.v1.schema.json).
+- `budget --json` emite `legolas.budget.v1`, documentado en [docs/schema/budget.v1.schema.json](./docs/schema/budget.v1.schema.json).
+- `ci --json` emite `legolas.ci.v1`, documentado en [docs/schema/ci.v1.schema.json](./docs/schema/ci.v1.schema.json).
+- `scan --sarif` y `ci --sarif` emiten SARIF `2.1.0`, documentado en [docs/schema/sarif.v1.json](./docs/schema/sarif.v1.json).
+
+`--json` y `--sarif` no se pueden usar juntos. `ci` devuelve un código de salida distinto de cero cuando fallan las reglas de presupuesto.
+
+## Ejemplos de resultado
+
+Los siguientes bloques son salidas reales de la CLI, por eso se mantienen en inglés.
+
+`scan` resume el proyecto, la estimación de impacto, la evidencia y los grupos de hallazgos:
 
 ```text
-Legolas scan for storefront
-Project root: /workspace/storefront
+Legolas scan for basic-parity-app
+Project root: <PROJECT_ROOT>
 Mode: heuristic
-Frameworks: Next.js, React
+Frameworks: Vite, React
 Package manager: pnpm
-Scanned 84 source files and 53 imported packages
+Scanned 1 source files and 4 imported packages
 
-Potential payload reduction: ~246 KB
-Estimated LCP improvement: ~517 ms
-Medium impact: there are several meaningful bundle wins available.
+Potential payload reduction: ~366 KB
+Estimated LCP improvement: ~769 ms
+High impact: the project has clear opportunities to reduce initial payload size.
+
+Heaviest known dependencies:
+- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s).
+  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`optimize` convierte hallazgos en acciones priorizadas:
+
+```text
+Legolas optimize for basic-parity-app
+
+1. Review chart.js upfront bundle weight [hard | high confidence | ~160 KB]
+   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
+   targets: src/Dashboard.tsx
+   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`budget` informa aprobación, advertencia o fallo para cada regla:
+
+```text
+Legolas budget for basic-parity-app
+
+Overall status: Fail
+
+Rule results:
+- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
+- dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)
 ```
 
 ## Desarrollo
 
 ```bash
-cargo test --workspace
 cargo run -p legolas-cli -- help
+cargo test --workspace
 ```
+
+Los flujos de contribución usan `cargo run -p legolas-cli -- ...` como referencia. El paquete npm ejecuta el binario Rust compilado desde `vendor/<triple>/legolas[.exe]`. Cuando el empaquetado de una versión ya haya preparado esos binarios de vendor, valida la disposición del paquete con `npm run pack:check`.
 
 ## Código Abierto
 
-- License: [MIT](./LICENSE)
-- Contributing guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
-- Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
-- Security policy: [SECURITY.md](./SECURITY.md)
-- Sponsor: [GitHub Sponsors](https://github.com/sponsors/JeremyDev87)
-
-## Notas
-
-- La versión actual es principalmente heurística. Si existen artefactos de bundle como `stats.json` o `meta.json`, Legolas los detecta, pero el análisis completo basado en artifacts sigue siendo el siguiente paso natural.
-- El paquete npm actual distribuye binarios precompilados para macOS `x64/arm64`, Linux `x64` con glibc y Windows `x64`.
-- El paquete npm distribuye binarios Rust por plataforma bajo `vendor/<triple>/legolas[.exe]`, mientras que la ruta de contribución del repositorio usa `cargo run -p legolas-cli -- ...` como referencia.
+- Licencia: [MIT](./LICENSE)
+- Guía de contribución: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Código de conducta: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- Política de seguridad: [SECURITY.md](./SECURITY.md)
+- Patrocinio: [GitHub Sponsors](https://github.com/sponsors/JeremyDev87)

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,78 +8,196 @@
   <strong>日本語</strong>
 </p>
 
-Slim bundles with precision.
+**精密にバンドルを軽くします。**
 
-Legolas は、npm パッケージ内に native Rust binary を同梱して配布する CLI で、モダンな Web プロジェクトのバンドルサイズ、重複パッケージ、tree-shaking の取りこぼし、lazy loading の余地を点検します。
+Legolas は、npm で配布される Rust 製 CLI です。モダンな Web プロジェクトのバンドル重量問題を見つけるために、ソースのインポート解析、ロックファイル検査、必要に応じたバンドル成果物の証拠、予算ゲート、機械処理しやすい出力をまとめて提供します。
 
-## なぜ Legolas か
+## 何を検査するか
 
-現代の Web アプリは、ひとつの大きな失敗だけで遅くなるわけではありません。多くの場合、次のような小さな重さが積み重なって遅くなります。
+- Next.js、Vite、Webpack、Rollup、Astro、Nuxt、React、Vue、Svelte プロジェクトのフレームワークと構成
+- JavaScript、TypeScript、JSX、TSX、Vue、Svelte ファイルの静的インポートと動的インポート
+- チャート、エディタ、アイコン、SDK、アニメーション、地図、監視、UI 系の重いクライアント依存
+- npm、pnpm、Yarn のロックファイルにある重複パッケージバージョン
+- 広すぎるアイコンインポート、ルートユーティリティインポート、繰り返しのロケールサブパスインポートなどのツリーシェイキングリスク
+- ルート、ダッシュボード、モーダル、エディタ、地図、チャート領域の遅延読み込み候補
+- ブラウザ側の領域が Node 専用モジュールを取り込むようなサーバー/クライアント境界の警告
+- 既知の場所にある Webpack `stats.json`、esbuild/Rollup `meta.json` などのバンドル成果物
 
-- 大きすぎるクライアント依存
-- 複数バージョンで重複しているパッケージ
-- 後から読み込めるのに静的 import されているコード
-- tree-shaking を弱めるアイコンやユーティリティの import
+Legolas の削減見積もりは優先順位付けのための方向性シグナルです。実際の配信影響は、プロジェクト側のバンドル解析ツールとパフォーマンス計測で確認してください。
 
-Legolas はこうしたシグナルをスキャンし、人がすぐに判断できる最適化レポートへ変換します。
+## インストールと実行
+
+依存関係を追加せずに実行できます。
+
+```bash
+npx @jeremyfellaz/legolas scan .
+npx @jeremyfellaz/legolas visualize .
+npx @jeremyfellaz/legolas optimize .
+```
+
+プロジェクトの開発依存として追加することもできます。
+
+```bash
+npm install -D @jeremyfellaz/legolas
+npx legolas scan .
+```
+
+npm パッケージは Node.js `>=18.17` を必要とします。同梱の Rust バイナリは macOS `arm64/x64`、glibc 版 Linux `x64`、Windows `x64` をサポートします。
 
 ## コマンド
 
+| コマンド | 用途 | 主なオプション |
+| --- | --- | --- |
+| `scan` | 依存、ロックファイル、インポート、成果物、境界警告を含む完全な解析レポート | `[path]`, `--config`, `--json`, `--sarif`, `--write-baseline`, `--baseline`, `--regression-only` |
+| `visualize` | 推定依存重量と重複パッケージ圧力をテキストバーで表示 | `[path]`, `--config`, `--limit` |
+| `optimize` | 難易度、信頼度、対象ファイル、推奨修正を含む優先順位付きアクション一覧 | `[path]`, `--config`, `--top`, `--json`, `--baseline`, `--regression-only` |
+| `budget` | バンドル健全性の予算ルールを評価 | `[path]`, `--config`, `--json`, `--baseline`, `--regression-only` |
+| `ci` | 予算ルール失敗時に終了コード `1` を返す CI 向けゲート | `[path]`, `--config`, `--json`, `--sarif`, `--baseline`, `--regression-only` |
+
+正確な CLI 契約は `legolas help` で確認できます。
+
 ```bash
-npx @jeremyfellaz/legolas scan
-npx @jeremyfellaz/legolas visualize
-npx @jeremyfellaz/legolas optimize
+npx @jeremyfellaz/legolas help
 ```
 
-特定のプロジェクトパスを直接指定して解析することもできます。
+## よく使う流れ
+
+アプリをスキャンします。
 
 ```bash
-cargo run -p legolas-cli -- scan ./apps/storefront
-cargo run -p legolas-cli -- visualize . --limit 12
-cargo run -p legolas-cli -- optimize . --top 7
+npx @jeremyfellaz/legolas scan ./apps/storefront
 ```
 
-## 現在の MVP でできること
+自動化向けに JSON を出力します。
 
-- Next.js、Vite、Webpack、Astro、Nuxt、React、Vue、Svelte などのフレームワークを検出
-- 内蔵の知識ベースを使って重いフロントエンド依存を特定
-- `package-lock.json`、`pnpm-lock.yaml`、`yarn.lock` を解析して重複バージョンを検出
-- ソースファイル内の静的 import、動的 import、tree-shaking のアンチパターンをスキャン
-- chart、editor、map、dashboard、modal、route 系の領域で lazy loading 候補を提案
-- 削減できそうな payload と LCP 改善幅を方向性ベースで推定
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --json
+```
 
-## 例
+スキャン結果を SARIF として出力します。
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --sarif
+```
+
+基準線を作成して比較します。
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --write-baseline ./legolas-baseline.json --json
+npx @jeremyfellaz/legolas scan ./apps/storefront --baseline ./legolas-baseline.json --regression-only --json
+```
+
+予算回帰がある場合に CI を失敗させます。
+
+```bash
+npx @jeremyfellaz/legolas ci ./apps/storefront --baseline ./legolas-baseline.json --regression-only --sarif
+```
+
+## 設定
+
+Legolas はプロジェクトルートの `legolas.config.json` を自動検出します。`--config` で設定ファイルを明示することもできます。
+
+```json
+{
+  "scan": {
+    "path": "src"
+  },
+  "visualize": {
+    "limit": 12
+  },
+  "optimize": {
+    "top": 7
+  },
+  "budget": {
+    "rules": {
+      "potentialKbSaved": {
+        "warnAt": 40,
+        "failAt": 80
+      },
+      "duplicatePackageCount": {
+        "warnAt": 2,
+        "failAt": 4
+      },
+      "dynamicImportCount": {
+        "warnAt": 1,
+        "failAt": 0
+      }
+    }
+  }
+}
+```
+
+`potentialKbSaved` と `duplicatePackageCount` は最大値ルールです。実際の値が高いほど悪い状態です。`dynamicImportCount` は最小値ルールです。動的インポートが少なすぎると警告または失敗になります。
+
+## 出力形式
+
+- `scan --json` と `optimize --json` は [docs/schema/analysis.v1.schema.json](./docs/schema/analysis.v1.schema.json) で文書化された `legolas.analysis.v1` を出力します。
+- `budget --json` は [docs/schema/budget.v1.schema.json](./docs/schema/budget.v1.schema.json) で文書化された `legolas.budget.v1` を出力します。
+- `ci --json` は [docs/schema/ci.v1.schema.json](./docs/schema/ci.v1.schema.json) で文書化された `legolas.ci.v1` を出力します。
+- `scan --sarif` と `ci --sarif` は [docs/schema/sarif.v1.json](./docs/schema/sarif.v1.json) で文書化された SARIF `2.1.0` を出力します。
+
+`--json` と `--sarif` は同時に使えません。`ci` は予算ルールが失敗すると 0 以外の終了コードを返します。
+
+## 出力例
+
+以下のブロックは CLI の実出力例なので英語のまま掲載しています。
+
+`scan` はプロジェクト概要、影響見積もり、証拠、発見グループを表示します。
 
 ```text
-Legolas scan for storefront
-Project root: /workspace/storefront
+Legolas scan for basic-parity-app
+Project root: <PROJECT_ROOT>
 Mode: heuristic
-Frameworks: Next.js, React
+Frameworks: Vite, React
 Package manager: pnpm
-Scanned 84 source files and 53 imported packages
+Scanned 1 source files and 4 imported packages
 
-Potential payload reduction: ~246 KB
-Estimated LCP improvement: ~517 ms
-Medium impact: there are several meaningful bundle wins available.
+Potential payload reduction: ~366 KB
+Estimated LCP improvement: ~769 ms
+High impact: the project has clear opportunities to reduce initial payload size.
+
+Heaviest known dependencies:
+- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s).
+  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`optimize` は発見内容を優先順位付きアクションに変換します。
+
+```text
+Legolas optimize for basic-parity-app
+
+1. Review chart.js upfront bundle weight [hard | high confidence | ~160 KB]
+   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
+   targets: src/Dashboard.tsx
+   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`budget` は各ルールの合格、警告、失敗を表示します。
+
+```text
+Legolas budget for basic-parity-app
+
+Overall status: Fail
+
+Rule results:
+- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
+- dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)
 ```
 
 ## 開発
 
 ```bash
-cargo test --workspace
 cargo run -p legolas-cli -- help
+cargo test --workspace
 ```
+
+コントリビューター向けの作業では `cargo run -p legolas-cli -- ...` を基準にします。npm パッケージは `vendor/<triple>/legolas[.exe]` にあるコンパイル済み Rust バイナリを実行します。リリース用のパッケージングで vendor バイナリを配置した後は、`npm run pack:check` でパッケージ構成を検証します。
 
 ## オープンソース
 
-- License: [MIT](./LICENSE)
-- Contributing guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
-- Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
-- Security policy: [SECURITY.md](./SECURITY.md)
-- Sponsor: [GitHub Sponsors](https://github.com/sponsors/JeremyDev87)
-
-## 補足
-
-- 現在のリリースは heuristic-first な方針です。`stats.json` や `meta.json` のようなバンドル成果物があれば存在は検出しますが、artifact-native の本格解析は次の自然な拡張です。
-- 現在の npm 配布物の prebuilt binary は macOS `x64/arm64`、Linux `x64` glibc、Windows `x64` をサポートします。
-- npm 配布物は `vendor/<triple>/legolas[.exe]` layout で platform ごとの Rust binary を含み、repository 側の contributor path は `cargo run -p legolas-cli -- ...` を基準にします。
+- ライセンス: [MIT](./LICENSE)
+- コントリビューションガイド: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- 行動規範: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- セキュリティポリシー: [SECURITY.md](./SECURITY.md)
+- スポンサー: [GitHub Sponsors](https://github.com/sponsors/JeremyDev87)

--- a/README.md
+++ b/README.md
@@ -8,87 +8,196 @@
   <a href="./README.ja.md">日本語</a>
 </p>
 
-Slim bundles with precision.
+**정밀하게 번들을 줄입니다.**
 
-> Quick Overview (EN): Legolas is a Rust-powered CLI, shipped through npm with native binaries, for analyzing bundle weight, duplicate packages, tree-shaking misses, and lazy-loading opportunities in modern web projects.
->
-> Quick Start:
-> ```bash
-> npx @jeremyfellaz/legolas scan
-> npx @jeremyfellaz/legolas visualize
-> npx @jeremyfellaz/legolas optimize
-> ```
+Legolas는 npm으로 배포되는 Rust 기반 CLI입니다. 최신 웹 프로젝트에서 번들 무게 문제를 찾기 위해 소스 가져오기 분석, 잠금 파일 검사, 선택적 번들 산출물 증거, 예산 게이트, 기계가 읽을 수 있는 출력을 함께 제공합니다.
 
-Legolas는 npm package 안에 native Rust binary를 담아 배포하는 CLI로, 최신 웹 프로젝트의 번들 크기, 중복 패키지, tree-shaking 누수, lazy loading 기회를 점검합니다.
+## 무엇을 검사하나요
 
-## 왜 Legolas인가
+- Next.js, Vite, Webpack, Rollup, Astro, Nuxt, React, Vue, Svelte 프로젝트의 프레임워크와 프로젝트 형태
+- JavaScript, TypeScript, JSX, TSX, Vue, Svelte 파일의 정적 가져오기와 동적 가져오기
+- 차트, 에디터, 아이콘, SDK, 애니메이션, 지도, 모니터링, UI 계열의 무거운 클라이언트 의존성
+- npm, pnpm, Yarn 잠금 파일에서 발견되는 중복 패키지 버전
+- 넓은 아이콘 가져오기, 루트 유틸리티 가져오기, 반복되는 지역화 하위 경로 가져오기 같은 트리 셰이킹 위험
+- 라우트, 대시보드, 모달, 에디터, 지도, 차트 영역의 지연 로딩 후보
+- 브라우저 영역이 Node 전용 모듈을 가져오는 경우 같은 서버/클라이언트 경계 경고
+- Webpack `stats.json`, esbuild/Rollup `meta.json` 등 알려진 위치의 번들 산출물
 
-현대 웹앱은 한 번의 큰 실수 때문에만 느려지지 않습니다. 보통 아래 같은 작은 무게들이 쌓이면서 점점 느려집니다.
+Legolas의 절감 추정치는 우선순위를 정하기 위한 방향성 신호입니다. 실제 배포 영향은 프로젝트의 번들 분석기와 성능 텔레메트리로 확인하세요.
 
-- 불필요하게 큰 클라이언트 의존성
-- 여러 버전으로 중복 설치된 패키지
-- 나중에 불러와도 되는 정적 import
-- tree-shaking을 방해하는 아이콘/유틸리티 import
+## 설치와 실행
 
-Legolas는 이런 신호들을 스캔해서 사람이 바로 읽고 판단할 수 있는 최적화 리포트로 바꿔줍니다.
+의존성을 추가하지 않고 바로 실행할 수 있습니다.
+
+```bash
+npx @jeremyfellaz/legolas scan .
+npx @jeremyfellaz/legolas visualize .
+npx @jeremyfellaz/legolas optimize .
+```
+
+프로젝트 개발 의존성으로 설치할 수도 있습니다.
+
+```bash
+npm install -D @jeremyfellaz/legolas
+npx legolas scan .
+```
+
+npm 패키지는 Node.js `>=18.17`을 요구합니다. 포함된 Rust 바이너리는 macOS `arm64/x64`, glibc 기반 Linux `x64`, Windows `x64`를 지원합니다.
 
 ## 명령어
 
+| 명령어 | 용도 | 자주 쓰는 옵션 |
+| --- | --- | --- |
+| `scan` | 의존성, 잠금 파일, 가져오기, 산출물, 경계 경고를 포함한 전체 분석 보고서 | `[path]`, `--config`, `--json`, `--sarif`, `--write-baseline`, `--baseline`, `--regression-only` |
+| `visualize` | 추정 의존성 무게와 중복 패키지 압력을 텍스트 막대로 표시 | `[path]`, `--config`, `--limit` |
+| `optimize` | 난이도, 신뢰도, 대상 파일, 권장 수정안을 포함한 우선순위 작업 목록 | `[path]`, `--config`, `--top`, `--json`, `--baseline`, `--regression-only` |
+| `budget` | 번들 상태 예산 규칙 평가 | `[path]`, `--config`, `--json`, `--baseline`, `--regression-only` |
+| `ci` | 예산 실패 시 종료 코드 `1`을 반환하는 CI용 게이트 | `[path]`, `--config`, `--json`, `--sarif`, `--baseline`, `--regression-only` |
+
+정확한 CLI 계약은 `legolas help`로 확인할 수 있습니다.
+
 ```bash
-npx @jeremyfellaz/legolas scan
-npx @jeremyfellaz/legolas visualize
-npx @jeremyfellaz/legolas optimize
+npx @jeremyfellaz/legolas help
 ```
 
-특정 프로젝트 경로를 직접 넘겨서 분석할 수도 있습니다.
+## 자주 쓰는 흐름
+
+앱을 스캔합니다.
 
 ```bash
-cargo run -p legolas-cli -- scan ./apps/storefront
-cargo run -p legolas-cli -- visualize . --limit 12
-cargo run -p legolas-cli -- optimize . --top 7
+npx @jeremyfellaz/legolas scan ./apps/storefront
 ```
 
-## 현재 MVP가 하는 일
+자동화에서 사용할 JSON을 출력합니다.
 
-- Next.js, Vite, Webpack, Astro, Nuxt, React, Vue, Svelte 같은 프로젝트 프레임워크 감지
-- 사전 정의된 지식 베이스를 이용해 무거운 프론트엔드 의존성 식별
-- `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`에서 중복 패키지 버전 탐지
-- 소스 파일에서 정적 import, 동적 import, tree-shaking 안티패턴 스캔
-- chart, editor, map, dashboard, modal, route 성격의 영역에서 lazy loading 후보 추천
-- 절감 가능한 payload 크기와 LCP 개선 폭을 방향성 기준으로 추정
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --json
+```
 
-## 예시
+스캔 결과를 SARIF로 출력합니다.
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --sarif
+```
+
+기준선을 만들고 비교합니다.
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --write-baseline ./legolas-baseline.json --json
+npx @jeremyfellaz/legolas scan ./apps/storefront --baseline ./legolas-baseline.json --regression-only --json
+```
+
+예산 회귀가 있으면 CI를 실패시킵니다.
+
+```bash
+npx @jeremyfellaz/legolas ci ./apps/storefront --baseline ./legolas-baseline.json --regression-only --sarif
+```
+
+## 설정
+
+Legolas는 프로젝트 루트의 `legolas.config.json`을 자동으로 찾습니다. `--config`로 설정 파일을 직접 지정할 수도 있습니다.
+
+```json
+{
+  "scan": {
+    "path": "src"
+  },
+  "visualize": {
+    "limit": 12
+  },
+  "optimize": {
+    "top": 7
+  },
+  "budget": {
+    "rules": {
+      "potentialKbSaved": {
+        "warnAt": 40,
+        "failAt": 80
+      },
+      "duplicatePackageCount": {
+        "warnAt": 2,
+        "failAt": 4
+      },
+      "dynamicImportCount": {
+        "warnAt": 1,
+        "failAt": 0
+      }
+    }
+  }
+}
+```
+
+`potentialKbSaved`와 `duplicatePackageCount`는 최댓값 규칙입니다. 실제 값이 커질수록 나쁩니다. `dynamicImportCount`는 최솟값 규칙입니다. 동적 가져오기가 너무 적으면 경고나 실패가 발생할 수 있습니다.
+
+## 출력 형식
+
+- `scan --json`과 `optimize --json`은 [docs/schema/analysis.v1.schema.json](./docs/schema/analysis.v1.schema.json)에 문서화된 `legolas.analysis.v1`을 출력합니다.
+- `budget --json`은 [docs/schema/budget.v1.schema.json](./docs/schema/budget.v1.schema.json)에 문서화된 `legolas.budget.v1`을 출력합니다.
+- `ci --json`은 [docs/schema/ci.v1.schema.json](./docs/schema/ci.v1.schema.json)에 문서화된 `legolas.ci.v1`을 출력합니다.
+- `scan --sarif`와 `ci --sarif`는 [docs/schema/sarif.v1.json](./docs/schema/sarif.v1.json)에 문서화된 SARIF `2.1.0`을 출력합니다.
+
+`--json`과 `--sarif`는 함께 사용할 수 없습니다. `ci`는 예산 규칙 실패 시 0이 아닌 종료 코드를 반환합니다.
+
+## 결과 예시
+
+아래 블록은 실제 CLI 출력 예시이므로 영어 원문을 유지합니다.
+
+`scan`은 프로젝트 요약, 영향 추정치, 증거, 발견 항목 그룹을 보여줍니다.
 
 ```text
-Legolas scan for storefront
-Project root: /workspace/storefront
+Legolas scan for basic-parity-app
+Project root: <PROJECT_ROOT>
 Mode: heuristic
-Frameworks: Next.js, React
+Frameworks: Vite, React
 Package manager: pnpm
-Scanned 84 source files and 53 imported packages
+Scanned 1 source files and 4 imported packages
 
-Potential payload reduction: ~246 KB
-Estimated LCP improvement: ~517 ms
-Medium impact: there are several meaningful bundle wins available.
+Potential payload reduction: ~366 KB
+Estimated LCP improvement: ~769 ms
+High impact: the project has clear opportunities to reduce initial payload size.
+
+Heaviest known dependencies:
+- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s).
+  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`optimize`는 발견 항목을 우선순위 작업으로 바꿉니다.
+
+```text
+Legolas optimize for basic-parity-app
+
+1. Review chart.js upfront bundle weight [hard | high confidence | ~160 KB]
+   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
+   targets: src/Dashboard.tsx
+   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`budget`은 각 규칙의 통과, 경고, 실패 상태를 보여줍니다.
+
+```text
+Legolas budget for basic-parity-app
+
+Overall status: Fail
+
+Rule results:
+- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
+- dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)
 ```
 
 ## 개발
 
 ```bash
-cargo test --workspace
 cargo run -p legolas-cli -- help
+cargo test --workspace
 ```
+
+기여자 워크플로우는 `cargo run -p legolas-cli -- ...`를 기준으로 합니다. npm 패키지는 `vendor/<triple>/legolas[.exe]`에 포함된 컴파일된 Rust 바이너리를 실행합니다. 릴리스 패키징 과정에서 vendor 바이너리를 준비한 뒤에는 `npm run pack:check`로 패키지 구성을 검증합니다.
 
 ## 오픈소스
 
-- License: [MIT](./LICENSE)
-- Contributing guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
-- Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
-- Security policy: [SECURITY.md](./SECURITY.md)
-- Sponsor: [GitHub Sponsors](https://github.com/sponsors/JeremyDev87)
-
-## 참고
-
-- 현재 릴리스는 heuristic-first 접근입니다. `stats.json`, `meta.json` 같은 번들 산출물이 있으면 존재는 감지하지만, artifact-native 정밀 분석은 다음 단계의 자연스러운 확장입니다.
-- 현재 npm 배포본의 prebuilt binary는 macOS `x64/arm64`, Linux `x64` glibc, Windows `x64`만 지원합니다.
-- npm 배포본은 `vendor/<triple>/legolas[.exe]` layout으로 platform별 Rust binary를 싣고, repository contributor path는 `cargo run -p legolas-cli -- ...`를 기준으로 유지합니다.
+- 라이선스: [MIT](./LICENSE)
+- 기여 안내: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- 행동 강령: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- 보안 정책: [SECURITY.md](./SECURITY.md)
+- 후원: [GitHub Sponsors](https://github.com/sponsors/JeremyDev87)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,78 +8,196 @@
   <a href="./README.ja.md">日本語</a>
 </p>
 
-Slim bundles with precision.
+**精准瘦身前端包体积。**
 
-Legolas 是一个由 Rust 驱动、通过 npm 分发原生二进制的 CLI，用来检查现代 Web 项目的打包体积、重复依赖、tree-shaking 漏损以及 lazy loading 优化机会。
+Legolas 是一个通过 npm 分发、由 Rust 驱动的 CLI。它面向现代 Web 项目的包体积问题，结合源码导入分析、锁文件检查、可选的构建产物证据、预算门禁以及机器可读输出，帮助把本地排查结果接入持续集成流程。
 
-## 为什么选择 Legolas
+## 检查内容
 
-现代 Web 应用通常不是因为一次巨大的错误才变慢，而是因为很多小的体积问题不断累积：
+- Next.js、Vite、Webpack、Rollup、Astro、Nuxt、React、Vue、Svelte 项目的框架和项目形态
+- JavaScript、TypeScript、JSX、TSX、Vue、Svelte 文件中的静态导入和动态导入
+- 图表、编辑器、图标、SDK、动画、地图、监控、界面组件等较重的客户端依赖
+- npm、pnpm、Yarn 锁文件中的重复包版本
+- 影响摇树优化的风险，例如宽泛图标导入、根工具库导入、重复本地化子路径导入
+- 路由、仪表盘、弹窗、编辑器、地图、图表区域的延迟加载候选项
+- 服务端/客户端边界警告，例如浏览器侧代码导入 Node 专用模块
+- 已知位置中的构建产物，例如 Webpack `stats.json` 和 esbuild/Rollup `meta.json`
 
-- 过大的前端依赖
-- 多版本重复安装的包
-- 本应延后加载的静态 import
-- 削弱 tree-shaking 的图标和工具库 import
+Legolas 的节省估算用于确定优化优先级。真实上线影响仍应通过项目自己的包分析器和性能遥测来确认。
 
-Legolas 会扫描这些信号，并把它们整理成便于人工阅读和决策的优化报告。
+## 安装与运行
+
+无需添加依赖即可运行：
+
+```bash
+npx @jeremyfellaz/legolas scan .
+npx @jeremyfellaz/legolas visualize .
+npx @jeremyfellaz/legolas optimize .
+```
+
+也可以安装到项目中：
+
+```bash
+npm install -D @jeremyfellaz/legolas
+npx legolas scan .
+```
+
+npm 包要求 Node.js `>=18.17`，并内置面向 macOS `arm64/x64`、glibc Linux `x64`、Windows `x64` 的预构建 Rust 二进制。
 
 ## 命令
 
+| 命令 | 用途 | 常用选项 |
+| --- | --- | --- |
+| `scan` | 输出包含依赖、锁文件、导入、构建产物、边界警告的完整分析报告 | `[path]`, `--config`, `--json`, `--sarif`, `--write-baseline`, `--baseline`, `--regression-only` |
+| `visualize` | 用文本条展示估算依赖重量和重复包压力 | `[path]`, `--config`, `--limit` |
+| `optimize` | 输出按优先级排序的操作列表，包含难度、可信度、目标文件和建议修复方式 | `[path]`, `--config`, `--top`, `--json`, `--baseline`, `--regression-only` |
+| `budget` | 评估包体积健康预算规则 | `[path]`, `--config`, `--json`, `--baseline`, `--regression-only` |
+| `ci` | 面向持续集成的门禁，预算规则失败时返回退出码 `1` | `[path]`, `--config`, `--json`, `--sarif`, `--baseline`, `--regression-only` |
+
+使用 `legolas help` 查看准确的 CLI 契约。
+
 ```bash
-npx @jeremyfellaz/legolas scan
-npx @jeremyfellaz/legolas visualize
-npx @jeremyfellaz/legolas optimize
+npx @jeremyfellaz/legolas help
 ```
 
-也可以直接指定某个项目路径进行分析：
+## 常用流程
+
+扫描一个应用：
 
 ```bash
-cargo run -p legolas-cli -- scan ./apps/storefront
-cargo run -p legolas-cli -- visualize . --limit 12
-cargo run -p legolas-cli -- optimize . --top 7
+npx @jeremyfellaz/legolas scan ./apps/storefront
 ```
 
-## 当前 MVP 的能力
+输出自动化可用的 JSON：
 
-- 检测 Next.js、Vite、Webpack、Astro、Nuxt、React、Vue、Svelte 等项目框架
-- 基于内置知识库识别较重的前端依赖
-- 解析 `package-lock.json`、`pnpm-lock.yaml`、`yarn.lock` 以发现重复包版本
-- 扫描源码中的静态 import、动态 import 以及 tree-shaking 反模式
-- 为 chart、editor、map、dashboard、modal、route 等区域推荐 lazy loading 候选项
-- 提供可节省 payload 与 LCP 改善幅度的方向性估算
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --json
+```
 
-## 示例
+以 SARIF 输出扫描结果：
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --sarif
+```
+
+创建并比较基线：
+
+```bash
+npx @jeremyfellaz/legolas scan ./apps/storefront --write-baseline ./legolas-baseline.json --json
+npx @jeremyfellaz/legolas scan ./apps/storefront --baseline ./legolas-baseline.json --regression-only --json
+```
+
+当预算回归出现时让持续集成失败：
+
+```bash
+npx @jeremyfellaz/legolas ci ./apps/storefront --baseline ./legolas-baseline.json --regression-only --sarif
+```
+
+## 配置
+
+Legolas 会从项目根目录自动发现 `legolas.config.json`。也可以通过 `--config` 显式指定配置文件。
+
+```json
+{
+  "scan": {
+    "path": "src"
+  },
+  "visualize": {
+    "limit": 12
+  },
+  "optimize": {
+    "top": 7
+  },
+  "budget": {
+    "rules": {
+      "potentialKbSaved": {
+        "warnAt": 40,
+        "failAt": 80
+      },
+      "duplicatePackageCount": {
+        "warnAt": 2,
+        "failAt": 4
+      },
+      "dynamicImportCount": {
+        "warnAt": 1,
+        "failAt": 0
+      }
+    }
+  }
+}
+```
+
+`potentialKbSaved` 和 `duplicatePackageCount` 是最大值规则，实际值越高越差。`dynamicImportCount` 是最小值规则，动态导入过少时可能触发警告或失败。
+
+## 输出格式
+
+- `scan --json` 和 `optimize --json` 输出 `legolas.analysis.v1`，结构见 [docs/schema/analysis.v1.schema.json](./docs/schema/analysis.v1.schema.json)。
+- `budget --json` 输出 `legolas.budget.v1`，结构见 [docs/schema/budget.v1.schema.json](./docs/schema/budget.v1.schema.json)。
+- `ci --json` 输出 `legolas.ci.v1`，结构见 [docs/schema/ci.v1.schema.json](./docs/schema/ci.v1.schema.json)。
+- `scan --sarif` 和 `ci --sarif` 输出 SARIF `2.1.0`，结构见 [docs/schema/sarif.v1.json](./docs/schema/sarif.v1.json)。
+
+`--json` 和 `--sarif` 不能同时使用。`ci` 在预算规则失败时返回非零退出码。
+
+## 结果示例
+
+以下代码块是 CLI 的真实输出示例，因此保留英文原文。
+
+`scan` 会汇总项目、影响估算、证据和发现项分组：
 
 ```text
-Legolas scan for storefront
-Project root: /workspace/storefront
+Legolas scan for basic-parity-app
+Project root: <PROJECT_ROOT>
 Mode: heuristic
-Frameworks: Next.js, React
+Frameworks: Vite, React
 Package manager: pnpm
-Scanned 84 source files and 53 imported packages
+Scanned 1 source files and 4 imported packages
 
-Potential payload reduction: ~246 KB
-Estimated LCP improvement: ~517 ms
-Medium impact: there are several meaningful bundle wins available.
+Potential payload reduction: ~366 KB
+Estimated LCP improvement: ~769 ms
+High impact: the project has clear opportunities to reduce initial payload size.
+
+Heaviest known dependencies:
+- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s).
+  evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`optimize` 会把发现项转换为按优先级排序的操作：
+
+```text
+Legolas optimize for basic-parity-app
+
+1. Review chart.js upfront bundle weight [hard | high confidence | ~160 KB]
+   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
+   targets: src/Dashboard.tsx
+   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+```
+
+`budget` 会报告每条规则的通过、警告或失败状态：
+
+```text
+Legolas budget for basic-parity-app
+
+Overall status: Fail
+
+Rule results:
+- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
+- dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)
 ```
 
 ## 开发
 
 ```bash
-cargo test --workspace
 cargo run -p legolas-cli -- help
+cargo test --workspace
 ```
 
-## 开源信息
+贡献者工作流以 `cargo run -p legolas-cli -- ...` 为准。npm 包会执行 `vendor/<triple>/legolas[.exe]` 中的已编译 Rust 二进制。发布打包流程准备好 vendor 二进制之后，再使用 `npm run pack:check` 验证包结构。
 
-- License: [MIT](./LICENSE)
-- Contributing guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
-- Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
-- Security policy: [SECURITY.md](./SECURITY.md)
-- Sponsor: [GitHub Sponsors](https://github.com/sponsors/JeremyDev87)
+## 开源
 
-## 说明
-
-- 当前版本以启发式分析为主。如果项目中存在 `stats.json`、`meta.json` 之类的打包产物，Legolas 会识别到它们，但完整的 artifact-native 精确分析仍是下一阶段的自然扩展。
-- 当前 npm 发布物提供 macOS `x64/arm64`、Linux `x64` glibc、Windows `x64` 的预构建二进制。
-- npm 发布物会把各平台 Rust 二进制放在 `vendor/<triple>/legolas[.exe]` 下，而仓库贡献路径则以 `cargo run -p legolas-cli -- ...` 为准。
+- 许可证：[MIT](./LICENSE)
+- 贡献指南：[CONTRIBUTING.md](./CONTRIBUTING.md)
+- 行为准则：[CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- 安全政策：[SECURITY.md](./SECURITY.md)
+- 赞助：[GitHub Sponsors](https://github.com/sponsors/JeremyDev87)

--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -34,7 +34,7 @@ Slim bundles with precision.
 Usage:
   legolas scan [path] [--config file] [--json | --sarif] [--write-baseline file] [--baseline file --regression-only]
   legolas visualize [path] [--config file] [--limit 10]
-  legolas optimize [path] [--config file] [--top 5] [--baseline file --regression-only]
+  legolas optimize [path] [--config file] [--top 5] [--json] [--baseline file --regression-only]
   legolas budget [path] [--config file] [--json] [--baseline file --regression-only]
   legolas ci [path] [--config file] [--json | --sarif] [--baseline file --regression-only]
   legolas help

--- a/tests/oracles/cli/help.txt
+++ b/tests/oracles/cli/help.txt
@@ -4,7 +4,7 @@ Slim bundles with precision.
 Usage:
   legolas scan [path] [--config file] [--json | --sarif] [--write-baseline file] [--baseline file --regression-only]
   legolas visualize [path] [--config file] [--limit 10]
-  legolas optimize [path] [--config file] [--top 5] [--baseline file --regression-only]
+  legolas optimize [path] [--config file] [--top 5] [--json] [--baseline file --regression-only]
   legolas budget [path] [--config file] [--json] [--baseline file --regression-only]
   legolas ci [path] [--config file] [--json | --sarif] [--baseline file --regression-only]
   legolas help


### PR DESCRIPTION
## 배경

README가 언어별로 분리되어 있지만, 일부 문서에는 다른 언어 표현이 섞여 있고 현재 Rust CLI 기능과 맞지 않는 오래된 MVP 설명이 남아 있었습니다.

## 변경 사항

- 한국어, 영어, 스페인어, 일본어, 중국어 간 README 구조를 맞췄습니다.
- 현재 CLI 계약에 맞춰 `scan`, `visualize`, `optimize`, `budget`, `ci` 사용법을 정리했습니다.
- `--json`, `--sarif`, `--config`, baseline/regression-only 흐름과 schema 링크를 추가했습니다.
- 실제 fixture 출력에 맞춘 `scan`, `optimize`, `budget` 예시를 보강했습니다.
- 일반 본문은 각 문서 언어에 맞게 정리하고, 실제 CLI 출력 예시는 원문 그대로 유지했습니다.

## 검증

- `cargo run -p legolas-cli -- help`
- `cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app`
- `cargo run -p legolas-cli -- visualize tests/fixtures/parity/basic-app --limit 12`
- `cargo run -p legolas-cli -- optimize tests/fixtures/parity/basic-app --top 5`
- `cargo run -p legolas-cli -- optimize tests/fixtures/parity/basic-app --json`
- `cargo run -p legolas-cli -- budget tests/fixtures/parity/basic-app`
- `cargo test --workspace`
- `git diff --check`
- Devil's Advocate fresh-session review: Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- base: `master`
- head: `codex/readme-current-cli-docs`
- worktree: `/Users/pjw/workspace/legolas`

## 참고

- `npm run pack:check`는 현재 source checkout에 vendor 바이너리가 없어서 실행하지 않았습니다. README에는 release packaging 과정에서 vendor 바이너리를 준비한 뒤 실행하는 검증으로 설명했습니다.
