### PR TITLE
test: 릴리스 버전 출력 기대값 동기화

### DIFF
--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -20,7 +20,7 @@ fn prints_version_without_a_command() {
         assert!(output.status.success());
         assert_eq!(
             support::normalize_cli_output(&String::from_utf8(output.stdout).expect("stdout")),
-            support::read_oracle("cli/version.txt")
+            support::expected_version_output()
         );
         assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
     }

--- a/crates/legolas-cli/tests/config_contract.rs
+++ b/crates/legolas-cli/tests/config_contract.rs
@@ -145,7 +145,7 @@ fn help_and_version_do_not_touch_invalid_discovered_config() {
     assert!(version_output.status.success());
     assert_eq!(
         support::normalize_cli_output(&stdout(&version_output)),
-        support::read_oracle("cli/version.txt")
+        support::expected_version_output()
     );
     assert_eq!(stderr(&version_output), "");
 }

--- a/crates/legolas-cli/tests/support/mod.rs
+++ b/crates/legolas-cli/tests/support/mod.rs
@@ -22,6 +22,11 @@ pub fn read_oracle(relative_path: &str) -> String {
 }
 
 #[allow(dead_code)]
+pub fn expected_version_output() -> String {
+    format!("{}\n", env!("CARGO_PKG_VERSION"))
+}
+
+#[allow(dead_code)]
 pub fn normalize_cli_output(output: &str) -> String {
     to_posix(output.to_string()).replace(
         &to_posix(


### PR DESCRIPTION
## 배경

릴리스 버전 bump 이후 `--version` 계약 테스트가 정적 oracle 파일의 이전 버전에 묶이면, 실제 CLI 출력이 정상이어도 테스트가 불필요하게 깨질 수 있습니다.

## 변경 사항

- CLI `--version` 기대값을 `tests/oracles/cli/version.txt` 대신 `env!("CARGO_PKG_VERSION")` 기반 helper로 계산하게 변경했습니다.
- invalid config 환경에서도 `--version`이 config를 읽지 않는다는 기존 계약 테스트가 동일한 동적 기대값을 쓰게 정리했습니다.

## 검증

- `git diff --cached --check`
- `cargo fmt --check`
- `cargo test -p legolas-cli --test cli_contract --test config_contract`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `$devils-advocate-review-loop`: fresh-session Round 1 findings 없음, Critical/High 0

## 브랜치 / 워크트리

- branch: `codex/release-bump-version-test`
- worktree: `/Users/pjw/workspace/legolas`
