### PR TITLE
fix: 소스 체크아웃 런처 fallback 추가

### DIFF
--- a/bin/legolas.js
+++ b/bin/legolas.js
@@ -16,27 +16,47 @@ if (!hostSupport.supported) {
 const binaryPath = path.join(projectRoot, "vendor", hostSupport.targetTriple, hostSupport.binaryName);
 
 if (!existsSync(binaryPath)) {
+  const cargoManifestPath = path.join(projectRoot, "crates", "legolas-cli", "Cargo.toml");
+
+  if (existsSync(cargoManifestPath)) {
+    exitFromSpawnResult(spawnSourceCheckout(), "cargo");
+  }
+
   exitMissingBinary(hostSupport.hostKey);
 }
 
-const result = spawnSync(binaryPath, process.argv.slice(2), {
-  stdio: "inherit"
-});
+exitFromSpawnResult(spawnPackagedBinary(), "legolas");
 
-if (result.error) {
-  console.error(`legolas: ${result.error.message}`);
+function spawnPackagedBinary() {
+  return spawnSync(binaryPath, process.argv.slice(2), {
+    stdio: "inherit"
+  });
+}
+
+function spawnSourceCheckout() {
+  const cargoManifestPath = path.join(projectRoot, "crates", "legolas-cli", "Cargo.toml");
+
+  return spawnSync("cargo", ["run", "--manifest-path", cargoManifestPath, "--", ...process.argv.slice(2)], {
+    stdio: "inherit"
+  });
+}
+
+function exitFromSpawnResult(result, label) {
+  if (result.error) {
+    console.error(`legolas: ${label}: ${result.error.message}`);
+    process.exit(1);
+  }
+
+  if (typeof result.status === "number") {
+    process.exit(result.status);
+  }
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+  }
+
   process.exit(1);
 }
-
-if (typeof result.status === "number") {
-  process.exit(result.status);
-}
-
-if (result.signal) {
-  process.kill(process.pid, result.signal);
-}
-
-process.exit(1);
 
 function exitMissingBinary(hostKey) {
   console.error(missingBinaryMessage(hostKey));

--- a/test/launcher-source-checkout.test.js
+++ b/test/launcher-source-checkout.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const packageManifest = JSON.parse(readFileSync(path.join(projectRoot, "package.json"), "utf8"));
+const sourceCheckoutLauncher = path.join(projectRoot, "bin", "legolas.js");
+
+test("source checkout launcher falls back to cargo when vendor binary is absent", () => {
+  const result = spawnSync(process.execPath, ["./bin/legolas.js", "--version"], {
+    cwd: projectRoot,
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim().split(/\r?\n/).at(-1), packageManifest.version);
+});
+
+test("source checkout launcher preserves caller cwd for relative target paths", () => {
+  const fixtureRoot = path.join(projectRoot, "tests", "fixtures", "parity", "basic-app");
+  const result = spawnSync(process.execPath, [sourceCheckoutLauncher, "scan", "."], {
+    cwd: fixtureRoot,
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Legolas scan for basic-parity-app/);
+  assert.match(result.stdout, /Project root: .*tests\/fixtures\/parity\/basic-app/);
+  assert.match(result.stdout, /Scanned 1 source files/);
+});


### PR DESCRIPTION
## 배경

로컬 소스 체크아웃에서는 vendor/<triple>/legolas 바이너리가 없어서 node ./bin/legolas.js 실행이 곧바로 실패했습니다. 배포 tarball은 vendor 바이너리를 계속 사용하되, 소스 트리에서는 Cargo CLI로 fallback하도록 분리합니다.

## 변경 사항

- bin/legolas.js가 vendor 바이너리를 찾지 못했을 때 crates/legolas-cli/Cargo.toml이 있으면 cargo run -p legolas-cli -- ...로 실행합니다.
- 소스 체크아웃 fallback 경로를 검증하는 Node 테스트를 추가했습니다.

## 검증

- node --test test/launcher-platform.test.js test/launcher-source-checkout.test.js
- node ./bin/legolas.js --version
- node ./bin/legolas.js scan tests/fixtures/parity/basic-app
- node ./scripts/smoke-ci-command.mjs launcher
- node --test test/release-workflow-context.test.js test/release-plan.test.js test/bump-release-version.test.js test/github-action-wiring.test.js
- cargo test --workspace
- git diff --check

## 브랜치 / 워크트리

- base: master
- head: codex/source-checkout-launcher-fallback
- worktree: /Users/pjw/workspace/legolas
