### PR TITLE
fix: JSX 슬래시 regex 오인 방지

### DIFF
--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -1530,6 +1530,12 @@ fn is_regex_literal_start(contents: &str, start_index: usize) -> bool {
         return false;
     }
 
+    if is_jsx_closing_tag_slash(contents, start_index)
+        || is_jsx_self_closing_tag_slash(contents, start_index)
+    {
+        return false;
+    }
+
     let Some(previous_index) = find_previous_significant_index(contents, start_index) else {
         return true;
     };
@@ -1604,19 +1610,141 @@ fn is_regex_literal_start(contents: &str, start_index: usize) -> bool {
     false
 }
 
+fn is_jsx_closing_tag_slash(contents: &str, start_index: usize) -> bool {
+    let Some((tag_start, '<')) = contents[..start_index].char_indices().next_back() else {
+        return false;
+    };
+    let Some(relative_tag_end) = contents[start_index..].find('>') else {
+        return false;
+    };
+    let tag_end = start_index + relative_tag_end;
+    let tag_text = &contents[tag_start..=tag_end];
+
+    is_likely_jsx_closing_tag(tag_text)
+        && !looks_like_less_than_followed_by_regex_body(contents, tag_start, tag_end)
+}
+
+fn is_jsx_self_closing_tag_slash(contents: &str, start_index: usize) -> bool {
+    if peek_char(contents, start_index + 1) != Some('>') {
+        return false;
+    }
+
+    find_jsx_opening_tag_start_before_self_closing_slash(contents, start_index).is_some()
+}
+
+fn find_jsx_opening_tag_start_before_self_closing_slash(
+    contents: &str,
+    start_index: usize,
+) -> Option<usize> {
+    let mut nested_expression_depth = 0usize;
+    let mut index = start_index;
+
+    while let Some((candidate_index, character)) = contents[..index].char_indices().next_back() {
+        if nested_expression_depth == 0 {
+            if character == '>' {
+                return None;
+            }
+
+            if character == '<' {
+                return is_likely_jsx_opening_tag_start(contents, candidate_index)
+                    .then_some(candidate_index);
+            }
+        }
+
+        if matches!(character, '}' | ')' | ']') {
+            nested_expression_depth += 1;
+        } else if matches!(character, '{' | '(' | '[') && nested_expression_depth > 0 {
+            nested_expression_depth -= 1;
+        }
+
+        index = candidate_index;
+    }
+
+    None
+}
+
+fn is_likely_jsx_opening_tag_start(contents: &str, start_index: usize) -> bool {
+    matches!(
+        peek_char(contents, start_index + 1),
+        Some(character) if character.is_ascii_alphabetic()
+    )
+}
+
+fn is_likely_jsx_closing_tag(tag_text: &str) -> bool {
+    if tag_text == "</>" {
+        return true;
+    }
+
+    let Some(tag_name) = tag_text
+        .strip_prefix("</")
+        .and_then(|text| text.strip_suffix('>'))
+    else {
+        return false;
+    };
+
+    is_likely_jsx_tag_name(tag_name.trim())
+}
+
+fn is_likely_jsx_tag_name(tag_name: &str) -> bool {
+    let mut characters = tag_name.chars();
+    let Some(first_character) = characters.next() else {
+        return false;
+    };
+
+    first_character.is_ascii_alphabetic()
+        && characters.all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | ':' | '.')
+        })
+}
+
+fn looks_like_less_than_followed_by_regex_body(
+    contents: &str,
+    tag_start: usize,
+    tag_end: usize,
+) -> bool {
+    let Some(previous_index) = find_previous_significant_index(contents, tag_start) else {
+        return false;
+    };
+    let Some(previous_character) = current_char(contents, previous_index) else {
+        return false;
+    };
+
+    if !is_identifier_character(previous_character) && !matches!(previous_character, ')' | ']') {
+        return false;
+    }
+
+    let next_index = skip_trivia(contents, advance_one(contents, tag_end));
+    matches!(
+        current_char(contents, next_index),
+        Some(character) if is_identifier_start(character)
+    )
+}
+
 fn regex_can_follow_parenthesized_construct(contents: &str, close_index: usize) -> bool {
+    if let Some(open_index) =
+        find_matching_open_delimiter_without_nested_lexing(contents, close_index, '(', ')')
+    {
+        return regex_can_follow_parenthesized_head(contents, open_index);
+    }
+
     let Some(open_index) = find_matching_open_delimiter(contents, close_index, '(', ')') else {
         return false;
     };
-    let head = normalize_whitespace(statement_head_segment(contents, open_index));
+    regex_can_follow_parenthesized_head(contents, open_index)
+}
 
-    head_ends_with_tokens(&head, &["if"])
-        || head_ends_with_tokens(&head, &["while"])
-        || head_ends_with_tokens(&head, &["for"])
-        || head_ends_with_tokens(&head, &["for", "await"])
-        || head_ends_with_tokens(&head, &["with"])
-        || head_ends_with_tokens(&head, &["switch"])
-        || head_ends_with_tokens(&head, &["catch"])
+fn regex_can_follow_parenthesized_head(contents: &str, open_index: usize) -> bool {
+    let Some(previous_index) = find_previous_significant_index(contents, open_index) else {
+        return false;
+    };
+    let Some((token_start, token)) = previous_identifier_span(contents, previous_index) else {
+        return false;
+    };
+
+    matches!(token, "if" | "while" | "for" | "with" | "switch" | "catch")
+        || (token == "await"
+            && previous_identifier_before(contents, token_start)
+                .is_some_and(|token| token == "for"))
 }
 
 fn regex_can_follow_braced_construct(
@@ -1668,6 +1796,40 @@ fn regex_can_follow_braced_construct(
     }
 
     matches!(before_open_character, ';' | '{' | '}')
+}
+
+fn find_matching_open_delimiter_without_nested_lexing(
+    contents: &str,
+    close_index: usize,
+    open_character: char,
+    close_character: char,
+) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut index = advance_one(contents, close_index);
+
+    while let Some((candidate_index, character)) = contents[..index].char_indices().next_back() {
+        if matches!(character, '\'' | '"' | '`' | '/') {
+            return None;
+        }
+
+        if character == close_character {
+            depth += 1;
+        } else if character == open_character {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(candidate_index);
+            }
+        }
+
+        index = candidate_index;
+    }
+
+    None
+}
+
+fn previous_identifier_before(contents: &str, end_index: usize) -> Option<&str> {
+    let previous_index = find_previous_significant_index(contents, end_index)?;
+    previous_identifier_token(contents, previous_index)
 }
 
 fn has_line_terminator_between(contents: &str, start_index: usize, end_index: usize) -> bool {

--- a/crates/legolas-core/tests/import_scanner_regressions.rs
+++ b/crates/legolas-core/tests/import_scanner_regressions.rs
@@ -741,6 +741,90 @@ fn scan_imports_preserves_dynamic_imports_after_postfix_increment_and_decrement(
 }
 
 #[test]
+fn scan_imports_ignores_jsx_tag_slashes_without_breaking_regex_literals() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "import Widget from \"widget-lib\";\n",
+            "export function View({ value }) {\n",
+            "  const exact = /abc/.test(value);\n",
+            "  const ignored = /import(\"fake-pkg\")/.test(value);\n",
+            "  return (\n",
+            "    <Widget\n",
+            "      prop={{ value }}\n",
+            "      render={<span>{exact && ignored ? value : \"fallback\"}</span>}\n",
+            "      footer={value ? <Footer label={value} /> : null}\n",
+            "    />\n",
+            "  );\n",
+            "}\n",
+            "export const load = () => import(\"chart.js/auto\");\n",
+        ),
+    );
+
+    let files = collect_source_files(root).expect("collect jsx slash regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan jsx slash regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["chart.js", "widget-lib"]
+    );
+    assert_eq!(
+        analysis.by_package.get("widget-lib"),
+        Some(&ImportedPackageRecord {
+            name: "widget-lib".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: vec!["src/App.tsx".to_string()],
+            dynamic_files: Vec::new(),
+        })
+    );
+    assert_eq!(
+        analysis.by_package.get("chart.js"),
+        Some(&ImportedPackageRecord {
+            name: "chart.js".to_string(),
+            files: vec!["src/App.tsx".to_string()],
+            static_files: Vec::new(),
+            dynamic_files: vec!["src/App.tsx".to_string()],
+        })
+    );
+}
+
+#[test]
+fn scan_imports_preserves_regex_after_no_space_less_than_expressions() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "export const compared = left</import(\"fake-pkg\")/.test(value)>right;\n",
+            "export const tagNameBody = left</Foo>import(\"fake-pkg\")/.test(value);\n",
+            "export const load = () => import(\"chart.js/auto\");\n",
+        ),
+    );
+
+    let files = collect_source_files(root).expect("collect less-than regex regression files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan less-than regex regression fixture");
+
+    assert_eq!(analysis.dynamic_import_count, 1);
+    assert_eq!(
+        analysis.by_package.keys().cloned().collect::<Vec<_>>(),
+        vec!["chart.js"]
+    );
+}
+
+#[test]
 fn scan_imports_emits_tree_shaking_warnings_for_export_from_root_packages() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();


### PR DESCRIPTION
## 배경

TSX/JSX 파일에서 closing tag 또는 self-closing slash가 regex literal 후보로 처리되면서 `legolas scan`이 orbit-dashboard 같은 실제 TSX 코드에서 장시간 무응답에 가까운 상태로 빠질 수 있었습니다.

## 변경 사항

- JSX closing tag slash와 self-closing tag slash를 regex literal 시작 후보에서 제외했습니다.
- 일반 괄호식 뒤 나눗셈이 regex 후보 판정 중 재귀성 병목으로 이어지지 않도록 parenthesized construct 판정을 토큰 기반으로 좁혔습니다.
- 실제 regex literal과 공백 없는 `< /regex/ >` 형태가 계속 regex로 처리되도록 회귀 테스트를 추가했습니다.

## 검증

- `cargo fmt --all --check`
- `cargo test -p legolas-core --test import_scanner_regressions`
- `cargo test -p legolas-core --test import_scanner`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `/usr/bin/time -p cargo run -p legolas-cli -- scan /Users/pjw/workspace/io/orbit-dashboard --json > /tmp/legolas-orbit-dashboard-scan.json` (`real 0.71`, `filesScanned=952`, `dynamicImports=14`, `importedPackages=16`)
- `git diff --check`
- `$devils-advocate-review-loop` Round 1: High 1건 수용 및 수정
- `$devils-advocate-review-loop` Round 2: PASS, Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- base: `master`
- head: `codex/fix-74-jsx-regex-slash`
- worktree: `/Users/pjw/workspace/legolas`

## 이슈 연결

Closes #74