### PR TITLE
feat(cli): JSON/SARIF reportSummary 계약 추가

### DIFF
--- a/crates/legolas-cli/src/main.rs
+++ b/crates/legolas-cli/src/main.rs
@@ -21,6 +21,7 @@ use legolas_core::{
     budget::{evaluate_budget, BudgetEvaluation},
     config::{load_config_file, load_discovered_config, LoadedConfig},
     impact::estimate_impact,
+    report_summary::build_report_summary,
     AnalyzeOptions, LegolasError, Result,
 };
 use serde_json::{json, Map, Value};
@@ -193,6 +194,7 @@ fn run() -> Result<i32> {
                 budget_evaluation
                     .as_ref()
                     .expect("budget evaluation exists for budget command"),
+                parsed.lang,
             ),
             Command::Ci => ci_json_output(
                 &output_analysis,
@@ -200,8 +202,9 @@ fn run() -> Result<i32> {
                     .as_ref()
                     .expect("budget evaluation exists for ci command"),
                 regression_diff.as_ref(),
+                parsed.lang,
             ),
-            _ => analysis_json_output(&output_analysis)?,
+            _ => analysis_json_output(&output_analysis, parsed.lang)?,
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
 
@@ -317,17 +320,32 @@ fn write_baseline_snapshot(path: &Path, analysis: &legolas_core::Analysis) -> Re
     fs::write(path, serde_json::to_string_pretty(&snapshot)?).map_err(Into::into)
 }
 
-fn analysis_json_output(analysis: &legolas_core::Analysis) -> Result<Value> {
+fn analysis_json_output(
+    analysis: &legolas_core::Analysis,
+    language: ReportLanguage,
+) -> Result<Value> {
     let mut output = Map::new();
     output.insert("schemaVersion".to_string(), json!(ANALYSIS_SCHEMA_VERSION));
+    output.insert(
+        "reportSummary".to_string(),
+        report_summary_json(analysis, language),
+    );
     output.extend(analysis_value_to_object(analysis)?);
 
     Ok(Value::Object(output))
 }
 
-fn budget_json_output(analysis: &legolas_core::Analysis, evaluation: &BudgetEvaluation) -> Value {
+fn budget_json_output(
+    analysis: &legolas_core::Analysis,
+    evaluation: &BudgetEvaluation,
+    language: ReportLanguage,
+) -> Value {
     let mut output = Map::new();
     output.insert("schemaVersion".to_string(), json!(BUDGET_SCHEMA_VERSION));
+    output.insert(
+        "reportSummary".to_string(),
+        report_summary_json(analysis, language),
+    );
     output.insert(
         "overallStatus".to_string(),
         json!(evaluation.overall_status),
@@ -348,9 +366,14 @@ fn ci_json_output(
     analysis: &legolas_core::Analysis,
     evaluation: &BudgetEvaluation,
     regression_diff: Option<&legolas_core::BaselineDiff>,
+    language: ReportLanguage,
 ) -> Value {
     let mut output = Map::new();
     output.insert("schemaVersion".to_string(), json!(CI_SCHEMA_VERSION));
+    output.insert(
+        "reportSummary".to_string(),
+        report_summary_json(analysis, language),
+    );
     output.insert("passed".to_string(), json!(!evaluation.has_failures()));
     output.insert(
         "overallStatus".to_string(),
@@ -376,6 +399,28 @@ fn ci_json_output(
     }
 
     Value::Object(output)
+}
+
+fn report_summary_json(analysis: &legolas_core::Analysis, language: ReportLanguage) -> Value {
+    let mut summary = serde_json::to_value(build_report_summary(analysis))
+        .expect("report summary must serialize to JSON");
+    let Value::Object(object) = &mut summary else {
+        unreachable!("serialized report summary must be an object");
+    };
+
+    object.insert(
+        "language".to_string(),
+        json!(report_language_code(language)),
+    );
+
+    summary
+}
+
+fn report_language_code(language: ReportLanguage) -> &'static str {
+    match language {
+        ReportLanguage::Ko => "ko",
+        ReportLanguage::En => "en",
+    }
 }
 
 fn analysis_value_to_object(analysis: &legolas_core::Analysis) -> Result<Map<String, Value>> {

--- a/crates/legolas-cli/src/reporters/sarif.rs
+++ b/crates/legolas-cli/src/reporters/sarif.rs
@@ -2,9 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::argv::ReportLanguage;
 use legolas_core::{
-    boundaries::BoundaryWarning, budget::BudgetEvaluation, Analysis, BaselineDiff,
-    DuplicatePackage, FindingConfidence, FindingEvidence, FindingMetadata, HeavyDependency,
-    LazyLoadCandidate, TreeShakingWarning,
+    boundaries::BoundaryWarning, budget::BudgetEvaluation, report_summary::build_report_summary,
+    Analysis, BaselineDiff, DuplicatePackage, FindingConfidence, FindingEvidence, FindingMetadata,
+    HeavyDependency, LazyLoadCandidate, TreeShakingWarning,
 };
 use serde_json::{json, Map, Value};
 
@@ -12,30 +12,22 @@ const SARIF_SCHEMA_URL: &str = "https://json.schemastore.org/sarif-2.1.0.json";
 const SARIF_VERSION: &str = "2.1.0";
 const LEGOLAS_INFO_URL: &str = "https://github.com/JeremyDev87/legolas";
 
-pub fn scan_sarif_output_for_language(analysis: &Analysis, _language: ReportLanguage) -> Value {
-    scan_sarif_output(analysis)
+pub fn scan_sarif_output_for_language(analysis: &Analysis, language: ReportLanguage) -> Value {
+    sarif_output(
+        collect_scan_records(analysis, language),
+        base_run_properties("scan", analysis, language),
+    )
 }
 
 pub fn scan_sarif_output(analysis: &Analysis) -> Value {
-    sarif_output(
-        collect_scan_records(analysis),
-        base_run_properties("scan", analysis),
-    )
+    scan_sarif_output_for_language(analysis, ReportLanguage::Ko)
 }
 
 pub fn ci_sarif_output_for_language(
     analysis: &Analysis,
     evaluation: &BudgetEvaluation,
     regression_diff: Option<&BaselineDiff>,
-    _language: ReportLanguage,
-) -> Value {
-    ci_sarif_output(analysis, evaluation, regression_diff)
-}
-
-pub fn ci_sarif_output(
-    analysis: &Analysis,
-    evaluation: &BudgetEvaluation,
-    regression_diff: Option<&BaselineDiff>,
+    language: ReportLanguage,
 ) -> Value {
     let triggered_finding_ids = evaluation
         .rules
@@ -47,15 +39,23 @@ pub fn ci_sarif_output(
         })
         .collect::<BTreeSet<_>>();
 
-    let records = collect_scan_records(analysis)
+    let records = collect_scan_records(analysis, language)
         .into_iter()
         .filter(|record| triggered_finding_ids.contains(&record.rule_id))
         .collect::<Vec<_>>();
 
     sarif_output(
         records,
-        ci_run_properties(analysis, evaluation, regression_diff),
+        ci_run_properties(analysis, evaluation, regression_diff, language),
     )
+}
+
+pub fn ci_sarif_output(
+    analysis: &Analysis,
+    evaluation: &BudgetEvaluation,
+    regression_diff: Option<&BaselineDiff>,
+) -> Value {
+    ci_sarif_output_for_language(analysis, evaluation, regression_diff, ReportLanguage::Ko)
 }
 
 #[derive(Debug, Clone)]
@@ -68,61 +68,82 @@ struct SarifRecord {
     properties: Map<String, Value>,
 }
 
-fn collect_scan_records(analysis: &Analysis) -> Vec<SarifRecord> {
+fn collect_scan_records(analysis: &Analysis, language: ReportLanguage) -> Vec<SarifRecord> {
     let mut records = Vec::new();
 
     records.extend(
         analysis
             .boundary_warnings
             .iter()
-            .filter_map(boundary_warning_record),
+            .filter_map(|item| boundary_warning_record(item, language)),
     );
     records.extend(
         analysis
             .heavy_dependencies
             .iter()
-            .filter_map(heavy_dependency_record),
+            .filter_map(|item| heavy_dependency_record(item, language)),
     );
     records.extend(
         analysis
             .duplicate_packages
             .iter()
-            .filter_map(duplicate_package_record),
+            .filter_map(|item| duplicate_package_record(item, language)),
     );
     records.extend(
         analysis
             .lazy_load_candidates
             .iter()
-            .filter_map(lazy_load_candidate_record),
+            .filter_map(|item| lazy_load_candidate_record(item, language)),
     );
     records.extend(
         analysis
             .tree_shaking_warnings
             .iter()
-            .filter_map(tree_shaking_warning_record),
+            .filter_map(|item| tree_shaking_warning_record(item, language)),
     );
 
     records
 }
 
-fn boundary_warning_record(item: &BoundaryWarning) -> Option<SarifRecord> {
+fn boundary_warning_record(
+    item: &BoundaryWarning,
+    language: ReportLanguage,
+) -> Option<SarifRecord> {
     finding_record(
         &item.finding,
-        item.message.clone(),
-        item.message.clone(),
+        match language {
+            ReportLanguage::Ko => format!("번들 경계 경고: {}", item.message),
+            ReportLanguage::En => item.message.clone(),
+        },
+        match language {
+            ReportLanguage::Ko => "번들 경계 검토".to_string(),
+            ReportLanguage::En => item.message.clone(),
+        },
         Some(item.recommendation.as_str()),
         [],
     )
 }
 
-fn heavy_dependency_record(item: &HeavyDependency) -> Option<SarifRecord> {
+fn heavy_dependency_record(
+    item: &HeavyDependency,
+    language: ReportLanguage,
+) -> Option<SarifRecord> {
     finding_record(
         &item.finding,
-        format!(
-            "{} ({} KB): {}",
-            item.name, item.estimated_kb, item.rationale
-        ),
-        format!("Review {} upfront bundle weight", item.name),
+        match language {
+            ReportLanguage::Ko => format!(
+                "{} 초기 번들 무게가 큽니다 ({} KB).",
+                item.name, item.estimated_kb
+            ),
+            ReportLanguage::En => format!(
+                "{} ({} KB): {}",
+                item.name, item.estimated_kb, item.rationale
+            ),
+        },
+        match language {
+            ReportLanguage::Ko => format!("{} 초기 번들 무게 검토", item.name),
+            ReportLanguage::En => format!("Review {} upfront bundle weight", item.name),
+        },
         Some(item.recommendation.as_str()),
         [
             ("name", json!(item.name)),
@@ -136,16 +157,30 @@ fn heavy_dependency_record(item: &HeavyDependency) -> Option<SarifRecord> {
     )
 }
 
-fn duplicate_package_record(item: &DuplicatePackage) -> Option<SarifRecord> {
+fn duplicate_package_record(
+    item: &DuplicatePackage,
+    language: ReportLanguage,
+) -> Option<SarifRecord> {
     finding_record(
         &item.finding,
-        format!(
-            "{} duplicated across {} ({} KB avoidable)",
-            item.name,
-            item.versions.join(", "),
-            item.estimated_extra_kb
-        ),
-        format!("Deduplicate {}", item.name),
+        match language {
+            ReportLanguage::Ko => format!(
+                "{} 중복 버전 {} (정리 가능 {} KB)",
+                item.name,
+                item.versions.join(", "),
+                item.estimated_extra_kb
+            ),
+            ReportLanguage::En => format!(
+                "{} duplicated across {} ({} KB avoidable)",
+                item.name,
+                item.versions.join(", "),
+                item.estimated_extra_kb
+            ),
+        },
+        match language {
+            ReportLanguage::Ko => format!("{} 중복 제거", item.name),
+            ReportLanguage::En => format!("Deduplicate {}", item.name),
+        },
         None,
         [
             ("name", json!(item.name)),
@@ -157,14 +192,26 @@ fn duplicate_package_record(item: &DuplicatePackage) -> Option<SarifRecord> {
     )
 }
 
-fn lazy_load_candidate_record(item: &LazyLoadCandidate) -> Option<SarifRecord> {
+fn lazy_load_candidate_record(
+    item: &LazyLoadCandidate,
+    language: ReportLanguage,
+) -> Option<SarifRecord> {
     finding_record(
         &item.finding,
-        format!(
-            "{} can be lazy loaded ({} KB): {}",
-            item.name, item.estimated_savings_kb, item.reason
-        ),
-        format!("Lazy load {}", item.name),
+        match language {
+            ReportLanguage::Ko => format!(
+                "지연 로딩 후보: {} ({} KB).",
+                item.name, item.estimated_savings_kb
+            ),
+            ReportLanguage::En => format!(
+                "{} can be lazy loaded ({} KB): {}",
+                item.name, item.estimated_savings_kb, item.reason
+            ),
+        },
+        match language {
+            ReportLanguage::Ko => format!("{} 지연 로딩", item.name),
+            ReportLanguage::En => format!("Lazy load {}", item.name),
+        },
         Some(item.recommendation.as_str()),
         [
             ("name", json!(item.name)),
@@ -175,11 +222,23 @@ fn lazy_load_candidate_record(item: &LazyLoadCandidate) -> Option<SarifRecord> {
     )
 }
 
-fn tree_shaking_warning_record(item: &TreeShakingWarning) -> Option<SarifRecord> {
+fn tree_shaking_warning_record(
+    item: &TreeShakingWarning,
+    language: ReportLanguage,
+) -> Option<SarifRecord> {
     finding_record(
         &item.finding,
-        format!("{}: {}", item.package_name, item.message),
-        format!("Review {} tree shaking", item.package_name),
+        match language {
+            ReportLanguage::Ko => format!(
+                "{} import 방식을 정리하세요 ({} KB).",
+                item.package_name, item.estimated_kb
+            ),
+            ReportLanguage::En => format!("{}: {}", item.package_name, item.message),
+        },
+        match language {
+            ReportLanguage::Ko => format!("{} import 정리", item.package_name),
+            ReportLanguage::En => format!("Review {} tree shaking", item.package_name),
+        },
         Some(item.recommendation.as_str()),
         [
             ("key", json!(item.key)),
@@ -271,9 +330,17 @@ fn sarif_level(confidence: Option<FindingConfidence>) -> &'static str {
     }
 }
 
-fn base_run_properties(command: &str, analysis: &Analysis) -> Map<String, Value> {
+fn base_run_properties(
+    command: &str,
+    analysis: &Analysis,
+    language: ReportLanguage,
+) -> Map<String, Value> {
     let mut properties = Map::new();
     properties.insert("command".to_string(), json!(command));
+    properties.insert(
+        "reportSummary".to_string(),
+        report_summary_json(analysis, language),
+    );
 
     if !analysis.warnings.is_empty() {
         properties.insert("warnings".to_string(), json!(analysis.warnings));
@@ -286,8 +353,9 @@ fn ci_run_properties(
     analysis: &Analysis,
     evaluation: &BudgetEvaluation,
     regression_diff: Option<&BaselineDiff>,
+    language: ReportLanguage,
 ) -> Map<String, Value> {
-    let mut properties = base_run_properties("ci", analysis);
+    let mut properties = base_run_properties("ci", analysis, language);
     properties.insert("passed".to_string(), json!(!evaluation.has_failures()));
     properties.insert(
         "overallStatus".to_string(),
@@ -306,6 +374,28 @@ fn ci_run_properties(
     }
 
     properties
+}
+
+fn report_summary_json(analysis: &Analysis, language: ReportLanguage) -> Value {
+    let mut summary =
+        serde_json::to_value(build_report_summary(analysis)).expect("report summary serializes");
+    let Value::Object(object) = &mut summary else {
+        unreachable!("serialized report summary must be an object");
+    };
+
+    object.insert(
+        "language".to_string(),
+        json!(report_language_code(language)),
+    );
+
+    summary
+}
+
+fn report_language_code(language: ReportLanguage) -> &'static str {
+    match language {
+        ReportLanguage::Ko => "ko",
+        ReportLanguage::En => "en",
+    }
 }
 
 fn sarif_output(records: Vec<SarifRecord>, run_properties: Map<String, Value>) -> Value {

--- a/crates/legolas-cli/tests/budget_contract.rs
+++ b/crates/legolas-cli/tests/budget_contract.rs
@@ -131,7 +131,7 @@ fn budget_json_output_has_a_stable_shape() {
 
     assert!(output.status.success());
     assert_eq!(
-        support::normalize_budget_json_output(&stdout(&output)),
+        normalize_budget_without_report_summary(&stdout(&output)),
         json!({
             "schemaVersion": "legolas.budget.v1",
             "overallStatus": "Fail",
@@ -173,6 +173,7 @@ fn budget_json_output_includes_workspace_summaries_for_monorepos() {
 
     assert!(output.status.success());
     let budget = support::normalize_budget_json_output(&stdout(&output));
+    assert_eq!(budget["reportSummary"]["language"], json!("ko"));
     assert_eq!(budget["workspaceSummaries"], json!(workspace_summaries()));
     assert_eq!(budget["overallStatus"], json!("Fail"));
 }
@@ -209,7 +210,7 @@ fn budget_uses_config_threshold_overrides_and_starter_fallbacks_together() {
 
     assert!(output.status.success());
     assert_eq!(
-        support::normalize_budget_json_output(&stdout(&output)),
+        normalize_budget_without_report_summary(&stdout(&output)),
         json!({
             "schemaVersion": "legolas.budget.v1",
             "overallStatus": "Fail",
@@ -276,7 +277,7 @@ fn budget_uses_discovered_config_from_project_root() {
 
     assert!(output.status.success());
     assert_eq!(
-        support::normalize_budget_json_output(&stdout(&output)),
+        normalize_budget_without_report_summary(&stdout(&output)),
         json!({
             "schemaVersion": "legolas.budget.v1",
             "overallStatus": "Fail",
@@ -399,4 +400,15 @@ fn budget_rejects_command_specific_numeric_flags() {
         assert_eq!(stdout(&output), "");
         assert_eq!(stderr(&output), expected_stderr);
     }
+}
+
+fn normalize_budget_without_report_summary(output: &str) -> serde_json::Value {
+    let mut budget = support::normalize_budget_json_output(output);
+    assert_eq!(budget["reportSummary"]["language"], json!("ko"));
+    budget
+        .as_object_mut()
+        .expect("budget json object")
+        .remove("reportSummary")
+        .expect("report summary exists");
+    budget
 }

--- a/crates/legolas-cli/tests/ci_contract.rs
+++ b/crates/legolas-cli/tests/ci_contract.rs
@@ -175,7 +175,7 @@ fn ci_json_output_uses_machine_readable_gate_shape() {
     assert!(!output.status.success());
     assert_eq!(output.status.code(), Some(1));
     assert_eq!(
-        support::normalize_ci_json_output(&stdout(&output)),
+        normalize_ci_without_report_summary(&stdout(&output)),
         json!({
             "schemaVersion": "legolas.ci.v1",
             "passed": false,
@@ -231,6 +231,7 @@ fn regression_only_ci_json_includes_regression_envelope() {
     assert_eq!(stderr(&output), "");
 
     let ci = support::normalize_ci_json_output(&stdout(&output));
+    assert_eq!(ci["reportSummary"]["language"], json!("ko"));
     assert_eq!(ci["passed"], json!(true));
     assert_eq!(ci["overallStatus"], json!("Warn"));
     assert_eq!(
@@ -250,6 +251,7 @@ fn ci_json_output_includes_workspace_summaries_for_monorepos() {
     assert!(!output.status.success());
     assert_eq!(output.status.code(), Some(1));
     let ci = support::normalize_ci_json_output(&stdout(&output));
+    assert_eq!(ci["reportSummary"]["language"], json!("ko"));
     assert_eq!(ci["workspaceSummaries"], json!(workspace_summaries()));
     assert_eq!(ci["overallStatus"], json!("Fail"));
     assert_eq!(ci["passed"], json!(false));
@@ -300,6 +302,16 @@ fn ci_rejects_command_specific_numeric_flags() {
         assert_eq!(stdout(&output), "");
         assert_eq!(stderr(&output), expected_stderr);
     }
+}
+
+fn normalize_ci_without_report_summary(output: &str) -> serde_json::Value {
+    let mut ci = support::normalize_ci_json_output(output);
+    assert_eq!(ci["reportSummary"]["language"], json!("ko"));
+    ci.as_object_mut()
+        .expect("ci json object")
+        .remove("reportSummary")
+        .expect("report summary exists");
+    ci
 }
 
 #[test]

--- a/crates/legolas-cli/tests/cli_contract.rs
+++ b/crates/legolas-cli/tests/cli_contract.rs
@@ -125,10 +125,15 @@ fn matches_scan_json_oracle() {
     let mut analysis =
         support::normalize_analysis_json_output(&String::from_utf8(output.stdout).expect("stdout"));
     assert_eq!(analysis["schemaVersion"], json!("legolas.analysis.v1"));
+    assert_eq!(analysis["reportSummary"]["language"], json!("ko"));
     analysis
         .as_object_mut()
         .expect("analysis object")
         .remove("schemaVersion");
+    analysis
+        .as_object_mut()
+        .expect("analysis object")
+        .remove("reportSummary");
     assert_eq!(
         analysis,
         support::normalize_analysis_json_output(&support::read_oracle("basic-app/scan.json"))

--- a/crates/legolas-cli/tests/json_schema_contract.rs
+++ b/crates/legolas-cli/tests/json_schema_contract.rs
@@ -1,5 +1,7 @@
 mod support;
 
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
 use assert_cmd::Command;
 use serde_json::{json, Value};
 
@@ -24,6 +26,11 @@ fn scan_json_matches_analysis_schema_doc() {
     let schema = read_schema("analysis.v1.schema.json");
 
     assert_eq!(value["schemaVersion"], json!(ANALYSIS_SCHEMA_VERSION));
+    assert_eq!(value["reportSummary"]["language"], json!("ko"));
+    assert_eq!(
+        value["duplicatePackages"][0]["impactScope"],
+        json!("unknown")
+    );
     assert_matches_schema(&value, &schema, "$");
 }
 
@@ -42,7 +49,30 @@ fn optimize_json_matches_analysis_schema_doc() {
     let schema = read_schema("analysis.v1.schema.json");
 
     assert_eq!(value["schemaVersion"], json!(ANALYSIS_SCHEMA_VERSION));
+    assert_eq!(value["reportSummary"]["language"], json!("ko"));
     assert_matches_schema(&value, &schema, "$");
+}
+
+#[test]
+fn scan_json_report_summary_honors_language_flag() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args([
+            "scan",
+            &fixture.display().to_string(),
+            "--json",
+            "--lang",
+            "en",
+        ])
+        .output()
+        .expect("run scan --json --lang en");
+
+    assert!(output.status.success());
+    let output = String::from_utf8(output.stdout).expect("stdout");
+    let value = serde_json::from_str::<Value>(&output).expect("parse scan json");
+
+    assert_eq!(value["reportSummary"]["language"], json!("en"));
 }
 
 #[test]
@@ -60,6 +90,7 @@ fn budget_json_matches_budget_schema_doc() {
     let schema = read_schema("budget.v1.schema.json");
 
     assert_eq!(value["schemaVersion"], json!(BUDGET_SCHEMA_VERSION));
+    assert_eq!(value["reportSummary"]["language"], json!("ko"));
     assert_matches_schema(&value, &schema, "$");
 }
 
@@ -78,6 +109,7 @@ fn ci_json_matches_ci_schema_doc() {
     let schema = read_schema("ci.v1.schema.json");
 
     assert_eq!(value["schemaVersion"], json!(CI_SCHEMA_VERSION));
+    assert_eq!(value["reportSummary"]["language"], json!("ko"));
     assert_matches_schema(&value, &schema, "$");
 }
 
@@ -104,6 +136,7 @@ fn regression_only_ci_json_matches_ci_schema_doc() {
     let schema = read_schema("ci.v1.schema.json");
 
     assert_eq!(value["schemaVersion"], json!(CI_SCHEMA_VERSION));
+    assert_eq!(value["reportSummary"]["language"], json!("ko"));
     assert_matches_schema(&value, &schema, "$");
 }
 
@@ -123,6 +156,10 @@ fn scan_sarif_matches_schema_doc() {
 
     assert_eq!(value["$schema"], json!(SARIF_SCHEMA_URL));
     assert_eq!(value["version"], json!(SARIF_VERSION));
+    assert_eq!(
+        value["runs"][0]["properties"]["reportSummary"]["language"],
+        json!("ko")
+    );
     assert_matches_schema(&value, &schema, "$");
 }
 
@@ -142,6 +179,10 @@ fn ci_sarif_matches_schema_doc() {
 
     assert_eq!(value["$schema"], json!(SARIF_SCHEMA_URL));
     assert_eq!(value["version"], json!(SARIF_VERSION));
+    assert_eq!(
+        value["runs"][0]["properties"]["reportSummary"]["language"],
+        json!("ko")
+    );
     assert_matches_schema(&value, &schema, "$");
 }
 
@@ -169,7 +210,72 @@ fn regression_only_ci_sarif_matches_schema_doc() {
 
     assert_eq!(value["$schema"], json!(SARIF_SCHEMA_URL));
     assert_eq!(value["version"], json!(SARIF_VERSION));
+    assert_eq!(
+        value["runs"][0]["properties"]["reportSummary"]["language"],
+        json!("ko")
+    );
     assert_matches_schema(&value, &schema, "$");
+}
+
+#[test]
+fn schema_docs_require_report_summary_contract() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+
+    let scan_output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run scan --json");
+    assert!(scan_output.status.success());
+    let mut scan = serde_json::from_slice::<Value>(&scan_output.stdout).expect("parse scan json");
+    scan.as_object_mut()
+        .expect("scan object")
+        .remove("reportSummary")
+        .expect("report summary exists");
+    assert_schema_rejects(&scan, &read_schema("analysis.v1.schema.json"), "$");
+
+    let budget_output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["budget", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run budget --json");
+    assert!(budget_output.status.success());
+    let mut budget =
+        serde_json::from_slice::<Value>(&budget_output.stdout).expect("parse budget json");
+    budget
+        .as_object_mut()
+        .expect("budget object")
+        .remove("reportSummary")
+        .expect("report summary exists");
+    assert_schema_rejects(&budget, &read_schema("budget.v1.schema.json"), "$");
+
+    let ci_output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["ci", &fixture.display().to_string(), "--json"])
+        .output()
+        .expect("run ci --json");
+    assert!(!ci_output.status.success());
+    let mut ci = serde_json::from_slice::<Value>(&ci_output.stdout).expect("parse ci json");
+    ci.as_object_mut()
+        .expect("ci object")
+        .remove("reportSummary")
+        .expect("report summary exists");
+    assert_schema_rejects(&ci, &read_schema("ci.v1.schema.json"), "$");
+
+    let sarif_output = Command::cargo_bin("legolas-cli")
+        .expect("build binary")
+        .args(["scan", &fixture.display().to_string(), "--sarif"])
+        .output()
+        .expect("run scan --sarif");
+    assert!(sarif_output.status.success());
+    let mut sarif =
+        serde_json::from_slice::<Value>(&sarif_output.stdout).expect("parse scan sarif");
+    sarif["runs"][0]["properties"]
+        .as_object_mut()
+        .expect("sarif run properties")
+        .remove("reportSummary")
+        .expect("report summary exists");
+    assert_schema_rejects(&sarif, &read_schema("sarif.v1.json"), "$");
 }
 
 fn read_schema(relative_path: &str) -> Value {
@@ -180,6 +286,17 @@ fn read_schema(relative_path: &str) -> Value {
     let contents = std::fs::read_to_string(&schema_path).expect("read schema");
 
     serde_json::from_str(&contents).expect("parse schema")
+}
+
+fn assert_schema_rejects(value: &Value, schema: &Value, path: &str) {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        assert_matches_schema(value, schema, path);
+    }));
+
+    assert!(
+        result.is_err(),
+        "{path}: schema unexpectedly accepted value"
+    );
 }
 
 fn assert_matches_schema(value: &Value, schema: &Value, path: &str) {

--- a/crates/legolas-cli/tests/sarif_contract.rs
+++ b/crates/legolas-cli/tests/sarif_contract.rs
@@ -3,7 +3,7 @@ mod support;
 use std::collections::BTreeSet;
 
 use assert_cmd::Command;
-use serde_json::json;
+use serde_json::{json, Value};
 
 fn run_cli(args: &[&str]) -> std::process::Output {
     Command::cargo_bin("legolas-cli")
@@ -36,6 +36,10 @@ fn scan_sarif_preserves_rule_ids_locations_and_metadata() {
     );
     assert_eq!(sarif["version"], json!("2.1.0"));
     assert_eq!(sarif["runs"][0]["properties"]["command"], json!("scan"));
+    assert_eq!(
+        sarif["runs"][0]["properties"]["reportSummary"]["language"],
+        json!("ko")
+    );
 
     let results = sarif["runs"][0]["results"]
         .as_array()
@@ -59,6 +63,20 @@ fn scan_sarif_preserves_rule_ids_locations_and_metadata() {
         .find(|result| result["ruleId"] == "heavy-dependency:chart.js")
         .expect("chart.js result");
     assert_eq!(chart_js["level"], json!("warning"));
+    assert!(chart_js["message"]["text"]
+        .as_str()
+        .expect("message text")
+        .starts_with("chart.js 초기 번들 무게가 큽니다 (160 KB)."));
+    let chart_js_rule = sarif["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("driver rules")
+        .iter()
+        .find(|rule| rule["id"] == "heavy-dependency:chart.js")
+        .expect("chart.js rule");
+    assert_eq!(
+        chart_js_rule["shortDescription"]["text"],
+        json!("chart.js 초기 번들 무게 검토")
+    );
     assert_eq!(
         chart_js["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
         json!("src/Dashboard.tsx")
@@ -101,6 +119,54 @@ fn scan_sarif_preserves_rule_ids_locations_and_metadata() {
 }
 
 #[test]
+fn scan_sarif_language_flag_changes_human_text_not_rule_ids() {
+    let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
+    let ko_output = run_cli(&["scan", &fixture.display().to_string(), "--sarif"]);
+    let en_output = run_cli(&[
+        "scan",
+        &fixture.display().to_string(),
+        "--sarif",
+        "--lang",
+        "en",
+    ]);
+
+    assert!(ko_output.status.success());
+    assert!(en_output.status.success());
+    let ko = support::normalize_sarif_output(&stdout(&ko_output));
+    let en = support::normalize_sarif_output(&stdout(&en_output));
+
+    assert_eq!(
+        ko["runs"][0]["properties"]["reportSummary"]["language"],
+        json!("ko")
+    );
+    assert_eq!(
+        en["runs"][0]["properties"]["reportSummary"]["language"],
+        json!("en")
+    );
+    assert_eq!(sarif_rule_ids(&ko), sarif_rule_ids(&en));
+
+    let en_results = en["runs"][0]["results"].as_array().expect("results");
+    let chart_js = en_results
+        .iter()
+        .find(|result| result["ruleId"] == "heavy-dependency:chart.js")
+        .expect("chart.js result");
+    assert!(chart_js["message"]["text"]
+        .as_str()
+        .expect("message text")
+        .starts_with("chart.js (160 KB):"));
+    let chart_js_rule = en["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("driver rules")
+        .iter()
+        .find(|rule| rule["id"] == "heavy-dependency:chart.js")
+        .expect("chart.js rule");
+    assert_eq!(
+        chart_js_rule["shortDescription"]["text"],
+        json!("Review chart.js upfront bundle weight")
+    );
+}
+
+#[test]
 fn ci_sarif_uses_triggered_findings_and_preserves_failure_exit_code() {
     let fixture = support::fixture_path("tests/fixtures/parity/basic-app");
     let output = run_cli(&["ci", &fixture.display().to_string(), "--sarif"]);
@@ -114,6 +180,10 @@ fn ci_sarif_uses_triggered_findings_and_preserves_failure_exit_code() {
 
     let sarif = support::normalize_sarif_output(&stdout(&output));
     assert_eq!(sarif["runs"][0]["properties"]["command"], json!("ci"));
+    assert_eq!(
+        sarif["runs"][0]["properties"]["reportSummary"]["language"],
+        json!("ko")
+    );
     assert_eq!(sarif["runs"][0]["properties"]["passed"], json!(false));
     assert_eq!(
         sarif["runs"][0]["properties"]["overallStatus"],
@@ -145,6 +215,15 @@ fn ci_sarif_uses_triggered_findings_and_preserves_failure_exit_code() {
             "tree-shaking:react-icons-root-import".to_string(),
         ])
     );
+}
+
+fn sarif_rule_ids(sarif: &Value) -> BTreeSet<String> {
+    sarif["runs"][0]["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|result| result["ruleId"].as_str().expect("rule id").to_string())
+        .collect()
 }
 
 #[test]

--- a/docs/schema/analysis.v1.schema.json
+++ b/docs/schema/analysis.v1.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "required": [
     "schemaVersion",
+    "reportSummary",
     "projectRoot",
     "packageManager",
     "frameworks",
@@ -25,6 +26,115 @@
     "schemaVersion": {
       "type": "string",
       "const": "legolas.analysis.v1"
+    },
+    "reportSummary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "language",
+        "verdictKey",
+        "textSource",
+        "confirmedInitialPayloadKbSaved",
+        "directionalOpportunityKb",
+        "estimatedLcpImprovementMs",
+        "topActions",
+        "groupSummaries"
+      ],
+      "properties": {
+        "language": {
+          "type": "string",
+          "enum": [
+            "ko",
+            "en"
+          ]
+        },
+        "verdictKey": {
+          "type": "string"
+        },
+        "textSource": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "titleKey",
+            "bodyKey"
+          ],
+          "properties": {
+            "titleKey": {
+              "type": "string"
+            },
+            "bodyKey": {
+              "type": "string"
+            }
+          }
+        },
+        "confirmedInitialPayloadKbSaved": {
+          "type": "integer"
+        },
+        "directionalOpportunityKb": {
+          "type": "integer"
+        },
+        "estimatedLcpImprovementMs": {
+          "type": "integer"
+        },
+        "topActions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "actionPriority",
+              "findingId",
+              "estimatedSavingsKb",
+              "confidence",
+              "difficulty"
+            ],
+            "properties": {
+              "actionPriority": {
+                "type": "integer"
+              },
+              "findingId": {
+                "type": "string"
+              },
+              "estimatedSavingsKb": {
+                "type": "integer"
+              },
+              "confidence": {
+                "type": "string"
+              },
+              "difficulty": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "groupSummaries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "key",
+              "findingCount",
+              "confirmedInitialPayloadKbSaved",
+              "directionalOpportunityKb"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "findingCount": {
+                "type": "integer"
+              },
+              "confirmedInitialPayloadKbSaved": {
+                "type": "integer"
+              },
+              "directionalOpportunityKb": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
     },
     "projectRoot": {
       "type": "string"

--- a/docs/schema/budget.v1.schema.json
+++ b/docs/schema/budget.v1.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "required": [
     "schemaVersion",
+    "reportSummary",
     "overallStatus",
     "rules"
   ],
@@ -13,6 +14,115 @@
     "schemaVersion": {
       "type": "string",
       "const": "legolas.budget.v1"
+    },
+    "reportSummary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "language",
+        "verdictKey",
+        "textSource",
+        "confirmedInitialPayloadKbSaved",
+        "directionalOpportunityKb",
+        "estimatedLcpImprovementMs",
+        "topActions",
+        "groupSummaries"
+      ],
+      "properties": {
+        "language": {
+          "type": "string",
+          "enum": [
+            "ko",
+            "en"
+          ]
+        },
+        "verdictKey": {
+          "type": "string"
+        },
+        "textSource": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "titleKey",
+            "bodyKey"
+          ],
+          "properties": {
+            "titleKey": {
+              "type": "string"
+            },
+            "bodyKey": {
+              "type": "string"
+            }
+          }
+        },
+        "confirmedInitialPayloadKbSaved": {
+          "type": "integer"
+        },
+        "directionalOpportunityKb": {
+          "type": "integer"
+        },
+        "estimatedLcpImprovementMs": {
+          "type": "integer"
+        },
+        "topActions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "actionPriority",
+              "findingId",
+              "estimatedSavingsKb",
+              "confidence",
+              "difficulty"
+            ],
+            "properties": {
+              "actionPriority": {
+                "type": "integer"
+              },
+              "findingId": {
+                "type": "string"
+              },
+              "estimatedSavingsKb": {
+                "type": "integer"
+              },
+              "confidence": {
+                "type": "string"
+              },
+              "difficulty": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "groupSummaries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "key",
+              "findingCount",
+              "confirmedInitialPayloadKbSaved",
+              "directionalOpportunityKb"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "findingCount": {
+                "type": "integer"
+              },
+              "confirmedInitialPayloadKbSaved": {
+                "type": "integer"
+              },
+              "directionalOpportunityKb": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
     },
     "overallStatus": {
       "type": "string",

--- a/docs/schema/ci.v1.schema.json
+++ b/docs/schema/ci.v1.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "required": [
     "schemaVersion",
+    "reportSummary",
     "passed",
     "overallStatus",
     "rules"
@@ -14,6 +15,115 @@
     "schemaVersion": {
       "type": "string",
       "const": "legolas.ci.v1"
+    },
+    "reportSummary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "language",
+        "verdictKey",
+        "textSource",
+        "confirmedInitialPayloadKbSaved",
+        "directionalOpportunityKb",
+        "estimatedLcpImprovementMs",
+        "topActions",
+        "groupSummaries"
+      ],
+      "properties": {
+        "language": {
+          "type": "string",
+          "enum": [
+            "ko",
+            "en"
+          ]
+        },
+        "verdictKey": {
+          "type": "string"
+        },
+        "textSource": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "titleKey",
+            "bodyKey"
+          ],
+          "properties": {
+            "titleKey": {
+              "type": "string"
+            },
+            "bodyKey": {
+              "type": "string"
+            }
+          }
+        },
+        "confirmedInitialPayloadKbSaved": {
+          "type": "integer"
+        },
+        "directionalOpportunityKb": {
+          "type": "integer"
+        },
+        "estimatedLcpImprovementMs": {
+          "type": "integer"
+        },
+        "topActions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "actionPriority",
+              "findingId",
+              "estimatedSavingsKb",
+              "confidence",
+              "difficulty"
+            ],
+            "properties": {
+              "actionPriority": {
+                "type": "integer"
+              },
+              "findingId": {
+                "type": "string"
+              },
+              "estimatedSavingsKb": {
+                "type": "integer"
+              },
+              "confidence": {
+                "type": "string"
+              },
+              "difficulty": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "groupSummaries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "key",
+              "findingCount",
+              "confirmedInitialPayloadKbSaved",
+              "directionalOpportunityKb"
+            ],
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "findingCount": {
+                "type": "integer"
+              },
+              "confirmedInitialPayloadKbSaved": {
+                "type": "integer"
+              },
+              "directionalOpportunityKb": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
     },
     "passed": {
       "type": "boolean"

--- a/docs/schema/sarif.v1.json
+++ b/docs/schema/sarif.v1.json
@@ -89,7 +89,8 @@
             "type": "object",
             "additionalProperties": false,
             "required": [
-              "command"
+              "command",
+              "reportSummary"
             ],
             "properties": {
               "command": {
@@ -98,6 +99,115 @@
                   "scan",
                   "ci"
                 ]
+              },
+              "reportSummary": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": [
+                  "language",
+                  "verdictKey",
+                  "textSource",
+                  "confirmedInitialPayloadKbSaved",
+                  "directionalOpportunityKb",
+                  "estimatedLcpImprovementMs",
+                  "topActions",
+                  "groupSummaries"
+                ],
+                "properties": {
+                  "language": {
+                    "type": "string",
+                    "enum": [
+                      "ko",
+                      "en"
+                    ]
+                  },
+                  "verdictKey": {
+                    "type": "string"
+                  },
+                  "textSource": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "titleKey",
+                      "bodyKey"
+                    ],
+                    "properties": {
+                      "titleKey": {
+                        "type": "string"
+                      },
+                      "bodyKey": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "confirmedInitialPayloadKbSaved": {
+                    "type": "integer"
+                  },
+                  "directionalOpportunityKb": {
+                    "type": "integer"
+                  },
+                  "estimatedLcpImprovementMs": {
+                    "type": "integer"
+                  },
+                  "topActions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "required": [
+                        "actionPriority",
+                        "findingId",
+                        "estimatedSavingsKb",
+                        "confidence",
+                        "difficulty"
+                      ],
+                      "properties": {
+                        "actionPriority": {
+                          "type": "integer"
+                        },
+                        "findingId": {
+                          "type": "string"
+                        },
+                        "estimatedSavingsKb": {
+                          "type": "integer"
+                        },
+                        "confidence": {
+                          "type": "string"
+                        },
+                        "difficulty": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "groupSummaries": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "key",
+                        "findingCount",
+                        "confirmedInitialPayloadKbSaved",
+                        "directionalOpportunityKb"
+                      ],
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "findingCount": {
+                          "type": "integer"
+                        },
+                        "confirmedInitialPayloadKbSaved": {
+                          "type": "integer"
+                        },
+                        "directionalOpportunityKb": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
               },
               "warnings": {
                 "type": "array",


### PR DESCRIPTION
## 배경

#81은 텍스트 리포트와 같은 판정 요약을 JSON/SARIF 사용자도 자동화에서 사용할 수 있게 만드는 작업입니다.

## 변경 사항

- `scan/optimize --json`, `budget --json`, `ci --json`에 `reportSummary`를 추가했습니다.
- `scan/ci --sarif`의 `runs[0].properties.reportSummary`를 추가했습니다.
- `reportSummary.language`가 `--lang ko|en`을 따르도록 했고, SARIF `message.text`/`shortDescription.text`는 언어별 human text를 사용하되 `ruleId`는 유지했습니다.
- analysis/budget/ci/SARIF schema가 `reportSummary`를 required contract로 검증하도록 갱신했습니다.
- schema/SARIF/JSON 계약 테스트와 negative schema test를 보강했습니다.

## 검증

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p legolas-cli --test json_schema_contract`
- `cargo test -p legolas-cli --test sarif_contract`
- `cargo test -p legolas-cli --test budget_contract`
- `cargo test -p legolas-cli --test ci_contract`
- `cargo test -p legolas-cli --test cli_contract`
- `cargo test -p legolas-cli --test config_contract`
- `cargo test -p legolas-cli --test baseline_contract`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## 리뷰 게이트

- Devil's Advocate Round 1: High 1건 수용 (`reportSummary` schema required 누락)
- 수정 후 Round 2 delta review: findings 없음, gate pass

## 브랜치 / 워크트리

- base: `origin/master`
- branch: `feature/81-report-summary-schema`
- worktree: `/tmp/legolas-issue-81`

Closes #81
