### PR TITLE
feat(cli): text 리포트 기본 한글 summary 추가

### DIFF
--- a/crates/legolas-cli/src/reporters/text.rs
+++ b/crates/legolas-cli/src/reporters/text.rs
@@ -1,12 +1,16 @@
 use crate::argv::ReportLanguage;
 use legolas_core::{
-    boundaries::BoundaryWarning, budget::BudgetEvaluation, rank_actions, ActionDifficulty,
-    Analysis, FindingConfidence, FindingEvidence, FindingMetadata, RecommendedFix,
+    boundaries::BoundaryWarning, budget::BudgetEvaluation, rank_actions,
+    report_summary::build_report_summary, ActionDifficulty, Analysis, DuplicateImpactScope,
+    FindingConfidence, FindingEvidence, FindingMetadata, RecommendedFix,
 };
 use std::collections::BTreeMap;
 
-pub fn format_scan_report_for_language(analysis: &Analysis, _language: ReportLanguage) -> String {
-    format_scan_report(analysis)
+pub fn format_scan_report_for_language(analysis: &Analysis, language: ReportLanguage) -> String {
+    match language {
+        ReportLanguage::Ko => format_scan_report_ko(analysis),
+        ReportLanguage::En => format_scan_report(analysis),
+    }
 }
 
 pub fn format_scan_report(analysis: &Analysis) -> String {
@@ -34,18 +38,13 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
     append_workspace_summaries(&mut lines, analysis);
     lines.push(String::new());
     append_boundary_warnings(&mut lines, &analysis.boundary_warnings);
-    lines.push(format!(
-        "Potential payload reduction: ~{} KB",
-        analysis.impact.potential_kb_saved
-    ));
-    lines.push(format!(
-        "Estimated LCP improvement: ~{} ms",
-        analysis.impact.estimated_lcp_improvement_ms
-    ));
-    lines.push(analysis.impact.summary.clone());
+    append_english_summary(&mut lines, analysis);
     append_warnings(&mut lines, &analysis.warnings);
     lines.push(String::new());
 
+    append_top_actions_en(&mut lines, analysis, 5);
+
+    lines.push(String::new());
     lines.push("Heaviest known dependencies:".to_string());
     append_section(
         &mut lines,
@@ -80,11 +79,12 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
         |item, _| {
             with_detail_lines(
                 format!(
-                    "- {}{}: {} ({} KB avoidable)",
+                    "- {}{}: {} ({} KB {})",
                     item.name,
                     confidence_bracket(&item.finding),
                     item.versions.join(", "),
-                    item.estimated_extra_kb
+                    item.estimated_extra_kb,
+                    duplicate_scope_summary_en(item.impact_scope)
                 ),
                 &duplicate_origin_lines(item),
                 &item.finding,
@@ -147,12 +147,149 @@ pub fn format_scan_report(analysis: &Analysis) -> String {
     lines.join("\n")
 }
 
+fn format_scan_report_ko(analysis: &Analysis) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "Legolas scan for {}",
+        analysis.package_summary.name
+    ));
+    lines.push(format!("프로젝트 루트: {}", analysis.project_root));
+    lines.push(format!("모드: {}", analysis.metadata.mode));
+    lines.push(format!(
+        "프레임워크: {}",
+        if analysis.frameworks.is_empty() {
+            "감지 안 됨".to_string()
+        } else {
+            analysis.frameworks.join(", ")
+        }
+    ));
+    lines.push(format!("패키지 매니저: {}", analysis.package_manager));
+    lines.push(format!(
+        "스캔: 소스 파일 {}개, import 패키지 {}개",
+        analysis.source_summary.files_scanned, analysis.source_summary.imported_packages
+    ));
+    append_workspace_summaries_ko(&mut lines, analysis);
+    lines.push(String::new());
+    append_boundary_warnings_ko(&mut lines, &analysis.boundary_warnings);
+    append_korean_summary(&mut lines, analysis);
+    append_warnings_ko(&mut lines, &analysis.warnings);
+    lines.push(String::new());
+
+    append_top_actions_ko(&mut lines, analysis, 5);
+
+    lines.push(String::new());
+    lines.push("가장 무거운 의존성:".to_string());
+    append_section(
+        &mut lines,
+        &analysis.heavy_dependencies,
+        |item, _| {
+            let import_text = if item.imported_by.is_empty() {
+                "소스에서 import가 감지되지 않음".to_string()
+            } else {
+                format!("{}개 파일에서 import됨", item.imported_by.len())
+            };
+            with_evidence(
+                format!(
+                    "- {} ({} KB){}: {} {}.",
+                    item.name,
+                    item.estimated_kb,
+                    confidence_bracket_ko(&item.finding),
+                    item.rationale,
+                    import_text
+                ),
+                &item.finding,
+                "  ",
+            )
+        },
+        "- 없음",
+    );
+
+    lines.push(String::new());
+    lines.push("중복 패키지 버전:".to_string());
+    append_section(
+        &mut lines,
+        &analysis.duplicate_packages,
+        |item, _| {
+            with_detail_lines(
+                format!(
+                    "- {}{}: {} ({} KB {})",
+                    item.name,
+                    confidence_bracket_ko(&item.finding),
+                    item.versions.join(", "),
+                    item.estimated_extra_kb,
+                    duplicate_scope_summary_ko(item.impact_scope)
+                ),
+                &duplicate_origin_lines(item),
+                &item.finding,
+                "  ",
+            )
+        },
+        "- 없음",
+    );
+
+    lines.push(String::new());
+    lines.push("지연 로딩 후보:".to_string());
+    append_section(
+        &mut lines,
+        &analysis.lazy_load_candidates,
+        |item, _| with_evidence(lazy_load_summary_ko(item), &item.finding, "  "),
+        "- 없음",
+    );
+
+    lines.push(String::new());
+    lines.push("트리셰이킹 경고:".to_string());
+    append_section(
+        &mut lines,
+        &analysis.tree_shaking_warnings,
+        |item, _| {
+            with_evidence(
+                format!(
+                    "- {}{}: {}",
+                    item.package_name,
+                    confidence_bracket_ko(&item.finding),
+                    item.message
+                ),
+                &item.finding,
+                "  ",
+            )
+        },
+        "- 없음",
+    );
+
+    lines.push(String::new());
+    lines.push("미사용 의존성 후보:".to_string());
+    append_section(
+        &mut lines,
+        &analysis
+            .unused_dependency_candidates
+            .iter()
+            .take(10)
+            .collect::<Vec<_>>(),
+        |item, _| format!("- {}@{}", item.name, item.version_range),
+        "- 없음",
+    );
+
+    if !analysis.bundle_artifacts.is_empty() {
+        lines.push(String::new());
+        lines.push(format!(
+            "감지된 번들 아티팩트: {}",
+            analysis.bundle_artifacts.join(", ")
+        ));
+    }
+
+    lines.join("\n")
+}
+
 pub fn format_visualization_report_for_language(
     analysis: &Analysis,
     limit: usize,
-    _language: ReportLanguage,
+    language: ReportLanguage,
 ) -> String {
-    format_visualization_report(analysis, limit)
+    match language {
+        ReportLanguage::Ko => format_visualization_report_ko(analysis, limit),
+        ReportLanguage::En => format_visualization_report(analysis, limit),
+    }
 }
 
 pub fn format_visualization_report(analysis: &Analysis, limit: usize) -> String {
@@ -206,12 +343,66 @@ pub fn format_visualization_report(analysis: &Analysis, limit: usize) -> String 
     lines.join("\n")
 }
 
+fn format_visualization_report_ko(analysis: &Analysis, limit: usize) -> String {
+    let mut lines = Vec::new();
+    let normalized_limit = limit.max(1);
+    let heavy_dependencies = analysis
+        .heavy_dependencies
+        .iter()
+        .take(normalized_limit)
+        .map(|item| BarItem {
+            label: item.name.clone(),
+            value: item.estimated_kb,
+        })
+        .collect::<Vec<_>>();
+    let duplicates = analysis
+        .duplicate_packages
+        .iter()
+        .take(normalized_limit)
+        .map(|item| BarItem {
+            label: item.name.clone(),
+            value: item.estimated_extra_kb,
+        })
+        .collect::<Vec<_>>();
+
+    lines.push(format!(
+        "Legolas visualize for {}",
+        analysis.package_summary.name
+    ));
+    append_warnings_ko(&mut lines, &analysis.warnings);
+    lines.push(String::new());
+    lines.push("추정 의존성 무게".to_string());
+    lines.push(render_bars(if heavy_dependencies.is_empty() {
+        vec![BarItem {
+            label: "없음".to_string(),
+            value: 0,
+        }]
+    } else {
+        heavy_dependencies
+    }));
+    lines.push(String::new());
+    lines.push("중복 패키지 압력".to_string());
+    lines.push(render_bars(if duplicates.is_empty() {
+        vec![BarItem {
+            label: "없음".to_string(),
+            value: 0,
+        }]
+    } else {
+        duplicates
+    }));
+
+    lines.join("\n")
+}
+
 pub fn format_optimize_report_for_language(
     analysis: &Analysis,
     top: usize,
-    _language: ReportLanguage,
+    language: ReportLanguage,
 ) -> String {
-    format_optimize_report(analysis, top)
+    match language {
+        ReportLanguage::Ko => format_optimize_report_ko(analysis, top),
+        ReportLanguage::En => format_optimize_report(analysis, top),
+    }
 }
 
 pub fn format_optimize_report(analysis: &Analysis, top: usize) -> String {
@@ -242,12 +433,44 @@ pub fn format_optimize_report(analysis: &Analysis, top: usize) -> String {
     lines.join("\n")
 }
 
+fn format_optimize_report_ko(analysis: &Analysis, top: usize) -> String {
+    let mut lines = Vec::new();
+    let actions = build_actions_for_language(analysis, ReportLanguage::Ko)
+        .into_iter()
+        .take(top.max(1))
+        .collect::<Vec<_>>();
+
+    lines.push(format!(
+        "Legolas optimize for {}",
+        analysis.package_summary.name
+    ));
+    append_warnings_ko(&mut lines, &analysis.warnings);
+    lines.push(String::new());
+    lines.push("Top next actions:".to_string());
+    append_section(
+        &mut lines,
+        &actions,
+        render_action_line_ko,
+        "1. 신뢰도 높은 최적화 후보를 찾지 못했습니다.",
+    );
+    lines.push(String::new());
+    lines.push(format!(
+        "예상 정리 여지: 약 {} KB, 신뢰도 {}.",
+        analysis.impact.potential_kb_saved, analysis.impact.confidence
+    ));
+
+    lines.join("\n")
+}
+
 pub fn format_budget_report_for_language(
     analysis: &Analysis,
     evaluation: &BudgetEvaluation,
-    _language: ReportLanguage,
+    language: ReportLanguage,
 ) -> String {
-    format_budget_report(analysis, evaluation)
+    match language {
+        ReportLanguage::Ko => format_budget_report_ko(analysis, evaluation),
+        ReportLanguage::En => format_budget_report(analysis, evaluation),
+    }
 }
 
 pub fn format_budget_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> String {
@@ -278,12 +501,43 @@ pub fn format_budget_report(analysis: &Analysis, evaluation: &BudgetEvaluation) 
     lines.join("\n")
 }
 
+fn format_budget_report_ko(analysis: &Analysis, evaluation: &BudgetEvaluation) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "Legolas budget for {}",
+        analysis.package_summary.name
+    ));
+    append_warnings_ko(&mut lines, &analysis.warnings);
+    append_workspace_summaries_ko(&mut lines, analysis);
+    lines.push(String::new());
+    lines.push(format!("전체 상태: {:?}", evaluation.overall_status));
+    lines.push(String::new());
+    lines.push("규칙 결과:".to_string());
+    append_section(
+        &mut lines,
+        &evaluation.rules,
+        |item, _| {
+            format!(
+                "- {}: {:?} (actual: {}, warnAt: {}, failAt: {})",
+                item.key, item.status, item.actual, item.warn_at, item.fail_at
+            )
+        },
+        "- 없음",
+    );
+
+    lines.join("\n")
+}
+
 pub fn format_ci_report_for_language(
     analysis: &Analysis,
     evaluation: &BudgetEvaluation,
-    _language: ReportLanguage,
+    language: ReportLanguage,
 ) -> String {
-    format_ci_report(analysis, evaluation)
+    match language {
+        ReportLanguage::Ko => format_ci_report_ko(analysis, evaluation),
+        ReportLanguage::En => format_ci_report(analysis, evaluation),
+    }
 }
 
 pub fn format_ci_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> String {
@@ -304,6 +558,35 @@ pub fn format_ci_report(analysis: &Analysis, evaluation: &BudgetEvaluation) -> S
     lines.push(format!("Overall status: {:?}", evaluation.overall_status));
     lines.push(format!(
         "Rule statuses: {}",
+        evaluation
+            .rules
+            .iter()
+            .map(|item| format!("{}={:?}", item.key, item.status))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    lines.join("\n")
+}
+
+fn format_ci_report_ko(analysis: &Analysis, evaluation: &BudgetEvaluation) -> String {
+    let mut lines = Vec::new();
+
+    lines.push(format!("Legolas CI for {}", analysis.package_summary.name));
+    append_warnings_ko(&mut lines, &analysis.warnings);
+    append_workspace_summaries_ko(&mut lines, analysis);
+    lines.push(String::new());
+    lines.push(format!(
+        "게이트 결과: {}",
+        match evaluation.overall_status {
+            legolas_core::budget::BudgetStatus::Pass => "PASS",
+            legolas_core::budget::BudgetStatus::Warn => "WARN",
+            legolas_core::budget::BudgetStatus::Fail => "FAIL",
+        }
+    ));
+    lines.push(format!("전체 상태: {:?}", evaluation.overall_status));
+    lines.push(format!(
+        "규칙 상태: {}",
         evaluation
             .rules
             .iter()
@@ -340,6 +623,31 @@ fn append_workspace_summaries(lines: &mut Vec<String>, analysis: &Analysis) {
     );
 }
 
+fn append_workspace_summaries_ko(lines: &mut Vec<String>, analysis: &Analysis) {
+    if analysis.workspace_summaries.is_empty() {
+        return;
+    }
+
+    lines.push(String::new());
+    lines.push("워크스페이스 요약:".to_string());
+    append_section(
+        lines,
+        &analysis.workspace_summaries,
+        |item, _| {
+            format!(
+                "- {} ({}): import 패키지 {}개, 무거운 의존성 {}개, 중복 패키지 {}개, 약 {} KB 정리 여지",
+                item.name,
+                item.path,
+                item.imported_packages,
+                item.heavy_dependencies,
+                item.duplicate_packages,
+                item.potential_kb_saved
+            )
+        },
+        "- 없음",
+    );
+}
+
 #[derive(Clone)]
 struct BarItem {
     label: String,
@@ -354,32 +662,39 @@ struct ActionLine {
 }
 
 fn build_actions(analysis: &Analysis) -> Vec<ActionLine> {
-    let ranked = build_ranked_actions(analysis);
+    build_actions_for_language(analysis, ReportLanguage::En)
+}
+
+fn build_actions_for_language(analysis: &Analysis, language: ReportLanguage) -> Vec<ActionLine> {
+    let ranked = build_ranked_actions(analysis, language);
     if !ranked.is_empty() {
         return ranked;
     }
 
-    build_legacy_actions(analysis)
+    build_legacy_actions(analysis, language)
 }
 
-fn build_ranked_actions(analysis: &Analysis) -> Vec<ActionLine> {
-    let contexts = build_action_contexts(analysis);
+fn build_ranked_actions(analysis: &Analysis, language: ReportLanguage) -> Vec<ActionLine> {
+    let contexts = build_action_contexts(analysis, language);
 
     rank_actions(analysis)
         .into_iter()
         .map(|action| {
             let context = contexts.get(&action.finding_id);
             ActionLine {
-                headline: format!(
-                    "{} [{} | {} confidence | ~{} KB]",
+                headline: action_headline(
                     context
                         .map(|item| item.headline.as_str())
                         .unwrap_or(action.finding_id.as_str()),
-                    difficulty_label(action.difficulty),
-                    confidence_label(action.confidence),
-                    action.estimated_savings_kb
+                    action.difficulty,
+                    action.confidence,
+                    action.estimated_savings_kb,
+                    language,
                 ),
-                details: recommended_fix_details(action.recommended_fix.as_ref()),
+                details: recommended_fix_details_for_language(
+                    action.recommended_fix.as_ref(),
+                    language,
+                ),
                 evidence: context
                     .map(|item| item.evidence.clone())
                     .unwrap_or_default(),
@@ -388,16 +703,22 @@ fn build_ranked_actions(analysis: &Analysis) -> Vec<ActionLine> {
         .collect()
 }
 
-fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
+fn build_legacy_actions(analysis: &Analysis, language: ReportLanguage) -> Vec<ActionLine> {
     let mut actions = Vec::new();
 
     for dependency in analysis.heavy_dependencies.iter().take(3) {
         if dependency.imported_by.is_empty() {
             actions.push(ActionLine {
-                headline: format!(
-                    "Remove or justify {}; it is declared but not imported in scanned source files.",
-                    dependency.name
-                ),
+                headline: match language {
+                    ReportLanguage::Ko => format!(
+                        "{} 의존성을 제거하거나 필요성을 설명하세요. 스캔한 소스에서 import가 감지되지 않았습니다.",
+                        dependency.name
+                    ),
+                    ReportLanguage::En => format!(
+                        "Remove or justify {}; it is declared but not imported in scanned source files.",
+                        dependency.name
+                    ),
+                },
                 details: Vec::new(),
                 evidence: display_evidence_lines(&dependency.finding),
             });
@@ -405,7 +726,14 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
         }
 
         actions.push(ActionLine {
-            headline: format!("Review {}: {}", dependency.name, dependency.recommendation),
+            headline: match language {
+                ReportLanguage::Ko => {
+                    format!("{} 검토: {}", dependency.name, dependency.recommendation)
+                }
+                ReportLanguage::En => {
+                    format!("Review {}: {}", dependency.name, dependency.recommendation)
+                }
+            },
             details: Vec::new(),
             evidence: display_evidence_lines(&dependency.finding),
         });
@@ -413,12 +741,7 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
 
     for duplicate in analysis.duplicate_packages.iter().take(3) {
         actions.push(ActionLine {
-            headline: format!(
-                "Deduplicate {} versions ({}) to recover roughly {} KB.",
-                duplicate.name,
-                duplicate.versions.join(", "),
-                duplicate.estimated_extra_kb
-            ),
+            headline: duplicate_action_headline(duplicate, language),
             details: Vec::new(),
             evidence: display_evidence_lines(&duplicate.finding),
         });
@@ -431,10 +754,16 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
             .map(String::as_str)
             .unwrap_or("undefined");
         actions.push(ActionLine {
-            headline: format!(
-                "Lazy load {} in {} to target roughly {} KB of deferred code.",
-                candidate.name, file, candidate.estimated_savings_kb
-            ),
+            headline: match language {
+                ReportLanguage::Ko => format!(
+                    "{}를 {}에서 지연 로딩해 약 {} KB 지연 로딩 여지를 검토하세요.",
+                    candidate.name, file, candidate.estimated_savings_kb
+                ),
+                ReportLanguage::En => format!(
+                    "Lazy load {} in {} to target roughly {} KB of deferred code.",
+                    candidate.name, file, candidate.estimated_savings_kb
+                ),
+            },
             details: Vec::new(),
             evidence: display_evidence_lines(&candidate.finding),
         });
@@ -442,10 +771,16 @@ fn build_legacy_actions(analysis: &Analysis) -> Vec<ActionLine> {
 
     for warning in analysis.tree_shaking_warnings.iter().take(2) {
         actions.push(ActionLine {
-            headline: format!(
-                "Clean up {} imports: {}",
-                warning.package_name, warning.recommendation
-            ),
+            headline: match language {
+                ReportLanguage::Ko => format!(
+                    "{} import 정리: {}",
+                    warning.package_name, warning.recommendation
+                ),
+                ReportLanguage::En => format!(
+                    "Clean up {} imports: {}",
+                    warning.package_name, warning.recommendation
+                ),
+            },
             details: Vec::new(),
             evidence: display_evidence_lines(&warning.finding),
         });
@@ -565,20 +900,33 @@ fn confidence_bracket(finding: &FindingMetadata) -> String {
         .unwrap_or_default()
 }
 
+fn confidence_bracket_ko(finding: &FindingMetadata) -> String {
+    finding
+        .confidence
+        .map(|confidence| format!(" [{} 신뢰도]", confidence_label_ko(confidence)))
+        .unwrap_or_default()
+}
+
 #[derive(Clone)]
 struct ActionContext {
     headline: String,
     evidence: Vec<String>,
 }
 
-fn build_action_contexts(analysis: &Analysis) -> BTreeMap<String, ActionContext> {
+fn build_action_contexts(
+    analysis: &Analysis,
+    language: ReportLanguage,
+) -> BTreeMap<String, ActionContext> {
     let mut contexts = BTreeMap::new();
 
     for dependency in &analysis.heavy_dependencies {
         insert_action_context(
             &mut contexts,
             dependency.finding.finding_id.as_ref(),
-            format!("Review {} upfront bundle weight", dependency.name),
+            match language {
+                ReportLanguage::Ko => format!("{} 초기 번들 무게 검토", dependency.name),
+                ReportLanguage::En => format!("Review {} upfront bundle weight", dependency.name),
+            },
             &dependency.finding,
         );
     }
@@ -587,11 +935,7 @@ fn build_action_contexts(analysis: &Analysis) -> BTreeMap<String, ActionContext>
         insert_action_context(
             &mut contexts,
             duplicate.finding.finding_id.as_ref(),
-            format!(
-                "Deduplicate {} versions ({})",
-                duplicate.name,
-                duplicate.versions.join(", ")
-            ),
+            duplicate_context_headline(duplicate, language),
             &duplicate.finding,
         );
     }
@@ -600,7 +944,10 @@ fn build_action_contexts(analysis: &Analysis) -> BTreeMap<String, ActionContext>
         insert_action_context(
             &mut contexts,
             candidate.finding.finding_id.as_ref(),
-            format!("Lazy load {}", candidate.name),
+            match language {
+                ReportLanguage::Ko => format!("{} 지연 로딩", candidate.name),
+                ReportLanguage::En => format!("Lazy load {}", candidate.name),
+            },
             &candidate.finding,
         );
     }
@@ -609,7 +956,10 @@ fn build_action_contexts(analysis: &Analysis) -> BTreeMap<String, ActionContext>
         insert_action_context(
             &mut contexts,
             warning.finding.finding_id.as_ref(),
-            format!("Clean up {} imports", warning.package_name),
+            match language {
+                ReportLanguage::Ko => format!("{} import 정리", warning.package_name),
+                ReportLanguage::En => format!("Clean up {} imports", warning.package_name),
+            },
             &warning.finding,
         );
     }
@@ -644,8 +994,24 @@ fn difficulty_label(difficulty: ActionDifficulty) -> &'static str {
     }
 }
 
+fn difficulty_label_ko(difficulty: ActionDifficulty) -> &'static str {
+    match difficulty {
+        ActionDifficulty::Easy => "쉬움",
+        ActionDifficulty::Medium => "보통",
+        ActionDifficulty::Hard => "어려움",
+    }
+}
+
 fn confidence_label(confidence: FindingConfidence) -> &'static str {
     confidence_display(confidence)
+}
+
+fn confidence_label_ko(confidence: FindingConfidence) -> &'static str {
+    match confidence {
+        FindingConfidence::Low => "낮음",
+        FindingConfidence::Medium => "중간",
+        FindingConfidence::High => "높음",
+    }
 }
 
 fn confidence_phrase(confidence: FindingConfidence) -> &'static str {
@@ -664,31 +1030,82 @@ fn confidence_display(confidence: FindingConfidence) -> &'static str {
     }
 }
 
-fn recommended_fix_details(recommended_fix: Option<&RecommendedFix>) -> Vec<String> {
+fn recommended_fix_details_for_language(
+    recommended_fix: Option<&RecommendedFix>,
+    language: ReportLanguage,
+) -> Vec<String> {
     let Some(recommended_fix) = recommended_fix else {
         return Vec::new();
     };
 
-    let mut details = vec![format!(
-        "recommended fix: {} - {}",
-        recommended_fix.kind, recommended_fix.title
-    )];
+    let mut details = vec![match language {
+        ReportLanguage::Ko => format!(
+            "권장 수정: {} - {}",
+            recommended_fix.kind, recommended_fix.title
+        ),
+        ReportLanguage::En => format!(
+            "recommended fix: {} - {}",
+            recommended_fix.kind, recommended_fix.title
+        ),
+    }];
 
     if !recommended_fix.target_files.is_empty() {
-        details.push(format!(
-            "targets: {}",
-            recommended_fix.target_files.join(", ")
-        ));
+        details.push(match language {
+            ReportLanguage::Ko => format!("대상: {}", recommended_fix.target_files.join(", ")),
+            ReportLanguage::En => format!("targets: {}", recommended_fix.target_files.join(", ")),
+        });
     }
 
     if let Some(replacement) = recommended_fix.replacement.as_deref() {
-        details.push(format!("replacement: {replacement}"));
+        details.push(match language {
+            ReportLanguage::Ko => format!("대체 후보: {replacement}"),
+            ReportLanguage::En => format!("replacement: {replacement}"),
+        });
     }
 
     details
 }
 
+fn action_headline(
+    base: &str,
+    difficulty: ActionDifficulty,
+    confidence: FindingConfidence,
+    estimated_savings_kb: usize,
+    language: ReportLanguage,
+) -> String {
+    match language {
+        ReportLanguage::Ko => format!(
+            "{} [난이도: {} | 신뢰도: {} | ~{} KB]",
+            base,
+            difficulty_label_ko(difficulty),
+            confidence_label_ko(confidence),
+            estimated_savings_kb
+        ),
+        ReportLanguage::En => format!(
+            "{} [{} | {} confidence | ~{} KB]",
+            base,
+            difficulty_label(difficulty),
+            confidence_label(confidence),
+            estimated_savings_kb
+        ),
+    }
+}
+
 fn render_action_line(item: &ActionLine, index: usize) -> String {
+    let mut lines = vec![format!("{}. {}", index + 1, item.headline)];
+
+    for detail in &item.details {
+        lines.push(format!("   {detail}"));
+    }
+
+    for evidence in &item.evidence {
+        lines.push(format!("   evidence: {evidence}"));
+    }
+
+    lines.join("\n")
+}
+
+fn render_action_line_ko(item: &ActionLine, index: usize) -> String {
     let mut lines = vec![format!("{}. {}", index + 1, item.headline)];
 
     for detail in &item.details {
@@ -763,6 +1180,213 @@ fn format_origin_chain(origin: &legolas_core::DuplicateOrigin) -> String {
     chain.join(" -> ")
 }
 
+fn append_korean_summary(lines: &mut Vec<String>, analysis: &Analysis) {
+    let summary = build_report_summary(analysis);
+    let has_confirmed_initial_payload_savings = summary.confirmed_initial_payload_kb_saved > 0;
+
+    lines.push(format!("판정: {}", verdict_label_ko(&summary.verdict_key)));
+    if has_confirmed_initial_payload_savings {
+        lines.push(format!(
+            "확정 초기 페이로드 절감: 약 {} KB (LCP 약 {} ms 개선 추정)",
+            summary.confirmed_initial_payload_kb_saved, summary.estimated_lcp_improvement_ms
+        ));
+    } else {
+        lines.push(
+            "확정 초기 페이로드 절감: 미확정 (중복 의존성 압력만으로는 초기 페이로드/LCP 절감을 확정하지 않음)"
+                .to_string(),
+        );
+    }
+    lines.push(format!(
+        "방향성 정리 여지: 약 {} KB",
+        summary.directional_opportunity_kb
+    ));
+}
+
+fn append_english_summary(lines: &mut Vec<String>, analysis: &Analysis) {
+    let summary = build_report_summary(analysis);
+    let has_confirmed_initial_payload_savings = summary.confirmed_initial_payload_kb_saved > 0;
+
+    lines.push(format!(
+        "Verdict: {}",
+        verdict_label_en(&summary.verdict_key)
+    ));
+    if has_confirmed_initial_payload_savings {
+        lines.push(format!(
+            "Confirmed initial payload savings: ~{} KB (estimated LCP improvement ~{} ms)",
+            summary.confirmed_initial_payload_kb_saved, summary.estimated_lcp_improvement_ms
+        ));
+    } else {
+        lines.push(
+            "Confirmed initial payload savings: not confirmed (duplicate dependency pressure alone does not confirm initial payload or LCP savings)"
+                .to_string(),
+        );
+    }
+    lines.push(format!(
+        "Directional cleanup opportunity: ~{} KB",
+        summary.directional_opportunity_kb
+    ));
+}
+
+fn append_top_actions_ko(lines: &mut Vec<String>, analysis: &Analysis, limit: usize) {
+    let actions = build_actions_for_language(analysis, ReportLanguage::Ko)
+        .into_iter()
+        .take(limit.max(1))
+        .collect::<Vec<_>>();
+
+    lines.push("Top next actions:".to_string());
+    append_section(
+        lines,
+        &actions,
+        render_action_line_ko,
+        "1. 신뢰도 높은 다음 조치를 찾지 못했습니다.",
+    );
+}
+
+fn append_top_actions_en(lines: &mut Vec<String>, analysis: &Analysis, limit: usize) {
+    let actions = build_actions_for_language(analysis, ReportLanguage::En)
+        .into_iter()
+        .take(limit.max(1))
+        .collect::<Vec<_>>();
+
+    lines.push("Top next actions:".to_string());
+    append_section(
+        lines,
+        &actions,
+        render_action_line,
+        "1. No high-confidence optimization candidates were found.",
+    );
+}
+
+fn verdict_label_ko(verdict_key: &str) -> &'static str {
+    match verdict_key {
+        "high-impact" => "큰 폭 절감 가능",
+        "medium-impact" => "의미 있는 절감 가능",
+        "targeted-impact" => "국소 개선 가능",
+        "low-impact" => "명확한 절감 근거 제한적",
+        _ => "추가 확인 필요",
+    }
+}
+
+fn verdict_label_en(verdict_key: &str) -> &'static str {
+    match verdict_key {
+        "high-impact" => "high impact",
+        "medium-impact" => "meaningful impact",
+        "targeted-impact" => "targeted impact",
+        "low-impact" => "limited confirmed impact",
+        _ => "needs review",
+    }
+}
+
+fn duplicate_scope_summary_ko(scope: DuplicateImpactScope) -> &'static str {
+    match scope {
+        DuplicateImpactScope::ProductionLikely => "초기 페이로드 절감 후보",
+        DuplicateImpactScope::DevOnly => "개발/테스트 의존성 중복 정리, dependency hygiene",
+        DuplicateImpactScope::Unknown => "방향성 정리 여지",
+    }
+}
+
+fn duplicate_scope_summary_en(scope: DuplicateImpactScope) -> &'static str {
+    match scope {
+        DuplicateImpactScope::ProductionLikely => "initial payload candidate",
+        DuplicateImpactScope::DevOnly => {
+            "development/test dependency duplication, dependency hygiene"
+        }
+        DuplicateImpactScope::Unknown => "directional cleanup opportunity",
+    }
+}
+
+fn duplicate_context_headline(
+    duplicate: &legolas_core::DuplicatePackage,
+    language: ReportLanguage,
+) -> String {
+    match (language, duplicate.impact_scope) {
+        (ReportLanguage::Ko, DuplicateImpactScope::DevOnly) => format!(
+            "{} 개발/테스트 의존성 중복 정리 ({})",
+            duplicate.name,
+            duplicate.versions.join(", ")
+        ),
+        (ReportLanguage::Ko, _) => format!(
+            "{} 버전 중복 정리 ({})",
+            duplicate.name,
+            duplicate.versions.join(", ")
+        ),
+        (ReportLanguage::En, DuplicateImpactScope::DevOnly) => format!(
+            "Clean up {} development/test dependency duplication ({})",
+            duplicate.name,
+            duplicate.versions.join(", ")
+        ),
+        (ReportLanguage::En, _) => format!(
+            "Deduplicate {} versions ({})",
+            duplicate.name,
+            duplicate.versions.join(", ")
+        ),
+    }
+}
+
+fn duplicate_action_headline(
+    duplicate: &legolas_core::DuplicatePackage,
+    language: ReportLanguage,
+) -> String {
+    match (language, duplicate.impact_scope) {
+        (ReportLanguage::Ko, DuplicateImpactScope::DevOnly) => format!(
+            "{} 개발/테스트 의존성 중복({})을 정리하세요. 약 {} KB의 dependency hygiene 여지입니다.",
+            duplicate.name,
+            duplicate.versions.join(", "),
+            duplicate.estimated_extra_kb
+        ),
+        (ReportLanguage::Ko, _) => format!(
+            "{} 버전 중복({})을 정리해 약 {} KB의 방향성 정리 여지를 확인하세요.",
+            duplicate.name,
+            duplicate.versions.join(", "),
+            duplicate.estimated_extra_kb
+        ),
+        (ReportLanguage::En, DuplicateImpactScope::DevOnly) => format!(
+            "Clean up {} development/test dependency duplication ({}) for roughly {} KB of dependency hygiene.",
+            duplicate.name,
+            duplicate.versions.join(", "),
+            duplicate.estimated_extra_kb
+        ),
+        (ReportLanguage::En, _) => format!(
+            "Deduplicate {} versions ({}) to recover roughly {} KB.",
+            duplicate.name,
+            duplicate.versions.join(", "),
+            duplicate.estimated_extra_kb
+        ),
+    }
+}
+
+fn lazy_load_summary_ko(item: &legolas_core::LazyLoadCandidate) -> String {
+    if item.reason.contains("route-aware") && !item.files.is_empty() {
+        if item.files.len() == 1 {
+            return format!(
+                "- {}{}: route surface {}에서 {}를 정적 import합니다. 지연 로딩 검토 여지 {} KB.",
+                item.name,
+                confidence_bracket_ko(&item.finding),
+                item.files[0],
+                item.name,
+                item.estimated_savings_kb
+            );
+        }
+
+        return format!(
+            "- {}{}: route surfaces {}에서 {}를 정적 import합니다. 지연 로딩 검토 여지 {} KB.",
+            item.name,
+            confidence_bracket_ko(&item.finding),
+            item.files.join(", "),
+            item.name,
+            item.estimated_savings_kb
+        );
+    }
+
+    format!(
+        "- {}{}: {}. 지연 로딩 검토 여지 {} KB.",
+        item.name,
+        confidence_bracket_ko(&item.finding),
+        item.reason,
+        item.estimated_savings_kb
+    )
+}
+
 fn append_warnings(lines: &mut Vec<String>, warnings: &[String]) {
     if warnings.is_empty() {
         return;
@@ -770,6 +1394,18 @@ fn append_warnings(lines: &mut Vec<String>, warnings: &[String]) {
 
     lines.push(String::new());
     lines.push("Warnings:".to_string());
+    for warning in warnings {
+        lines.push(format!("- {warning}"));
+    }
+}
+
+fn append_warnings_ko(lines: &mut Vec<String>, warnings: &[String]) {
+    if warnings.is_empty() {
+        return;
+    }
+
+    lines.push(String::new());
+    lines.push("경고:".to_string());
     for warning in warnings {
         lines.push(format!("- {warning}"));
     }
@@ -784,6 +1420,22 @@ fn append_boundary_warnings(lines: &mut Vec<String>, warnings: &[BoundaryWarning
     for warning in warnings {
         lines.push(format!("- {}", warning.message));
         lines.push(format!("  recommendation: {}", warning.recommendation));
+        for evidence in display_evidence_lines(&warning.finding) {
+            lines.push(format!("  evidence: {evidence}"));
+        }
+    }
+    lines.push(String::new());
+}
+
+fn append_boundary_warnings_ko(lines: &mut Vec<String>, warnings: &[BoundaryWarning]) {
+    if warnings.is_empty() {
+        return;
+    }
+
+    lines.push("경계 경고:".to_string());
+    for warning in warnings {
+        lines.push(format!("- {}", warning.message));
+        lines.push(format!("  권장: {}", warning.recommendation));
         for evidence in display_evidence_lines(&warning.finding) {
             lines.push(format!("  evidence: {evidence}"));
         }

--- a/crates/legolas-cli/tests/baseline_contract.rs
+++ b/crates/legolas-cli/tests/baseline_contract.rs
@@ -179,7 +179,7 @@ fn regression_only_scan_text_only_mentions_new_findings() {
     assert!(stdout.contains("Legolas scan for baseline-app"));
     assert!(stdout.contains("- chart.js"));
     assert!(stdout.contains("- lodash"));
-    assert!(stdout.contains("Tree-shaking warnings:"));
+    assert!(stdout.contains("트리셰이킹 경고:"));
     assert!(stdout
         .contains("Root lodash imports often keep more code than expected in client bundles."));
 }

--- a/crates/legolas-cli/tests/budget_contract.rs
+++ b/crates/legolas-cli/tests/budget_contract.rs
@@ -113,9 +113,9 @@ fn budget_text_output_uses_built_in_starter_thresholds() {
         "\
 Legolas budget for basic-parity-app
 
-Overall status: Fail
+전체 상태: Fail
 
-Rule results:
+규칙 결과:
 - potentialKbSaved: Fail (actual: 348, warnAt: 40, failAt: 80)
 - duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
 - dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)
@@ -318,9 +318,13 @@ fn budget_text_output_includes_workspace_summaries_for_monorepos() {
 
     assert!(output.status.success());
     let stdout = stdout(&output);
-    assert!(stdout.contains("Workspace summaries:"));
-    assert!(stdout.contains("admin-app (apps/admin): 3 imported packages, 2 heavy dependencies, 0 duplicate packages, ~42 KB potential saved"));
-    assert!(stdout.contains("storefront-app (apps/storefront): 2 imported packages, 1 heavy dependencies, 0 duplicate packages, ~13 KB potential saved"));
+    assert!(stdout.contains("워크스페이스 요약:"));
+    assert!(stdout.contains(
+        "admin-app (apps/admin): import 패키지 3개, 무거운 의존성 2개, 중복 패키지 0개, 약 42 KB 정리 여지"
+    ));
+    assert!(stdout.contains(
+        "storefront-app (apps/storefront): import 패키지 2개, 무거운 의존성 1개, 중복 패키지 0개, 약 13 KB 정리 여지"
+    ));
 }
 
 #[test]

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -118,9 +118,9 @@ fn ci_fail_returns_exit_code_one_and_fixed_failure_prefix() {
         "\
 Legolas CI for basic-parity-app
 
-Gate result: FAIL
-Overall status: Fail
-Rule statuses: potentialKbSaved=Fail, duplicatePackageCount=Pass, dynamicImportCount=Fail
+게이트 결과: FAIL
+전체 상태: Fail
+규칙 상태: potentialKbSaved=Fail, duplicatePackageCount=Pass, dynamicImportCount=Fail
 "
     );
     assert_eq!(
@@ -140,9 +140,9 @@ fn ci_warn_keeps_exit_code_zero() {
         "\
 Legolas CI for ci-warn-app
 
-Gate result: WARN
-Overall status: Warn
-Rule statuses: potentialKbSaved=Pass, duplicatePackageCount=Pass, dynamicImportCount=Warn
+게이트 결과: WARN
+전체 상태: Warn
+규칙 상태: potentialKbSaved=Pass, duplicatePackageCount=Pass, dynamicImportCount=Warn
 "
     );
     assert_eq!(stderr(&output), "");
@@ -159,9 +159,9 @@ fn ci_pass_keeps_exit_code_zero() {
         "\
 Legolas CI for ci-pass-app
 
-Gate result: PASS
-Overall status: Pass
-Rule statuses: potentialKbSaved=Pass, duplicatePackageCount=Pass, dynamicImportCount=Pass
+게이트 결과: PASS
+전체 상태: Pass
+규칙 상태: potentialKbSaved=Pass, duplicatePackageCount=Pass, dynamicImportCount=Pass
 "
     );
     assert_eq!(stderr(&output), "");
@@ -348,9 +348,9 @@ fn ci_suppresses_config_warnings_to_keep_failure_prefix_stable() {
         "\
 Legolas CI for basic-parity-app
 
-Gate result: FAIL
-Overall status: Fail
-Rule statuses: potentialKbSaved=Fail, duplicatePackageCount=Pass, dynamicImportCount=Fail
+게이트 결과: FAIL
+전체 상태: Fail
+규칙 상태: potentialKbSaved=Fail, duplicatePackageCount=Pass, dynamicImportCount=Fail
 "
     );
     assert_eq!(
@@ -366,9 +366,13 @@ fn ci_text_output_includes_workspace_summaries_for_monorepos() {
 
     assert!(!output.status.success());
     let stdout = stdout(&output);
-    assert!(stdout.contains("Workspace summaries:"));
-    assert!(stdout.contains("admin-app (apps/admin): 3 imported packages, 2 heavy dependencies, 0 duplicate packages, ~42 KB potential saved"));
-    assert!(stdout.contains("storefront-app (apps/storefront): 2 imported packages, 1 heavy dependencies, 0 duplicate packages, ~13 KB potential saved"));
+    assert!(stdout.contains("워크스페이스 요약:"));
+    assert!(stdout.contains(
+        "admin-app (apps/admin): import 패키지 3개, 무거운 의존성 2개, 중복 패키지 0개, 약 42 KB 정리 여지"
+    ));
+    assert!(stdout.contains(
+        "storefront-app (apps/storefront): import 패키지 2개, 무거운 의존성 1개, 중복 패키지 0개, 약 13 KB 정리 여지"
+    ));
 }
 
 fn dynamic_import_project(name: &str, dynamic_imports: usize) -> TempDir {

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -183,9 +183,13 @@ fn monorepo_scan_outputs_workspace_summaries_in_text_and_json() {
         .expect("run monorepo scan");
     assert!(text_output.status.success());
     let text_stdout = String::from_utf8(text_output.stdout).expect("stdout");
-    assert!(text_stdout.contains("Workspace summaries:"));
-    assert!(text_stdout.contains("admin-app (apps/admin): 3 imported packages, 2 heavy dependencies, 0 duplicate packages, ~42 KB potential saved"));
-    assert!(text_stdout.contains("storefront-app (apps/storefront): 2 imported packages, 1 heavy dependencies, 0 duplicate packages, ~13 KB potential saved"));
+    assert!(text_stdout.contains("워크스페이스 요약:"));
+    assert!(text_stdout.contains(
+        "admin-app (apps/admin): import 패키지 3개, 무거운 의존성 2개, 중복 패키지 0개, 약 42 KB 정리 여지"
+    ));
+    assert!(text_stdout.contains(
+        "storefront-app (apps/storefront): import 패키지 2개, 무거운 의존성 1개, 중복 패키지 0개, 약 13 KB 정리 여지"
+    ));
     assert_eq!(String::from_utf8(text_output.stderr).expect("stderr"), "");
 
     let json_output = Command::cargo_bin("legolas-cli")

--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -1,12 +1,15 @@
 mod support;
 
+use legolas_cli::argv::ReportLanguage;
 use legolas_cli::reporters::text::{
-    format_optimize_report, format_scan_report, format_visualization_report,
+    format_budget_report_for_language, format_optimize_report, format_optimize_report_for_language,
+    format_scan_report, format_scan_report_for_language, format_visualization_report,
+    format_visualization_report_for_language,
 };
 use legolas_core::{
-    Analysis, DuplicateImpactScope, DuplicateOrigin, DuplicatePackage, FindingAnalysisSource,
-    FindingConfidence, FindingEvidence, FindingMetadata, HeavyDependency, Impact,
-    LazyLoadCandidate, Metadata, PackageSummary, SourceSummary,
+    budget::evaluate_budget, Analysis, DuplicateImpactScope, DuplicateOrigin, DuplicatePackage,
+    FindingAnalysisSource, FindingConfidence, FindingEvidence, FindingMetadata, HeavyDependency,
+    Impact, LazyLoadCandidate, Metadata, PackageSummary, SourceSummary,
 };
 
 fn load_analysis() -> Analysis {
@@ -21,14 +24,47 @@ fn assert_report_matches_oracle(actual: String, oracle: &str) {
 fn matches_scan_visualize_and_optimize_oracles() {
     let analysis = load_analysis();
 
-    assert_report_matches_oracle(format_scan_report(&analysis), "basic-app/scan.txt");
     assert_report_matches_oracle(
-        format_visualization_report(&analysis, 10),
+        format_scan_report_for_language(&analysis, ReportLanguage::Ko),
+        "basic-app/scan.txt",
+    );
+    assert_report_matches_oracle(
+        format_visualization_report_for_language(&analysis, 10, ReportLanguage::Ko),
         "basic-app/visualize.txt",
     );
     assert_report_matches_oracle(
-        format_optimize_report(&analysis, 5),
+        format_optimize_report_for_language(&analysis, 5, ReportLanguage::Ko),
         "basic-app/optimize.txt",
+    );
+    assert_report_matches_oracle(
+        format_budget_report_for_language(
+            &analysis,
+            &evaluate_budget(&analysis, None),
+            ReportLanguage::Ko,
+        ),
+        "basic-app/budget.txt",
+    );
+}
+
+#[test]
+fn english_language_wrappers_keep_existing_output() {
+    let analysis = load_analysis();
+    let scan = format_scan_report_for_language(&analysis, ReportLanguage::En);
+
+    assert_eq!(scan, format_scan_report(&analysis));
+    assert!(scan.contains("Verdict: high impact"));
+    assert!(scan.contains(
+        "Confirmed initial payload savings: ~348 KB (estimated LCP improvement ~731 ms)"
+    ));
+    assert!(scan.contains("Directional cleanup opportunity: ~366 KB"));
+    assert!(scan.contains("Top next actions:"));
+    assert_eq!(
+        format_visualization_report_for_language(&analysis, 10, ReportLanguage::En),
+        format_visualization_report(&analysis, 10)
+    );
+    assert_eq!(
+        format_optimize_report_for_language(&analysis, 5, ReportLanguage::En),
+        format_optimize_report(&analysis, 5)
     );
 }
 
@@ -178,7 +214,8 @@ fn scan_report_renders_all_duplicate_origin_lines() {
     }];
 
     let scan = format_scan_report(&analysis);
-    assert!(scan.contains("- lodash: 4.17.19, 4.17.20, 4.17.21 (36 KB avoidable)"));
+    assert!(scan
+        .contains("- lodash: 4.17.19, 4.17.20, 4.17.21 (36 KB directional cleanup opportunity)"));
     assert!(scan.contains("  origin: 4.17.19 via shell -> shared"));
     assert!(scan.contains("  origin: 4.17.20 via admin"));
     assert!(scan.contains("  origin: 4.17.21 via docs -> shared"));
@@ -264,9 +301,12 @@ fn scan_report_covers_empty_section_fallbacks() {
             "Package manager: npm\n",
             "Scanned 0 source files and 0 imported packages\n",
             "\n",
-            "Potential payload reduction: ~0 KB\n",
-            "Estimated LCP improvement: ~0 ms\n",
-            "Low impact: obvious bundle issues are limited in the current scan.\n",
+            "Verdict: limited confirmed impact\n",
+            "Confirmed initial payload savings: not confirmed (duplicate dependency pressure alone does not confirm initial payload or LCP savings)\n",
+            "Directional cleanup opportunity: ~0 KB\n",
+            "\n",
+            "Top next actions:\n",
+            "1. No high-confidence optimization candidates were found.\n",
             "\n",
             "Heaviest known dependencies:\n",
             "- none\n",
@@ -284,6 +324,110 @@ fn scan_report_covers_empty_section_fallbacks() {
             "- none"
         )
     );
+}
+
+#[test]
+fn korean_scan_report_does_not_confirm_lcp_savings_for_duplicate_only_pressure() {
+    let mut analysis = base_analysis("duplicate-only-app");
+    analysis.duplicate_packages = vec![DuplicatePackage {
+        name: "vitest".to_string(),
+        versions: vec!["1.6.0".to_string(), "2.0.0".to_string()],
+        count: 2,
+        estimated_extra_kb: 48,
+        impact_scope: DuplicateImpactScope::Unknown,
+        finding: FindingMetadata::new(
+            "duplicate-package:vitest",
+            FindingAnalysisSource::LockfileTrace,
+        )
+        .with_confidence(FindingConfidence::Medium),
+        ..DuplicatePackage::default()
+    }];
+
+    let report = format_scan_report_for_language(&analysis, ReportLanguage::Ko);
+
+    assert!(report.contains("판정:"));
+    assert!(report.contains("확정 초기 페이로드 절감: 미확정"));
+    assert!(!report.contains("LCP 약"));
+    assert!(report.contains("방향성 정리 여지: 약 48 KB"));
+    assert!(report.contains("Top next actions:"));
+}
+
+#[test]
+fn korean_scan_report_renders_dev_only_duplicates_as_dependency_hygiene() {
+    let mut analysis = base_analysis("dev-duplicate-app");
+    analysis.duplicate_packages = vec![DuplicatePackage {
+        name: "vitest".to_string(),
+        versions: vec!["1.6.0".to_string(), "2.0.0".to_string()],
+        count: 2,
+        estimated_extra_kb: 48,
+        impact_scope: DuplicateImpactScope::DevOnly,
+        finding: FindingMetadata::new(
+            "duplicate-package:vitest",
+            FindingAnalysisSource::LockfileTrace,
+        )
+        .with_confidence(FindingConfidence::Medium),
+        ..DuplicatePackage::default()
+    }];
+
+    let report = format_scan_report_for_language(&analysis, ReportLanguage::Ko);
+
+    assert!(report.contains("vitest 개발/테스트 의존성 중복 정리"));
+    assert!(report.contains("개발/테스트 의존성 중복 정리"));
+    assert!(report.contains("dependency hygiene"));
+    assert!(report.contains("확정 초기 페이로드 절감: 미확정"));
+}
+
+#[test]
+fn english_scan_report_renders_dev_only_duplicates_as_dependency_hygiene() {
+    let mut analysis = base_analysis("dev-duplicate-app");
+    analysis.duplicate_packages = vec![DuplicatePackage {
+        name: "vitest".to_string(),
+        versions: vec!["1.6.0".to_string(), "2.0.0".to_string()],
+        count: 2,
+        estimated_extra_kb: 48,
+        impact_scope: DuplicateImpactScope::DevOnly,
+        finding: FindingMetadata::new(
+            "duplicate-package:vitest",
+            FindingAnalysisSource::LockfileTrace,
+        )
+        .with_confidence(FindingConfidence::Medium),
+        ..DuplicatePackage::default()
+    }];
+
+    let report = format_scan_report_for_language(&analysis, ReportLanguage::En);
+
+    assert!(report.contains("development/test dependency duplication"));
+    assert!(report.contains("dependency hygiene"));
+    assert!(!report.contains("48 KB avoidable"));
+    assert!(report.contains("Confirmed initial payload savings: not confirmed"));
+}
+
+#[test]
+fn scan_report_confirms_production_likely_duplicate_savings_without_other_findings() {
+    let mut analysis = base_analysis("production-duplicate-app");
+    analysis.duplicate_packages = vec![DuplicatePackage {
+        name: "lodash".to_string(),
+        versions: vec!["4.17.20".to_string(), "4.17.21".to_string()],
+        count: 2,
+        estimated_extra_kb: 48,
+        impact_scope: DuplicateImpactScope::ProductionLikely,
+        finding: FindingMetadata::new(
+            "duplicate-package:lodash",
+            FindingAnalysisSource::LockfileTrace,
+        )
+        .with_confidence(FindingConfidence::High),
+        ..DuplicatePackage::default()
+    }];
+
+    let ko_report = format_scan_report_for_language(&analysis, ReportLanguage::Ko);
+    let en_report = format_scan_report_for_language(&analysis, ReportLanguage::En);
+
+    assert!(ko_report.contains("확정 초기 페이로드 절감: 약 48 KB"));
+    assert!(!ko_report.contains("확정 초기 페이로드 절감: 미확정"));
+    assert!(ko_report.contains("초기 페이로드 절감 후보"));
+    assert!(en_report.contains("Confirmed initial payload savings: ~48 KB"));
+    assert!(!en_report.contains("Confirmed initial payload savings: not confirmed"));
+    assert!(en_report.contains("initial payload candidate"));
 }
 
 #[test]

--- a/scripts/smoke-packed-install.mjs
+++ b/scripts/smoke-packed-install.mjs
@@ -68,7 +68,7 @@ if (!scan.stdout.includes("Legolas scan for basic-parity-app")) {
   throw new Error(`installed legolas scan did not report the basic fixture:\n${scan.stdout}`);
 }
 
-if (!scan.stdout.includes("Scanned 1 source files")) {
+if (!scan.stdout.includes("스캔: 소스 파일 1개")) {
   throw new Error(`installed legolas scan did not report the expected source count:\n${scan.stdout}`);
 }
 

--- a/tests/oracles/basic-app/budget.txt
+++ b/tests/oracles/basic-app/budget.txt
@@ -1,8 +1,8 @@
 Legolas budget for basic-parity-app
 
-Overall status: Fail
+전체 상태: Fail
 
-Rule results:
+규칙 결과:
 - potentialKbSaved: Fail (actual: 348, warnAt: 40, failAt: 80)
 - duplicatePackageCount: Pass (actual: 1, warnAt: 2, failAt: 4)
 - dynamicImportCount: Fail (actual: 0, warnAt: 1, failAt: 0)

--- a/tests/oracles/basic-app/optimize.txt
+++ b/tests/oracles/basic-app/optimize.txt
@@ -1,21 +1,22 @@
 Legolas optimize for basic-parity-app
 
-1. Review chart.js upfront bundle weight [hard | high confidence | ~160 KB]
-   recommended fix: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
-   targets: src/Dashboard.tsx
+Top next actions:
+1. chart.js 초기 번들 무게 검토 [난이도: 어려움 | 신뢰도: 높음 | ~160 KB]
+   권장 수정: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
+   대상: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
-2. Lazy load chart.js [medium | low confidence | ~120 KB]
+2. chart.js 지연 로딩 [난이도: 보통 | 신뢰도: 낮음 | ~120 KB]
    evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
-3. Review react-icons upfront bundle weight [hard | high confidence | ~90 KB]
-   recommended fix: narrow-import - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
-   targets: src/Dashboard.tsx
+3. react-icons 초기 번들 무게 검토 [난이도: 어려움 | 신뢰도: 높음 | ~90 KB]
+   권장 수정: narrow-import - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
+   대상: src/Dashboard.tsx
    evidence: src/Dashboard.tsx | specifier: react-icons | static import; Wide icon-pack imports can defeat tree shaking.
-4. Review lodash upfront bundle weight [hard | high confidence | ~72 KB]
-   recommended fix: narrow-import - Use per-method imports or switch to lodash-es when the toolchain supports it.
-   targets: src/Dashboard.tsx
-   replacement: lodash-es
+4. lodash 초기 번들 무게 검토 [난이도: 어려움 | 신뢰도: 높음 | ~72 KB]
+   권장 수정: narrow-import - Use per-method imports or switch to lodash-es when the toolchain supports it.
+   대상: src/Dashboard.tsx
+   대체 후보: lodash-es
    evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
-5. Lazy load react-icons [medium | low confidence | ~68 KB]
+5. react-icons 지연 로딩 [난이도: 보통 | 신뢰도: 낮음 | ~68 KB]
    evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
 
-Projected savings: ~348 KB, with directional confidence.
+예상 정리 여지: 약 348 KB, 신뢰도 directional.

--- a/tests/oracles/basic-app/scan.txt
+++ b/tests/oracles/basic-app/scan.txt
@@ -1,40 +1,59 @@
 Legolas scan for basic-parity-app
-Project root: <PROJECT_ROOT>
-Mode: heuristic
-Frameworks: Vite, React
-Package manager: pnpm
-Scanned 1 source files and 4 imported packages
+프로젝트 루트: <PROJECT_ROOT>
+모드: heuristic
+프레임워크: Vite, React
+패키지 매니저: pnpm
+스캔: 소스 파일 1개, import 패키지 4개
 
-Potential payload reduction: ~348 KB
-Estimated LCP improvement: ~731 ms
-High impact: the project has clear opportunities to reduce initial payload size.
+판정: 큰 폭 절감 가능
+확정 초기 페이로드 절감: 약 348 KB (LCP 약 731 ms 개선 추정)
+방향성 정리 여지: 약 366 KB
 
-Heaviest known dependencies:
-- chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s).
+Top next actions:
+1. chart.js 초기 번들 무게 검토 [난이도: 어려움 | 신뢰도: 높음 | ~160 KB]
+   권장 수정: lazy-load - Register only the chart primitives you use and lazy load dashboard surfaces.
+   대상: src/Dashboard.tsx
+   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
+2. chart.js 지연 로딩 [난이도: 보통 | 신뢰도: 낮음 | ~120 KB]
+   evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
+3. react-icons 초기 번들 무게 검토 [난이도: 어려움 | 신뢰도: 높음 | ~90 KB]
+   권장 수정: narrow-import - Import narrowly from specific icon files or migrate to a more tree-shakable icon set.
+   대상: src/Dashboard.tsx
+   evidence: src/Dashboard.tsx | specifier: react-icons | static import; Wide icon-pack imports can defeat tree shaking.
+4. lodash 초기 번들 무게 검토 [난이도: 어려움 | 신뢰도: 높음 | ~72 KB]
+   권장 수정: narrow-import - Use per-method imports or switch to lodash-es when the toolchain supports it.
+   대상: src/Dashboard.tsx
+   대체 후보: lodash-es
+   evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
+5. react-icons 지연 로딩 [난이도: 보통 | 신뢰도: 낮음 | ~68 KB]
+   evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
+
+가장 무거운 의존성:
+- chart.js (160 KB) [높음 신뢰도]: Charting code is often only needed on a subset of screens. 1개 파일에서 import됨.
   evidence: src/Dashboard.tsx | specifier: chart.js | static import; Charting code is often only needed on a subset of screens.
-- react-icons (90 KB) [high confidence]: Wide icon-pack imports can defeat tree shaking. imported in 1 file(s).
+- react-icons (90 KB) [높음 신뢰도]: Wide icon-pack imports can defeat tree shaking. 1개 파일에서 import됨.
   evidence: src/Dashboard.tsx | specifier: react-icons | static import; Wide icon-pack imports can defeat tree shaking.
-- lodash (72 KB) [high confidence]: Root lodash imports are a classic source of tree-shaking misses. imported in 1 file(s).
+- lodash (72 KB) [높음 신뢰도]: Root lodash imports are a classic source of tree-shaking misses. 1개 파일에서 import됨.
   evidence: src/Dashboard.tsx | specifier: lodash | static import; Root lodash imports are a classic source of tree-shaking misses.
 
-Duplicate package versions:
-- lodash [high confidence]: 4.17.20, 4.17.21 (18 KB avoidable)
+중복 패키지 버전:
+- lodash [높음 신뢰도]: 4.17.20, 4.17.21 (18 KB 방향성 정리 여지)
   origin: 4.17.20 via lodash
   origin: 4.17.21 via lodash
 
-Lazy-load candidates:
-- chart.js [low confidence]: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 120 KB.
+지연 로딩 후보:
+- chart.js [낮음 신뢰도]: chart.js is statically imported in UI surfaces that usually tolerate lazy loading. 지연 로딩 검토 여지 120 KB.
   evidence: src/Dashboard.tsx | specifier: chart.js | route-like UI surface matched `dashboard` keyword
-- react-icons [low confidence]: react-icons is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 68 KB.
+- react-icons [낮음 신뢰도]: react-icons is statically imported in UI surfaces that usually tolerate lazy loading. 지연 로딩 검토 여지 68 KB.
   evidence: src/Dashboard.tsx | specifier: react-icons | route-like UI surface matched `dashboard` keyword
-- lodash [low confidence]: lodash is statically imported in UI surfaces that usually tolerate lazy loading. Estimated win 54 KB.
+- lodash [낮음 신뢰도]: lodash is statically imported in UI surfaces that usually tolerate lazy loading. 지연 로딩 검토 여지 54 KB.
   evidence: src/Dashboard.tsx | specifier: lodash | route-like UI surface matched `dashboard` keyword
 
-Tree-shaking warnings:
-- lodash [high confidence]: Root lodash imports often keep more code than expected in client bundles.
+트리셰이킹 경고:
+- lodash [높음 신뢰도]: Root lodash imports often keep more code than expected in client bundles.
   evidence: src/Dashboard.tsx | specifier: lodash | root package import
-- react-icons [high confidence]: Root react-icons imports can make tree shaking unreliable.
+- react-icons [높음 신뢰도]: Root react-icons imports can make tree shaking unreliable.
   evidence: src/Dashboard.tsx | specifier: react-icons | root package import
 
-Unused dependency candidates:
-- none
+미사용 의존성 후보:
+- 없음

--- a/tests/oracles/basic-app/visualize.txt
+++ b/tests/oracles/basic-app/visualize.txt
@@ -1,9 +1,9 @@
 Legolas visualize for basic-parity-app
 
-Estimated dependency weight
+추정 의존성 무게
 chart.js                 ████████████████████████ 160 KB
 react-icons              ██████████████           90 KB
 lodash                   ███████████              72 KB
 
-Duplicate package pressure
+중복 패키지 압력
 lodash                   ████████████████████████ 18 KB


### PR DESCRIPTION
## 배경
#80은 사람이 보는 text 리포트를 기본 한글로 바꾸고, scan 상단에서 판정과 다음 행동을 바로 확인할 수 있게 하는 lane입니다.

## 변경 사항
- 기본 scan text 출력에 한글 프로젝트 요약, 판정, 확정 초기 페이로드 절감, 방향성 정리 여지, Top next actions를 추가했습니다.
- --lang en scan 경로에도 영어 summary와 Top next actions를 추가했습니다.
- duplicate impact scope별 문구를 text 상세와 action에 반영해 dev/test-only 중복을 dependency hygiene으로 표시합니다.
- production-likely duplicate-only 결과도 confirmed initial payload savings로 표시되도록 보강했습니다.
- optimize, visualize, budget, ci text 출력의 기본 문구와 oracle/test 계약을 최소 한글화했습니다.
- packed install smoke가 새 기본 한글 scan 출력의 source-count 문구를 검증하도록 갱신했습니다.
- 기존 evidence/origin 상세 출력은 유지했습니다.

## 검증
- cargo fmt --all --check
- git diff --check
- cargo test -p legolas-cli --test text_report_parity
- cargo test -p legolas-cli --test cli_contract
- cargo test -p legolas-cli --test budget_contract
- cargo test -p legolas-cli --test ci_contract
- cargo test -p legolas-cli --test optimize_action_ranking
- cargo test -p legolas-cli
- cargo clippy -p legolas-cli --all-targets -- -D warnings
- cargo test --workspace
- cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app
- cargo run -p legolas-cli -- scan tests/fixtures/parity/basic-app --lang en
- GitHub checks: all pass, including Smoke And Package and Pack Check Windows

참고: npm run pack:smoke는 로컬 worktree에 packaged vendor Rust binary가 없어 --version 단계에서 실행 불가했습니다. 원격 CI의 vendor staging 후 smoke로 검증했습니다.

## 리뷰
- Devil's Advocate Round 1: Medium 1건 수용 및 수정
- Devil's Advocate Round 2: Critical 0 / High 0 / Medium 0 / Low 0, PASS
- Independent PR Review pass 1: CHANGE_REQUEST, Critical 1 / Medium 1 수용 및 수정
- Independent PR Review pass 2: APPROVE, Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리
- Branch: codex/feat-80-ko-text-summary
- Worktree: /tmp/legolas-wave2/issue-80-ko-text-summary

Closes #80