### PR TITLE
feat(core): duplicate 영향 범위와 리포트 요약 모델 추가

### DIFF
--- a/crates/legolas-cli/tests/budget_contract.rs
+++ b/crates/legolas-cli/tests/budget_contract.rs
@@ -116,7 +116,7 @@ Legolas budget for basic-parity-app
 Overall status: Fail
 
 Rule results:
-- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- potentialKbSaved: Fail (actual: 348, warnAt: 40, failAt: 80)
 - duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
 - dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)
 "
@@ -138,7 +138,7 @@ fn budget_json_output_has_a_stable_shape() {
             "rules": [
                 {
                     "key": "potentialKbSaved",
-                    "actual": 366,
+                    "actual": 348,
                     "warnAt": 40,
                     "failAt": 80,
                     "status": "Fail",
@@ -216,7 +216,7 @@ fn budget_uses_config_threshold_overrides_and_starter_fallbacks_together() {
             "rules": [
                 {
                     "key": "potentialKbSaved",
-                    "actual": 366,
+                    "actual": 348,
                     "warnAt": 400,
                     "failAt": 500,
                     "status": "Pass",
@@ -283,7 +283,7 @@ fn budget_uses_discovered_config_from_project_root() {
             "rules": [
                 {
                     "key": "potentialKbSaved",
-                    "actual": 366,
+                    "actual": 348,
                     "warnAt": 40,
                     "failAt": 80,
                     "status": "Fail",

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -183,7 +183,7 @@ fn ci_json_output_uses_machine_readable_gate_shape() {
             "rules": [
                 {
                     "key": "potentialKbSaved",
-                    "actual": 366,
+                    "actual": 348,
                     "warnAt": 40,
                     "failAt": 80,
                     "status": "Fail",

--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -4,9 +4,9 @@ use legolas_cli::reporters::text::{
     format_optimize_report, format_scan_report, format_visualization_report,
 };
 use legolas_core::{
-    Analysis, DuplicateOrigin, DuplicatePackage, FindingAnalysisSource, FindingConfidence,
-    FindingEvidence, FindingMetadata, HeavyDependency, Impact, LazyLoadCandidate, Metadata,
-    PackageSummary, SourceSummary,
+    Analysis, DuplicateImpactScope, DuplicateOrigin, DuplicatePackage, FindingAnalysisSource,
+    FindingConfidence, FindingEvidence, FindingMetadata, HeavyDependency, Impact,
+    LazyLoadCandidate, Metadata, PackageSummary, SourceSummary,
 };
 
 fn load_analysis() -> Analysis {
@@ -165,6 +165,7 @@ fn scan_report_renders_all_duplicate_origin_lines() {
         ],
         count: 3,
         estimated_extra_kb: 36,
+        impact_scope: DuplicateImpactScope::Unknown,
         origins: vec![
             origin("4.17.19", "shell", &["shell", "shared"]),
             origin("4.17.20", "admin", &["admin"]),

--- a/crates/legolas-core/src/impact.rs
+++ b/crates/legolas-core/src/impact.rs
@@ -1,5 +1,6 @@
 use crate::models::{
-    DuplicatePackage, HeavyDependency, Impact, LazyLoadCandidate, TreeShakingWarning,
+    DuplicateImpactScope, DuplicatePackage, HeavyDependency, Impact, LazyLoadCandidate,
+    TreeShakingWarning,
 };
 
 pub fn estimate_impact(
@@ -15,6 +16,7 @@ pub fn estimate_impact(
         .sum();
     let duplicate_kb: usize = duplicate_packages
         .iter()
+        .filter(|item| item.impact_scope == DuplicateImpactScope::ProductionLikely)
         .map(|item| item.estimated_extra_kb)
         .sum();
     let lazy_kb: usize = lazy_load_candidates

--- a/crates/legolas-core/src/lib.rs
+++ b/crates/legolas-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod lockfiles;
 pub mod models;
 pub mod package_intelligence;
 pub mod project_shape;
+pub mod report_summary;
 pub mod route_context;
 pub mod workspace;
 pub mod workspaces;

--- a/crates/legolas-core/src/lockfiles.rs
+++ b/crates/legolas-core/src/lockfiles.rs
@@ -10,7 +10,7 @@ use serde_json::{Map, Value};
 
 use crate::{
     error::Result,
-    models::{DuplicateOrigin, DuplicatePackage},
+    models::{DuplicateImpactScope, DuplicateOrigin, DuplicatePackage},
     workspace::{exists, read_json_if_exists, read_text_if_exists},
 };
 
@@ -37,11 +37,19 @@ struct Lockfile {
 
 type VersionsByName = BTreeMap<String, Vec<String>>;
 type OriginsByName = BTreeMap<String, Vec<DuplicateOrigin>>;
+type ScopeEvidenceByName = BTreeMap<String, DuplicateScopeEvidence>;
 
 #[derive(Debug, Default)]
 struct DuplicateData {
     versions_by_name: VersionsByName,
     origins_by_name: OriginsByName,
+    scope_evidence_by_name: ScopeEvidenceByName,
+}
+
+#[derive(Debug, Default)]
+struct DuplicateScopeEvidence {
+    dev_origins: usize,
+    production_origins: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -209,6 +217,11 @@ fn collect_from_package_lock(package_lock: Option<Value>) -> DuplicateData {
                     &mut data.origins_by_name,
                     package_name,
                     build_duplicate_origin(version, &package_chain),
+                );
+                add_scope_evidence(
+                    &mut data.scope_evidence_by_name,
+                    package_name,
+                    npm_package_scope(metadata),
                 );
             }
 
@@ -784,12 +797,18 @@ fn summarize_duplicates(mut data: DuplicateData) -> Vec<DuplicatePackage> {
                 .then_with(|| left.via_chain.cmp(&right.via_chain))
         });
         let estimated_extra_kb = usize::max((versions.len().saturating_sub(1)) * 18, 18);
+        let impact_scope = data
+            .scope_evidence_by_name
+            .remove(&name)
+            .map(|evidence| evidence.impact_scope())
+            .unwrap_or(DuplicateImpactScope::Unknown);
 
         results.push(DuplicatePackage {
             name,
             count: versions.len(),
             versions,
             estimated_extra_kb,
+            impact_scope,
             origins,
             finding: Default::default(),
         });
@@ -849,6 +868,46 @@ fn add_version(versions_by_name: &mut VersionsByName, name: &str, version: &str)
     let versions = versions_by_name.entry(name.to_string()).or_default();
     if !versions.iter().any(|existing| existing == version) {
         versions.push(version.to_string());
+    }
+}
+
+fn npm_package_scope(metadata: &Value) -> DuplicateImpactScope {
+    if metadata
+        .get("dev")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        DuplicateImpactScope::DevOnly
+    } else {
+        DuplicateImpactScope::ProductionLikely
+    }
+}
+
+fn add_scope_evidence(
+    scope_evidence_by_name: &mut ScopeEvidenceByName,
+    name: &str,
+    impact_scope: DuplicateImpactScope,
+) {
+    let evidence = scope_evidence_by_name.entry(name.to_string()).or_default();
+
+    match impact_scope {
+        DuplicateImpactScope::ProductionLikely => evidence.production_origins += 1,
+        DuplicateImpactScope::DevOnly => evidence.dev_origins += 1,
+        DuplicateImpactScope::Unknown => {}
+    }
+}
+
+impl DuplicateScopeEvidence {
+    fn impact_scope(&self) -> DuplicateImpactScope {
+        if self.production_origins > 0 {
+            return DuplicateImpactScope::ProductionLikely;
+        }
+
+        if self.dev_origins > 0 {
+            return DuplicateImpactScope::DevOnly;
+        }
+
+        DuplicateImpactScope::Unknown
     }
 }
 

--- a/crates/legolas-core/src/models.rs
+++ b/crates/legolas-core/src/models.rs
@@ -68,10 +68,21 @@ pub struct DuplicatePackage {
     pub versions: Vec<String>,
     pub count: usize,
     pub estimated_extra_kb: usize,
+    #[serde(default)]
+    pub impact_scope: DuplicateImpactScope,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub origins: Vec<DuplicateOrigin>,
     #[serde(flatten, default, skip_serializing_if = "FindingMetadata::is_empty")]
     pub finding: FindingMetadata,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum DuplicateImpactScope {
+    ProductionLikely,
+    DevOnly,
+    #[default]
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -121,6 +132,44 @@ pub struct Impact {
     pub estimated_lcp_improvement_ms: usize,
     pub confidence: String,
     pub summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportSummary {
+    pub verdict_key: String,
+    pub text_source: ReportSummaryTextSource,
+    pub confirmed_initial_payload_kb_saved: usize,
+    pub directional_opportunity_kb: usize,
+    pub estimated_lcp_improvement_ms: usize,
+    pub top_actions: Vec<ReportSummaryAction>,
+    pub group_summaries: Vec<ReportSummaryGroupSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportSummaryTextSource {
+    pub title_key: String,
+    pub body_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportSummaryAction {
+    pub action_priority: usize,
+    pub finding_id: String,
+    pub estimated_savings_kb: usize,
+    pub confidence: crate::FindingConfidence,
+    pub difficulty: ActionDifficulty,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ReportSummaryGroupSummary {
+    pub key: String,
+    pub finding_count: usize,
+    pub confirmed_initial_payload_kb_saved: usize,
+    pub directional_opportunity_kb: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/crates/legolas-core/src/report_summary.rs
+++ b/crates/legolas-core/src/report_summary.rs
@@ -1,0 +1,138 @@
+use crate::{
+    action_plan::rank_actions,
+    models::{
+        Analysis, DuplicateImpactScope, ReportSummary, ReportSummaryAction,
+        ReportSummaryGroupSummary, ReportSummaryTextSource,
+    },
+};
+
+const TOP_ACTION_LIMIT: usize = 5;
+
+pub fn build_report_summary(analysis: &Analysis) -> ReportSummary {
+    let group_summaries = build_group_summaries(analysis);
+    let confirmed_initial_payload_kb_saved = group_summaries
+        .iter()
+        .map(|group| group.confirmed_initial_payload_kb_saved)
+        .sum();
+    let directional_opportunity_kb = group_summaries
+        .iter()
+        .map(|group| group.directional_opportunity_kb)
+        .sum();
+    let verdict_key = verdict_key(confirmed_initial_payload_kb_saved).to_string();
+
+    ReportSummary {
+        text_source: text_source_for_verdict(&verdict_key),
+        verdict_key,
+        confirmed_initial_payload_kb_saved,
+        directional_opportunity_kb,
+        estimated_lcp_improvement_ms: (confirmed_initial_payload_kb_saved as f64 * 2.1).round()
+            as usize,
+        top_actions: rank_actions(analysis)
+            .into_iter()
+            .take(TOP_ACTION_LIMIT)
+            .map(|action| ReportSummaryAction {
+                action_priority: action.action_priority,
+                finding_id: action.finding_id,
+                estimated_savings_kb: action.estimated_savings_kb,
+                confidence: action.confidence,
+                difficulty: action.difficulty,
+            })
+            .collect(),
+        group_summaries,
+    }
+}
+
+fn build_group_summaries(analysis: &Analysis) -> Vec<ReportSummaryGroupSummary> {
+    let heavy_dependency_kb = analysis
+        .heavy_dependencies
+        .iter()
+        .take(5)
+        .map(|item| item.estimated_kb as f64 * 0.18)
+        .sum::<f64>()
+        .round() as usize;
+    let production_duplicate_kb = analysis
+        .duplicate_packages
+        .iter()
+        .filter(|item| item.impact_scope == DuplicateImpactScope::ProductionLikely)
+        .map(|item| item.estimated_extra_kb)
+        .sum();
+    let all_duplicate_kb = analysis
+        .duplicate_packages
+        .iter()
+        .map(|item| item.estimated_extra_kb)
+        .sum();
+    let lazy_load_kb = analysis
+        .lazy_load_candidates
+        .iter()
+        .map(|item| item.estimated_savings_kb)
+        .sum();
+    let tree_shaking_kb = analysis
+        .tree_shaking_warnings
+        .iter()
+        .map(|item| item.estimated_kb)
+        .sum();
+
+    vec![
+        group_summary(
+            "heavy-dependencies",
+            analysis.heavy_dependencies.len(),
+            heavy_dependency_kb,
+            heavy_dependency_kb,
+        ),
+        group_summary(
+            "duplicate-packages",
+            analysis.duplicate_packages.len(),
+            production_duplicate_kb,
+            all_duplicate_kb,
+        ),
+        group_summary(
+            "lazy-load-candidates",
+            analysis.lazy_load_candidates.len(),
+            lazy_load_kb,
+            lazy_load_kb,
+        ),
+        group_summary(
+            "tree-shaking-warnings",
+            analysis.tree_shaking_warnings.len(),
+            tree_shaking_kb,
+            tree_shaking_kb,
+        ),
+    ]
+}
+
+fn group_summary(
+    key: &str,
+    finding_count: usize,
+    confirmed_initial_payload_kb_saved: usize,
+    directional_opportunity_kb: usize,
+) -> ReportSummaryGroupSummary {
+    ReportSummaryGroupSummary {
+        key: key.to_string(),
+        finding_count,
+        confirmed_initial_payload_kb_saved,
+        directional_opportunity_kb,
+    }
+}
+
+fn verdict_key(confirmed_initial_payload_kb_saved: usize) -> &'static str {
+    if confirmed_initial_payload_kb_saved >= 300 {
+        return "high-impact";
+    }
+
+    if confirmed_initial_payload_kb_saved >= 120 {
+        return "medium-impact";
+    }
+
+    if confirmed_initial_payload_kb_saved >= 40 {
+        return "targeted-impact";
+    }
+
+    "low-impact"
+}
+
+fn text_source_for_verdict(verdict_key: &str) -> ReportSummaryTextSource {
+    ReportSummaryTextSource {
+        title_key: format!("report.summary.{verdict_key}.title"),
+        body_key: format!("report.summary.{verdict_key}.body"),
+    }
+}

--- a/crates/legolas-core/tests/duplicate_origin_trace.rs
+++ b/crates/legolas-core/tests/duplicate_origin_trace.rs
@@ -2,7 +2,7 @@ mod support;
 
 use legolas_core::{
     lockfiles::{parse_duplicate_packages, DuplicateAnalysis},
-    DuplicateOrigin, DuplicatePackage,
+    DuplicateImpactScope, DuplicateOrigin, DuplicatePackage,
 };
 
 #[test]
@@ -14,9 +14,10 @@ fn parses_npm_origin_traces_from_package_paths() {
     assert_eq!(
         analysis,
         DuplicateAnalysis {
-            duplicates: vec![duplicate_with_origins(
+            duplicates: vec![duplicate_with_origins_with_scope(
                 "shared-lib",
                 &["1.0.0", "2.0.0"],
+                DuplicateImpactScope::ProductionLikely,
                 &[
                     origin("1.0.0", "app-shell", &["app-shell", "widget-core"]),
                     origin("2.0.0", "admin-shell", &["admin-shell"]),
@@ -120,11 +121,21 @@ fn duplicate_with_origins(
     versions: &[&str],
     origins: &[DuplicateOrigin],
 ) -> DuplicatePackage {
+    duplicate_with_origins_with_scope(name, versions, DuplicateImpactScope::Unknown, origins)
+}
+
+fn duplicate_with_origins_with_scope(
+    name: &str,
+    versions: &[&str],
+    impact_scope: DuplicateImpactScope,
+    origins: &[DuplicateOrigin],
+) -> DuplicatePackage {
     DuplicatePackage {
         name: name.to_string(),
         versions: versions.iter().map(|value| (*value).to_string()).collect(),
         count: versions.len(),
         estimated_extra_kb: usize::max((versions.len().saturating_sub(1)) * 18, 18),
+        impact_scope,
         origins: origins.to_vec(),
         finding: Default::default(),
     }

--- a/crates/legolas-core/tests/intelligence_impact.rs
+++ b/crates/legolas-core/tests/intelligence_impact.rs
@@ -2,8 +2,13 @@ use std::{fs, path::PathBuf};
 
 use legolas_core::{
     impact::estimate_impact,
-    models::{DuplicatePackage, HeavyDependency, Impact, LazyLoadCandidate, TreeShakingWarning},
+    models::{
+        Analysis, DuplicateImpactScope, DuplicatePackage, HeavyDependency, Impact,
+        LazyLoadCandidate, TreeShakingWarning,
+    },
     package_intelligence::{get_package_intel, package_intelligence_entries, PackageIntel},
+    report_summary::build_report_summary,
+    FindingAnalysisSource, FindingConfidence, FindingMetadata,
 };
 use serde::Deserialize;
 
@@ -143,6 +148,79 @@ fn estimate_impact_uses_the_js_summary_thresholds() {
     }
 }
 
+#[test]
+fn estimate_impact_excludes_non_production_duplicate_savings_from_initial_payload() {
+    let impact = estimate_impact(
+        &[],
+        &[
+            duplicate_package_with_scope(80, DuplicateImpactScope::ProductionLikely),
+            duplicate_package_with_scope(60, DuplicateImpactScope::DevOnly),
+            duplicate_package_with_scope(40, DuplicateImpactScope::Unknown),
+        ],
+        &[],
+        &[],
+    );
+
+    assert_eq!(impact.potential_kb_saved, 80);
+    assert_eq!(impact.estimated_lcp_improvement_ms, 168);
+    assert_eq!(impact.confidence, "directional");
+}
+
+#[test]
+fn report_summary_separates_confirmed_initial_payload_from_directional_duplicate_opportunity() {
+    let mut production_duplicate =
+        duplicate_package_with_scope(50, DuplicateImpactScope::ProductionLikely);
+    production_duplicate.finding = FindingMetadata::new(
+        "duplicate-package:prod-shared",
+        FindingAnalysisSource::LockfileTrace,
+    )
+    .with_confidence(FindingConfidence::Medium);
+
+    let mut dev_duplicate = duplicate_package_with_scope(30, DuplicateImpactScope::DevOnly);
+    dev_duplicate.finding = FindingMetadata::new(
+        "duplicate-package:dev-shared",
+        FindingAnalysisSource::LockfileTrace,
+    )
+    .with_confidence(FindingConfidence::Medium);
+
+    let analysis = Analysis {
+        duplicate_packages: vec![production_duplicate, dev_duplicate],
+        impact: Impact {
+            potential_kb_saved: 50,
+            estimated_lcp_improvement_ms: 105,
+            confidence: "directional".to_string(),
+            summary: "Targeted impact: a handful of focused optimizations should pay off."
+                .to_string(),
+        },
+        ..Analysis::default()
+    };
+
+    let summary = build_report_summary(&analysis);
+
+    assert_eq!(summary.verdict_key, "targeted-impact");
+    assert_eq!(
+        summary.text_source.title_key,
+        "report.summary.targeted-impact.title"
+    );
+    assert_eq!(summary.confirmed_initial_payload_kb_saved, 50);
+    assert_eq!(summary.directional_opportunity_kb, 80);
+    assert_eq!(summary.estimated_lcp_improvement_ms, 105);
+    assert_eq!(summary.top_actions.len(), 2);
+    assert_eq!(
+        summary.top_actions[0].finding_id,
+        "duplicate-package:prod-shared"
+    );
+    assert_eq!(
+        summary
+            .group_summaries
+            .iter()
+            .find(|group| group.key == "duplicate-packages")
+            .expect("duplicate group summary")
+            .directional_opportunity_kb,
+        80
+    );
+}
+
 fn heavy_dependency(estimated_kb: usize) -> HeavyDependency {
     HeavyDependency {
         estimated_kb,
@@ -151,8 +229,16 @@ fn heavy_dependency(estimated_kb: usize) -> HeavyDependency {
 }
 
 fn duplicate_package(estimated_extra_kb: usize) -> DuplicatePackage {
+    duplicate_package_with_scope(estimated_extra_kb, DuplicateImpactScope::ProductionLikely)
+}
+
+fn duplicate_package_with_scope(
+    estimated_extra_kb: usize,
+    impact_scope: DuplicateImpactScope,
+) -> DuplicatePackage {
     DuplicatePackage {
         estimated_extra_kb,
+        impact_scope,
         ..DuplicatePackage::default()
     }
 }

--- a/crates/legolas-core/tests/lockfiles.rs
+++ b/crates/legolas-core/tests/lockfiles.rs
@@ -4,7 +4,7 @@ use std::{fs, process::Command};
 
 use legolas_core::{
     lockfiles::{parse_duplicate_packages, DuplicateAnalysis},
-    DuplicateOrigin, DuplicatePackage,
+    DuplicateImpactScope, DuplicateOrigin, DuplicatePackage,
 };
 use serde_json::json;
 use tempfile::tempdir;
@@ -22,6 +22,7 @@ fn parses_npm_v3_duplicates_from_the_packages_section() {
                 duplicate_with_origins(
                     "@scope/pkg",
                     &["1.0.0", "1.2.0"],
+                    DuplicateImpactScope::ProductionLikely,
                     &[
                         origin("1.0.0", "@scope/pkg", &["@scope/pkg"]),
                         origin("1.2.0", "bar", &["bar"]),
@@ -30,6 +31,7 @@ fn parses_npm_v3_duplicates_from_the_packages_section() {
                 duplicate_with_origins(
                     "lodash",
                     &["4.17.20", "4.17.21"],
+                    DuplicateImpactScope::ProductionLikely,
                     &[
                         origin("4.17.20", "lodash", &["lodash"]),
                         origin("4.17.21", "foo", &["foo"]),
@@ -91,6 +93,7 @@ fn parses_npm_v1_duplicates_from_dependency_trees_and_sorts_versions_naturally()
                 duplicate_with_origins(
                     "shared",
                     &["1.2.0", "1.2.2", "1.2.10"],
+                    DuplicateImpactScope::Unknown,
                     &[
                         origin("1.2.0", "shared", &["shared"]),
                         origin("1.2.2", "beta", &["beta"]),
@@ -100,6 +103,7 @@ fn parses_npm_v1_duplicates_from_dependency_trees_and_sorts_versions_naturally()
                 duplicate_with_origins(
                     "left-pad",
                     &["1.0.0", "1.0.1"],
+                    DuplicateImpactScope::Unknown,
                     &[
                         origin("1.0.0", "left-pad", &["left-pad"]),
                         origin("1.0.1", "alpha", &["alpha"]),
@@ -123,6 +127,7 @@ fn parses_pnpm_duplicates_from_packages_and_snapshots_sections() {
             duplicates: vec![duplicate_with_origins(
                 "lodash",
                 &["4.17.20", "4.17.21"],
+                DuplicateImpactScope::Unknown,
                 &[
                     origin("4.17.20", "lodash", &["lodash"]),
                     origin("4.17.21", "lodash", &["lodash"]),
@@ -145,6 +150,7 @@ fn parses_yarn_berry_entries_with_version_colons() {
             duplicates: vec![duplicate_with_origins(
                 "lodash",
                 &["4.17.20", "4.17.21"],
+                DuplicateImpactScope::Unknown,
                 &[
                     origin("4.17.20", "lodash", &["lodash"]),
                     origin("4.17.21", "lodash", &["lodash"]),
@@ -167,6 +173,7 @@ fn parses_yarn_aliases_as_the_underlying_package_name() {
             duplicates: vec![duplicate_with_origins(
                 "react",
                 &["18.2.0", "18.3.1"],
+                DuplicateImpactScope::Unknown,
                 &[
                     origin("18.2.0", "react", &["react"]),
                     origin("18.3.1", "react", &["react"]),
@@ -201,6 +208,7 @@ lodash@npm:^4.17.21:
             duplicates: vec![duplicate_with_origins(
                 "lodash",
                 &["4.17.20", "4.17.21"],
+                DuplicateImpactScope::Unknown,
                 &[
                     origin("4.17.20", "lodash", &["lodash"]),
                     origin("4.17.21", "lodash", &["lodash"]),
@@ -237,6 +245,7 @@ fn parses_yarn_entries_with_leading_slashes_like_berry_exports() {
             duplicates: vec![duplicate_with_origins(
                 "lodash",
                 &["4.17.20", "4.17.21"],
+                DuplicateImpactScope::Unknown,
                 &[
                     origin("4.17.20", "lodash", &["lodash"]),
                     origin("4.17.21", "lodash", &["lodash"]),
@@ -390,6 +399,7 @@ fn sorts_versions_like_js_locale_compare_numeric() {
             versions: expected_versions,
             count: input_versions.len(),
             estimated_extra_kb: 162,
+            impact_scope: DuplicateImpactScope::ProductionLikely,
             origins: input_versions
                 .iter()
                 .enumerate()
@@ -420,6 +430,7 @@ fn prefers_the_package_manager_lockfile_and_warns_about_the_rest() {
             duplicates: vec![duplicate_with_origins(
                 "kleur",
                 &["4.1.4", "4.1.5"],
+                DuplicateImpactScope::Unknown,
                 &[
                     origin("4.1.4", "kleur", &["kleur"]),
                     origin("4.1.5", "kleur", &["kleur"]),
@@ -444,6 +455,7 @@ fn falls_back_to_default_lockfile_priority_when_package_manager_is_unknown() {
             duplicates: vec![duplicate_with_origins(
                 "left-pad",
                 &["1.0.0", "1.1.0"],
+                DuplicateImpactScope::ProductionLikely,
                 &[
                     origin("1.0.0", "left-pad", &["left-pad"]),
                     origin("1.1.0", "tooling", &["tooling"]),
@@ -465,9 +477,81 @@ fn returns_empty_results_when_no_supported_lockfile_exists() {
     assert_eq!(analysis, DuplicateAnalysis::default());
 }
 
+#[test]
+fn classifies_npm_v3_duplicates_as_dev_only_when_all_origins_are_dev() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let package_lock_path = temp_dir.path().join("package-lock.json");
+
+    fs::write(
+        &package_lock_path,
+        r#"{
+  "name": "npm-v3-dev-only",
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/tool-a/node_modules/shared": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "node_modules/tool-b/node_modules/shared": {
+      "version": "2.0.0",
+      "dev": true
+    }
+  }
+}"#,
+    )
+    .expect("write package lockfile");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "npm").expect("parse npm v3");
+
+    assert_eq!(
+        analysis.duplicates[0].impact_scope,
+        DuplicateImpactScope::DevOnly
+    );
+    assert_eq!(
+        serde_json::to_value(&analysis.duplicates[0]).expect("serialize duplicate")["impactScope"],
+        json!("dev-only")
+    );
+}
+
+#[test]
+fn classifies_npm_v3_duplicates_as_production_likely_when_any_origin_is_not_dev() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let package_lock_path = temp_dir.path().join("package-lock.json");
+
+    fs::write(
+        &package_lock_path,
+        r#"{
+  "name": "npm-v3-production-origin",
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/tool-a/node_modules/shared": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "node_modules/shared": {
+      "version": "2.0.0"
+    }
+  }
+}"#,
+    )
+    .expect("write package lockfile");
+
+    let analysis = parse_duplicate_packages(temp_dir.path(), "npm").expect("parse npm v3");
+
+    assert_eq!(
+        analysis.duplicates[0].impact_scope,
+        DuplicateImpactScope::ProductionLikely
+    );
+    assert_eq!(
+        serde_json::to_value(&analysis.duplicates[0]).expect("serialize duplicate")["impactScope"],
+        json!("production-likely")
+    );
+}
+
 fn duplicate_with_origins(
     name: &str,
     versions: &[&str],
+    impact_scope: DuplicateImpactScope,
     origins: &[DuplicateOrigin],
 ) -> DuplicatePackage {
     DuplicatePackage {
@@ -475,6 +559,7 @@ fn duplicate_with_origins(
         versions: versions.iter().map(|value| (*value).to_string()).collect(),
         count: versions.len(),
         estimated_extra_kb: usize::max((versions.len().saturating_sub(1)) * 18, 18),
+        impact_scope,
         origins: origins.to_vec(),
         finding: Default::default(),
     }

--- a/docs/schema/analysis.v1.schema.json
+++ b/docs/schema/analysis.v1.schema.json
@@ -372,6 +372,14 @@
           "estimatedExtraKb": {
             "type": "integer"
           },
+          "impactScope": {
+            "type": "string",
+            "enum": [
+              "production-likely",
+              "dev-only",
+              "unknown"
+            ]
+          },
           "origins": {
             "type": "array",
             "items": {

--- a/tests/oracles/basic-app/budget.txt
+++ b/tests/oracles/basic-app/budget.txt
@@ -3,6 +3,6 @@ Legolas budget for basic-parity-app
 Overall status: Fail
 
 Rule results:
-- potentialKbSaved: Fail (actual: 366, warnAt: 40, failAt: 80)
+- potentialKbSaved: Fail (actual: 348, warnAt: 40, failAt: 80)
 - duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
 - dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)

--- a/tests/oracles/basic-app/optimize-ranked.txt
+++ b/tests/oracles/basic-app/optimize-ranked.txt
@@ -18,4 +18,4 @@ Legolas optimize for basic-parity-app
 5. Lazy load react-icons [medium | low confidence | ~68 KB]
    evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
 
-Projected savings: ~366 KB, with directional confidence.
+Projected savings: ~348 KB, with directional confidence.

--- a/tests/oracles/basic-app/optimize.txt
+++ b/tests/oracles/basic-app/optimize.txt
@@ -18,4 +18,4 @@ Legolas optimize for basic-parity-app
 5. Lazy load react-icons [medium | low confidence | ~68 KB]
    evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
 
-Projected savings: ~366 KB, with directional confidence.
+Projected savings: ~348 KB, with directional confidence.

--- a/tests/oracles/basic-app/scan.json
+++ b/tests/oracles/basic-app/scan.json
@@ -124,6 +124,7 @@
       ],
       "count": 2,
       "estimatedExtraKb": 18,
+      "impactScope": "unknown",
       "origins": [
         {
           "version": "4.17.20",
@@ -280,8 +281,8 @@
   "unusedDependencyCandidates": [],
   "warnings": [],
   "impact": {
-    "potentialKbSaved": 366,
-    "estimatedLcpImprovementMs": 769,
+    "potentialKbSaved": 348,
+    "estimatedLcpImprovementMs": 731,
     "confidence": "directional",
     "summary": "High impact: the project has clear opportunities to reduce initial payload size."
   },

--- a/tests/oracles/basic-app/scan.txt
+++ b/tests/oracles/basic-app/scan.txt
@@ -5,8 +5,8 @@ Frameworks: Vite, React
 Package manager: pnpm
 Scanned 1 source files and 4 imported packages
 
-Potential payload reduction: ~366 KB
-Estimated LCP improvement: ~769 ms
+Potential payload reduction: ~348 KB
+Estimated LCP improvement: ~731 ms
 High impact: the project has clear opportunities to reduce initial payload size.
 
 Heaviest known dependencies:


### PR DESCRIPTION
## 배경
#78은 lockfile duplicate가 실제 초기 페이로드 개선인지 dev/test hygiene인지 구분할 수 있도록 core 모델과 계산 계약을 추가하는 작업입니다.

## 변경 사항
- `DuplicatePackage`에 additive `impactScope`를 추가했습니다.
- npm package-lock v2/v3 `packages[*].dev` 기반으로 `production-likely`, `dev-only`, `unknown` 범위를 판정합니다.
- dev-only/unknown duplicate는 초기 페이로드 절감 추정에서 제외합니다.
- `ReportSummary` 모델과 생성 함수를 추가했습니다.
- 공개 analysis schema와 기존 oracle/test 기대값을 새 additive 출력과 impact 계산에 맞게 갱신했습니다.

## 검증
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p legolas-core --test lockfiles`
- `cargo test -p legolas-core --test intelligence_impact`
- `cargo test -p legolas-core --test duplicate_origin_trace`
- `cargo test -p legolas-cli --test json_schema_contract scan_json_matches_analysis_schema_doc`
- `cargo test -p legolas-cli --test cli_contract matches_scan_visualize_and_optimize_oracles`
- `cargo test -p legolas-cli --test budget_contract`
- `cargo test -p legolas-cli --test ci_contract ci_json_output_uses_machine_readable_gate_shape`
- `cargo test -p legolas-core`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## 리뷰 게이트
- Devil’s Advocate Round 1: High 2건 수용 후 수정
- Devil’s Advocate Round 2: Critical/High 없음, pass

## 브랜치 / 워크트리
- Branch: `codex/feat-78-core-report-summary`
- Worktree: `/tmp/legolas-wave1/issue-78-core-report-summary`

Closes #78