### PR TITLE
fix(ci): release Cargo 버전 추출 수정

### DIFF
--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
           current_version="$(node -p "require('./package.json').version")"
-          current_cargo_version="$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' crates/legolas-cli/Cargo.toml | head -n 1)"
+          current_cargo_version="$(awk -F '"' '/^version[[:space:]]*=[[:space:]]*"/ { print $2; exit }' crates/legolas-cli/Cargo.toml)"
           expected_version="${tag#v}"
           branch="$(node --input-type=module -e "import { createManualBumpBranchName } from './scripts/bump-release-version.mjs'; console.log(createManualBumpBranchName(process.argv[1]));" "$tag")"
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: |
           package_version="$(node -p "require('./package.json').version")"
-          cargo_version="$(sed -n 's/^version = "\\(.*\\)"$/\\1/p' crates/legolas-cli/Cargo.toml | head -n 1)"
+          cargo_version="$(awk -F '"' '/^version[[:space:]]*=[[:space:]]*"/ { print $2; exit }' crates/legolas-cli/Cargo.toml)"
           release_tag="v${package_version}"
 
           if [ -z "$cargo_version" ]; then

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -55,6 +55,18 @@ test("manual bump workflow dispatches a dispatch-enabled CI workflow", async () 
   assert.match(manualBumpWorkflow, /gh workflow run ci\.yml --ref/);
 });
 
+test("release workflows read Cargo manifest versions with a shell-safe parser", async () => {
+  const manualBumpWorkflow = await readFile(".github/workflows/manual-release-bump.yml", "utf8");
+  const releaseCandidateWorkflow = await readFile(".github/workflows/release-candidate.yml", "utf8");
+  const cargoVersionSedParser = /sed -n .*crates\/legolas-cli\/Cargo\.toml/;
+  const cargoVersionParser = /awk -F '"' '\/\^version\[\[:space:\]\]\*=\[\[:space:\]\]\*"\/ \{ print \$2; exit \}' crates\/legolas-cli\/Cargo\.toml/;
+
+  assert.doesNotMatch(manualBumpWorkflow, cargoVersionSedParser);
+  assert.doesNotMatch(releaseCandidateWorkflow, cargoVersionSedParser);
+  assert.match(manualBumpWorkflow, cargoVersionParser);
+  assert.match(releaseCandidateWorkflow, cargoVersionParser);
+});
+
 test("release workflow rejects tags whose commit is outside master", async () => {
   const workflow = await readFile(".github/workflows/release.yml", "utf8");
 


### PR DESCRIPTION
## 배경

Manual Release Bump workflow가 `crates/legolas-cli/Cargo.toml` version을 읽지 못해 `Resolve bump metadata` 단계에서 실패했습니다.

## 변경 사항

- manual release bump와 release candidate workflow의 Cargo version 추출을 shell-safe한 `awk` 파서로 변경했습니다.
- 동일한 fragile `sed` 파서가 재도입되지 않도록 release wiring 회귀 테스트를 추가했습니다.

## 검증

- `npm run test:release-contract`
- `git diff --check`
- `-advocate-review-loop` Round 1 Low 1건 수정 후 Round 2 findings 없음

## 브랜치 / 워크트리

- branch: `codex/fix-release-bump-cargo-version`
- worktree: `/Users/pjw/workspace/legolas`