### PR TITLE
fix: 수동 릴리스 bump Cargo.lock 포함

### DIFF
--- a/.github/workflows/manual-release-bump.yml
+++ b/.github/workflows/manual-release-bump.yml
@@ -119,14 +119,14 @@ jobs:
           # shellcheck disable=SC2016
           node --input-type=module -e '
             import { execFileSync } from "node:child_process";
-            import { versionFilePaths } from "./scripts/bump-release-version.mjs";
+            import { validatedVersionFilePaths } from "./scripts/bump-release-version.mjs";
 
             const changedFiles = execFileSync("git", ["diff", "--name-only"], { encoding: "utf8" })
               .trim()
               .split("\n")
               .filter(Boolean)
               .sort();
-            const expectedFiles = [...versionFilePaths].sort();
+            const expectedFiles = [...validatedVersionFilePaths].sort();
 
             if (JSON.stringify(changedFiles) !== JSON.stringify(expectedFiles)) {
               throw new Error(`Unexpected changed files after validation: ${changedFiles.join(", ")}`);
@@ -186,7 +186,7 @@ jobs:
             # shellcheck disable=SC2016
             node --input-type=module -e '
               import { execFileSync } from "node:child_process";
-              import { versionFilePaths } from "./scripts/bump-release-version.mjs";
+              import { validatedVersionFilePaths } from "./scripts/bump-release-version.mjs";
 
               const branch = process.argv[1];
               const expectedVersion = process.argv[2];
@@ -199,7 +199,7 @@ jobs:
                 .split("\n")
                 .filter(Boolean)
                 .sort();
-              const expectedFiles = [...versionFilePaths].sort();
+              const expectedFiles = [...validatedVersionFilePaths].sort();
 
               if (JSON.stringify(diffFiles) !== JSON.stringify(expectedFiles)) {
                 throw new Error(`Existing PR is not a version-only bump: ${diffFiles.join(", ")}`);
@@ -254,7 +254,7 @@ jobs:
           fi
 
           git switch -C "$BUMP_BRANCH"
-          git add package.json crates/legolas-cli/Cargo.toml
+          git add package.json crates/legolas-cli/Cargo.toml Cargo.lock
           git commit -m "$BUMP_TITLE"
           git push "${lease_args[@]}" -u origin "$BUMP_BRANCH"
 
@@ -310,7 +310,7 @@ jobs:
             "" \
             "## 변경 사항 / Changes" \
             "" \
-            "- \`package.json\` 과 \`crates/legolas-cli/Cargo.toml\` version을 \`${RELEASE_VERSION}\`으로 맞췄습니다." \
+            "- \`package.json\`, \`crates/legolas-cli/Cargo.toml\`, \`Cargo.lock\` version을 \`${RELEASE_VERSION}\`으로 맞췄습니다." \
             "" \
             "## 검증 / Verification" \
             "" \

--- a/scripts/bump-release-version.mjs
+++ b/scripts/bump-release-version.mjs
@@ -13,6 +13,11 @@ export const versionFilePaths = [
   "crates/legolas-cli/Cargo.toml",
 ];
 
+export const validatedVersionFilePaths = [
+  ...versionFilePaths,
+  "Cargo.lock",
+];
+
 export function normalizeReleaseTag(input) {
   return input.startsWith("v") ? input : `v${input}`;
 }

--- a/test/bump-release-version.test.js
+++ b/test/bump-release-version.test.js
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 import {
   bumpReleaseVersion,
   createManualBumpBranchName,
+  validatedVersionFilePaths,
+  versionFilePaths,
 } from "../scripts/bump-release-version.mjs";
 import { createReleaseFixture } from "./helpers/release-fixture.mjs";
 
@@ -28,6 +30,18 @@ test("bumpReleaseVersion updates package.json and cargo manifest together", asyn
 
   assert.equal(packageManifest.version, "0.1.1");
   assert.match(cargoManifest, /^version\s*=\s*"0\.1\.1"$/m);
+});
+
+test("release bump distinguishes direct manifest edits from validated lockfile edits", () => {
+  assert.deepEqual(versionFilePaths, [
+    "package.json",
+    "crates/legolas-cli/Cargo.toml",
+  ]);
+  assert.deepEqual(validatedVersionFilePaths, [
+    "package.json",
+    "crates/legolas-cli/Cargo.toml",
+    "Cargo.lock",
+  ]);
 });
 
 test("createManualBumpBranchName is deterministic per tag and base", () => {

--- a/test/github-action-wiring.test.js
+++ b/test/github-action-wiring.test.js
@@ -47,6 +47,13 @@ test("manual bump workflow validates the actual bump PR head for release candida
   assert.match(workflow, /target_sha="\$CANDIDATE_SHA"/);
 });
 
+test("manual bump workflow commits validated Cargo lockfile changes", async () => {
+  const workflow = await readFile(".github/workflows/manual-release-bump.yml", "utf8");
+
+  assert.match(workflow, /validatedVersionFilePaths/);
+  assert.match(workflow, /git add package\.json crates\/legolas-cli\/Cargo\.toml Cargo\.lock/);
+});
+
 test("manual bump workflow dispatches a dispatch-enabled CI workflow", async () => {
   const ciWorkflow = await readFile(".github/workflows/ci.yml", "utf8");
   const manualBumpWorkflow = await readFile(".github/workflows/manual-release-bump.yml", "utf8");


### PR DESCRIPTION
## 배경

Manual Release Bump run 24944567069/job 73043661318에서 `npm test` 이후 `Cargo.lock`이 정상 갱신됐지만, post-validation changed-file gate가 manifest 2개만 허용해 실패했습니다.

## 변경 사항

- 직접 bump 파일 목록은 `package.json`, `crates/legolas-cli/Cargo.toml`로 유지했습니다.
- 검증 이후 및 기존 bump PR diff 검사용 목록에는 `Cargo.lock`을 포함했습니다.
- bump branch commit 단계가 `Cargo.lock`도 함께 stage하도록 수정했습니다.
- release contract 테스트에 파일 목록 분리와 workflow staging 회귀 검사를 추가했습니다.

## 검증

- `npm run test:release-contract`
- `git diff --check`
- isolated post-bump repro: `node ./scripts/bump-release-version.mjs v0.1.1` -> immediate changed-file gate -> `npm run test:release-contract` -> `npm test` -> post-validation changed-file gate
- `-advocate-review-loop` Round 1: findings 없음, gate_result pass

## 리스크

- 실제 release tag 생성이나 package publish는 실행하지 않았습니다.
- 원격 CI 결과는 PR 생성 후 확인합니다.