### PR TITLE
feat(cli): 언어 옵션 plumbing 추가

### DIFF
--- a/crates/legolas-cli/src/argv.rs
+++ b/crates/legolas-cli/src/argv.rs
@@ -13,6 +13,13 @@ pub enum Command {
     Unknown(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ReportLanguage {
+    #[default]
+    Ko,
+    En,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CliArgs {
     pub command: Option<Command>,
@@ -27,6 +34,7 @@ pub struct CliArgs {
     pub top: Option<usize>,
     pub help: bool,
     pub version: bool,
+    pub lang: ReportLanguage,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,6 +85,10 @@ where
             }
             "--config" => {
                 parsed.config_path = Some(parse_path_flag(&tokens, index, "--config")?);
+                index += 1;
+            }
+            "--lang" => {
+                parsed.lang = parse_language_flag(&tokens, index)?;
                 index += 1;
             }
             "--baseline" => {
@@ -166,6 +178,16 @@ fn parse_path_flag(tokens: &[String], index: usize, flag: &str) -> Result<PathBu
     }
 
     resolve_path_token(next)
+}
+
+fn parse_language_flag(tokens: &[String], index: usize) -> Result<ReportLanguage> {
+    match tokens.get(index + 1).map(String::as_str) {
+        Some("ko") => Ok(ReportLanguage::Ko),
+        Some("en") => Ok(ReportLanguage::En),
+        _ => Err(LegolasError::CliUsage(
+            "--lang expects ko or en".to_string(),
+        )),
+    }
 }
 
 fn validate_baseline_flags(parsed: &CliArgs) -> Result<()> {

--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -5,12 +5,13 @@ use std::{
 };
 
 use legolas_cli::{
-    argv::{self, Command},
+    argv::{self, Command, ReportLanguage},
     reporters::{
-        sarif::{ci_sarif_output, scan_sarif_output},
+        sarif::{ci_sarif_output_for_language, scan_sarif_output_for_language},
         text::{
-            format_budget_report, format_ci_report, format_optimize_report, format_scan_report,
-            format_visualization_report,
+            format_budget_report_for_language, format_ci_report_for_language,
+            format_optimize_report_for_language, format_scan_report_for_language,
+            format_visualization_report_for_language,
         },
     },
 };
@@ -28,7 +29,33 @@ const ANALYSIS_SCHEMA_VERSION: &str = "legolas.analysis.v1";
 const BUDGET_SCHEMA_VERSION: &str = "legolas.budget.v1";
 const CI_SCHEMA_VERSION: &str = "legolas.ci.v1";
 
-const HELP_TEXT: &str = r#"Legolas
+const HELP_TEXT_KO: &str = r#"Legolas
+정밀하게 번들 크기를 줄입니다.
+
+Usage: / 사용법:
+  legolas scan [path] [--config file] [--json | --sarif] [--write-baseline file] [--baseline file --regression-only]
+  legolas visualize [path] [--config file] [--limit 10]
+  legolas optimize [path] [--config file] [--top 5] [--json] [--baseline file --regression-only]
+  legolas budget [path] [--config file] [--json] [--baseline file --regression-only]
+  legolas ci [path] [--config file] [--json | --sarif] [--baseline file --regression-only]
+  legolas help [--lang ko|en]
+
+전역 옵션:
+  --lang ko|en  도움말과 텍스트 리포트 언어를 선택합니다. 기본값은 ko입니다.
+
+예시:
+  legolas scan .
+  legolas scan ./apps/storefront --sarif
+  legolas scan ./apps/storefront --write-baseline ./baseline.json --json
+  legolas scan ./apps/storefront --baseline ./baseline.json --regression-only --json
+  legolas scan --config ./legolas.config.json
+  legolas visualize ./apps/storefront --limit 12
+  legolas optimize ./apps/storefront --top 7 --baseline ./baseline.json --regression-only
+  legolas budget ./apps/storefront --baseline ./baseline.json --regression-only --json
+  legolas ci ./apps/storefront --baseline ./baseline.json --regression-only --sarif
+"#;
+
+const HELP_TEXT_EN: &str = r#"Legolas
 Slim bundles with precision.
 
 Usage:
@@ -69,8 +96,13 @@ fn run() -> Result<i32> {
         return Ok(0);
     }
 
-    if parsed.help || parsed.command.is_none() || matches!(parsed.command, Some(Command::Help)) {
-        print!("{HELP_TEXT}");
+    if parsed.command.is_none() && !parsed.help {
+        print!("{}", help_text(parsed.lang));
+        return Ok(0);
+    }
+
+    if parsed.help || matches!(parsed.command, Some(Command::Help)) {
+        print!("{}", help_text(parsed.lang));
         return Ok(0);
     }
 
@@ -118,13 +150,14 @@ fn run() -> Result<i32> {
 
     if parsed.sarif {
         let output = match command {
-            Command::Scan => scan_sarif_output(&output_analysis),
-            Command::Ci => ci_sarif_output(
+            Command::Scan => scan_sarif_output_for_language(&output_analysis, parsed.lang),
+            Command::Ci => ci_sarif_output_for_language(
                 &output_analysis,
                 budget_evaluation
                     .as_ref()
                     .expect("budget evaluation exists for ci command"),
                 regression_diff.as_ref(),
+                parsed.lang,
             ),
             Command::Visualize | Command::Optimize | Command::Budget => {
                 unreachable!("argv validation already restricts --sarif")
@@ -193,26 +226,30 @@ fn run() -> Result<i32> {
     }
 
     let output = match command {
-        Command::Scan => format_scan_report(&output_analysis),
-        Command::Visualize => format_visualization_report(
+        Command::Scan => format_scan_report_for_language(&output_analysis, parsed.lang),
+        Command::Visualize => format_visualization_report_for_language(
             &output_analysis,
             resolve_visualize_limit(&parsed, loaded_config.as_ref()),
+            parsed.lang,
         ),
-        Command::Optimize => format_optimize_report(
+        Command::Optimize => format_optimize_report_for_language(
             &output_analysis,
             resolve_optimize_top(&parsed, loaded_config.as_ref()),
+            parsed.lang,
         ),
-        Command::Budget => format_budget_report(
+        Command::Budget => format_budget_report_for_language(
             &output_analysis,
             budget_evaluation
                 .as_ref()
                 .expect("budget evaluation exists for budget command"),
+            parsed.lang,
         ),
-        Command::Ci => format_ci_report(
+        Command::Ci => format_ci_report_for_language(
             &output_analysis,
             budget_evaluation
                 .as_ref()
                 .expect("budget evaluation exists for ci command"),
+            parsed.lang,
         ),
         Command::Help | Command::Unknown(_) => unreachable!("handled above"),
     };
@@ -236,6 +273,13 @@ fn run() -> Result<i32> {
     }
 
     Ok(0)
+}
+
+fn help_text(language: ReportLanguage) -> &'static str {
+    match language {
+        ReportLanguage::Ko => HELP_TEXT_KO,
+        ReportLanguage::En => HELP_TEXT_EN,
+    }
 }
 
 fn resolve_baseline_snapshot(parsed: &argv::CliArgs) -> Result<Option<BaselineSnapshot>> {

--- a/crates/legolas-cli/src/reporters/sarif.rs
+++ b/crates/legolas-cli/src/reporters/sarif.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::argv::ReportLanguage;
 use legolas_core::{
     boundaries::BoundaryWarning, budget::BudgetEvaluation, Analysis, BaselineDiff,
     DuplicatePackage, FindingConfidence, FindingEvidence, FindingMetadata, HeavyDependency,
@@ -11,11 +12,24 @@ const SARIF_SCHEMA_URL: &str = "https://json.schemastore.org/sarif-2.1.0.json";
 const SARIF_VERSION: &str = "2.1.0";
 const LEGOLAS_INFO_URL: &str = "https://github.com/JeremyDev87/legolas";
 
+pub fn scan_sarif_output_for_language(analysis: &Analysis, _language: ReportLanguage) -> Value {
+    scan_sarif_output(analysis)
+}
+
 pub fn scan_sarif_output(analysis: &Analysis) -> Value {
     sarif_output(
         collect_scan_records(analysis),
         base_run_properties("scan", analysis),
     )
+}
+
+pub fn ci_sarif_output_for_language(
+    analysis: &Analysis,
+    evaluation: &BudgetEvaluation,
+    regression_diff: Option<&BaselineDiff>,
+    _language: ReportLanguage,
+) -> Value {
+    ci_sarif_output(analysis, evaluation, regression_diff)
 }
 
 pub fn ci_sarif_output(

--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -1,8 +1,13 @@
+use crate::argv::ReportLanguage;
 use legolas_core::{
     boundaries::BoundaryWarning, budget::BudgetEvaluation, rank_actions, ActionDifficulty,
     Analysis, FindingConfidence, FindingEvidence, FindingMetadata, RecommendedFix,
 };
 use std::collections::BTreeMap;
+
+pub fn format_scan_report_for_language(analysis: &Analysis, _language: ReportLanguage) -> String {
+    format_scan_report(analysis)
+}
 
 pub fn format_scan_report(analysis: &Analysis) -> String {
     let mut lines = Vec::new();
@@ -142,6 +147,14 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
     lines.join("\n")
 }
 
+pub fn format_visualization_report_for_language(
+    analysis: &Analysis,
+    limit: usize,
+    _language: ReportLanguage,
+) -> String {
+    format_visualization_report(analysis, limit)
+}
+
 pub fn format_visualization_report(analysis: &Analysis, limit: usize) -> String {
     let mut lines = Vec::new();
     let normalized_limit = limit.max(1);
@@ -193,6 +206,14 @@ pub fn format_visualization_report(analysis: &Analysis, limit: usize) -> String 
     lines.join("\n")
 }
 
+pub fn format_optimize_report_for_language(
+    analysis: &Analysis,
+    top: usize,
+    _language: ReportLanguage,
+) -> String {
+    format_optimize_report(analysis, top)
+}
+
 pub fn format_optimize_report(analysis: &Analysis, top: usize) -> String {
     let mut lines = Vec::new();
     let actions = build_actions(analysis)
@@ -221,6 +242,14 @@ pub fn format_optimize_report(analysis: &Analysis, top: usize) -> String {
     lines.join("\n")
 }
 
+pub fn format_budget_report_for_language(
+    analysis: &Analysis,
+    evaluation: &BudgetEvaluation,
+    _language: ReportLanguage,
+) -> String {
+    format_budget_report(analysis, evaluation)
+}
+
 pub fn format_budget_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> String {
     let mut lines = Vec::new();
 
@@ -247,6 +276,14 @@ pub fn format_budget_report(analysis: &Analysis, evaluation: &BudgetEvaluation) 
     );
 
     lines.join("\n")
+}
+
+pub fn format_ci_report_for_language(
+    analysis: &Analysis,
+    evaluation: &BudgetEvaluation,
+    _language: ReportLanguage,
+) -> String {
+    format_ci_report(analysis, evaluation)
 }
 
 pub fn format_ci_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> String {

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -29,12 +29,35 @@ fn prints_version_without_a_command() {
 #[test]
 fn prints_help_for_empty_command_and_help_variants() {
     for args in [
-        Vec::<&str>::new(),
+        vec![],
+        vec!["--lang", "ko"],
         vec!["help"],
         vec!["--help"],
         vec!["-h"],
         vec!["budget", "--help", "--limit", "1"],
         vec!["ci", "--help", "--top", "1"],
+    ] {
+        let output = Command::cargo_bin("legolas-cli")
+            .expect("build binary")
+            .args(args)
+            .output()
+            .expect("run help");
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).expect("stdout");
+        assert!(stdout.contains("사용법:"));
+        assert!(stdout.contains("전역 옵션:"));
+        assert_eq!(String::from_utf8(output.stderr).expect("stderr"), "");
+    }
+}
+
+#[test]
+fn prints_english_help_when_lang_en_is_requested() {
+    for args in [
+        vec!["--lang", "en"],
+        vec!["help", "--lang", "en"],
+        vec!["--lang", "en", "help"],
+        vec!["--help", "--lang", "en"],
     ] {
         let output = Command::cargo_bin("legolas-cli")
             .expect("build binary")
@@ -423,6 +446,14 @@ fn matches_missing_number_and_unknown_flag_contracts() {
         (
             vec!["--bogus".to_string()],
             "legolas: unknown flag \"--bogus\"\n",
+        ),
+        (
+            vec!["--lang".to_string(), "fr".to_string()],
+            "legolas: --lang expects ko or en\n",
+        ),
+        (
+            vec!["help".to_string(), "--lang".to_string()],
+            "legolas: --lang expects ko or en\n",
         ),
         (
             vec!["scan".to_string(), "--config".to_string()],

--- a/crates/legolas-cli/tests/config_contract.rs
+++ b/crates/legolas-cli/tests/config_contract.rs
@@ -135,10 +135,9 @@ fn help_and_version_do_not_touch_invalid_discovered_config() {
 
     let help_output = run_cli_in_dir(&invalid_root, &[]);
     assert!(help_output.status.success());
-    assert_eq!(
-        support::normalize_cli_output(&stdout(&help_output)),
-        support::read_oracle("cli/help.txt")
-    );
+    let help_stdout = stdout(&help_output);
+    assert!(help_stdout.contains("사용법:"));
+    assert!(help_stdout.contains("전역 옵션:"));
     assert_eq!(stderr(&help_output), "");
 
     let version_output = run_cli_in_dir(&invalid_root, &["--version"]);


### PR DESCRIPTION
## 배경
#79는 CLI 전역 언어 옵션을 추가하고 후속 한글 기본 출력 작업에서 사용할 language plumbing을 준비하는 작업입니다.

## 변경 사항
- `ReportLanguage`와 `CliArgs.lang`을 추가하고 기본값을 `ko`로 설정했습니다.
- 전역 `--lang ko|en` 파싱과 invalid value usage error를 추가했습니다.
- 빈 명령, `help`, `--help` 경로가 language에 맞는 help를 출력하도록 정리했습니다.
- text/SARIF reporter 호출 경로에 language 인자를 전달하는 wrapper를 추가했습니다.
- detailed text copy 변경은 #80 범위로 남겼습니다.

## 검증
- `git diff --check`
- `cargo test -p legolas-cli --test cli_contract`
- `cargo test -p legolas-cli --test config_contract`
- `cargo fmt --all --check`
- `cargo test -p legolas-cli`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## 리뷰 게이트
- Devil’s Advocate Round 1: High 1건 수용 후 수정
- Devil’s Advocate Round 2: Critical/High 없음, pass
- 남은 Medium은 #80 범위의 실제 text localization으로 분류했습니다.

## 브랜치 / 워크트리
- Branch: `codex/feat-79-lang-plumbing`
- Worktree: `/tmp/legolas-wave1/issue-79-lang-plumbing`

Closes #79