### PR TITLE
fix(core): scanner 스택 오버플로우 방지

### DIFF
--- a/crates/legolas-core/src/import_scanner.rs
+++ b/crates/legolas-core/src/import_scanner.rs
@@ -1808,8 +1808,27 @@ fn find_matching_open_delimiter_without_nested_lexing(
     let mut index = advance_one(contents, close_index);
 
     while let Some((candidate_index, character)) = contents[..index].char_indices().next_back() {
-        if matches!(character, '\'' | '"' | '`' | '/') {
-            return None;
+        if let Some(comment_start_index) =
+            find_reverse_skippable_comment_start(contents, candidate_index)
+        {
+            index = comment_start_index;
+            continue;
+        }
+
+        if character == '/' {
+            if let Some(regex_start_index) =
+                find_regex_literal_start_for_closing_slash(contents, candidate_index)
+            {
+                index = regex_start_index;
+                continue;
+            }
+        }
+
+        if matches!(character, '\'' | '"' | '`') {
+            let string_start_index =
+                find_reverse_quoted_string_start(contents, candidate_index, character)?;
+            index = string_start_index;
+            continue;
         }
 
         if character == close_character {
@@ -2044,6 +2063,175 @@ fn find_matching_open_delimiter(
     }
 
     None
+}
+
+fn find_reverse_quoted_string_start(
+    contents: &str,
+    closing_quote_index: usize,
+    quote: char,
+) -> Option<usize> {
+    let mut search_index = closing_quote_index;
+
+    while let Some((candidate_index, character)) =
+        contents[..search_index].char_indices().next_back()
+    {
+        if matches!(character, '\n' | '\r') && quote != '`' {
+            return None;
+        }
+
+        if character == quote && !is_escaped_at(contents, candidate_index) {
+            return Some(candidate_index);
+        }
+
+        search_index = candidate_index;
+    }
+
+    None
+}
+
+fn is_escaped_at(contents: &str, index: usize) -> bool {
+    let mut slash_count = 0usize;
+    let mut search_index = index;
+
+    while let Some((candidate_index, character)) =
+        contents[..search_index].char_indices().next_back()
+    {
+        if character != '\\' {
+            break;
+        }
+
+        slash_count += 1;
+        search_index = candidate_index;
+    }
+
+    slash_count % 2 == 1
+}
+
+fn find_reverse_skippable_comment_start(contents: &str, candidate_index: usize) -> Option<usize> {
+    if current_char(contents, candidate_index) == Some('/')
+        && previous_char(contents, candidate_index) == Some('*')
+    {
+        return contents[..candidate_index.saturating_sub(1)].rfind("/*");
+    }
+
+    find_line_comment_start(contents, candidate_index)
+}
+
+fn find_regex_literal_start_for_closing_slash(
+    contents: &str,
+    closing_slash_index: usize,
+) -> Option<usize> {
+    let flags_end_index = skip_regex_flags(contents, advance_one(contents, closing_slash_index))?;
+    if !regex_literal_has_valid_follow(contents, flags_end_index) {
+        return None;
+    }
+
+    let mut search_index = closing_slash_index;
+    while let Some((candidate_index, character)) =
+        contents[..search_index].char_indices().next_back()
+    {
+        if matches!(character, '\n' | '\r') {
+            return None;
+        }
+
+        if character != '/' {
+            search_index = candidate_index;
+            continue;
+        }
+
+        if peek_char(contents, candidate_index + 1).is_some_and(|next| matches!(next, '/' | '*')) {
+            search_index = candidate_index;
+            continue;
+        }
+
+        let Some(parsed_end_index) = skip_regex_literal(contents, candidate_index) else {
+            search_index = candidate_index;
+            continue;
+        };
+
+        if parsed_end_index == flags_end_index
+            && regex_literal_start_context_allows_fast_skip(contents, candidate_index)
+        {
+            return Some(candidate_index);
+        }
+
+        search_index = candidate_index;
+    }
+
+    None
+}
+
+fn skip_regex_flags(contents: &str, start_index: usize) -> Option<usize> {
+    let mut index = start_index;
+    let mut seen_flags = Vec::new();
+
+    while matches!(current_char(contents, index), Some(flag) if is_identifier_character(flag)) {
+        let flag = current_char(contents, index)?;
+        if !is_regex_flag(flag) || seen_flags.contains(&flag) {
+            return None;
+        }
+        seen_flags.push(flag);
+        index = advance_one(contents, index);
+    }
+
+    Some(index)
+}
+
+fn regex_literal_start_context_allows_fast_skip(contents: &str, start_index: usize) -> bool {
+    let Some(previous_index) = find_previous_significant_index(contents, start_index) else {
+        return true;
+    };
+    let Some(previous_character) = current_char(contents, previous_index) else {
+        return true;
+    };
+
+    if matches!(
+        previous_character,
+        '(' | '{'
+            | '['
+            | ','
+            | ';'
+            | ':'
+            | '?'
+            | '!'
+            | '~'
+            | '^'
+            | '&'
+            | '|'
+            | '='
+            | '+'
+            | '-'
+            | '*'
+            | '%'
+            | '<'
+            | '>'
+    ) {
+        return true;
+    }
+
+    if is_identifier_character(previous_character) {
+        return previous_identifier_token(contents, previous_index).is_some_and(|token| {
+            matches!(
+                token,
+                "await"
+                    | "case"
+                    | "do"
+                    | "delete"
+                    | "else"
+                    | "of"
+                    | "in"
+                    | "instanceof"
+                    | "new"
+                    | "return"
+                    | "throw"
+                    | "typeof"
+                    | "void"
+                    | "yield"
+            )
+        });
+    }
+
+    false
 }
 
 fn skip_regex_literal(contents: &str, start_index: usize) -> Option<usize> {

--- a/crates/legolas-core/tests/import_scanner_regressions.rs
+++ b/crates/legolas-core/tests/import_scanner_regressions.rs
@@ -245,6 +245,52 @@ fn scan_imports_ignores_import_like_text_inside_statement_regex_after_control_he
 }
 
 #[test]
+fn scan_imports_ignores_import_like_regex_after_regex_condition_with_escaped_parenthesis() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "if (/\\(/.test(value)) /import(\"chart.js\\/auto\")/.test(value);\n",
+    );
+
+    let files = collect_source_files(root).expect("collect regex condition false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan regex condition false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_ignores_import_like_regex_after_control_head_with_comment_parenthesis() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "if (ok /* ( */) /import(\"chart.js\\/auto\")/.test(value);\n",
+    );
+
+    let files =
+        collect_source_files(root).expect("collect comment parenthesis false-positive files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan comment parenthesis false-positive fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
 fn scan_imports_ignores_import_like_text_inside_statement_regex_after_block_boundaries() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();
@@ -637,6 +683,55 @@ fn scan_imports_preserves_dynamic_imports_after_url_template_strings_followed_by
             dynamic_files: vec!["src/App.tsx".to_string()],
         })
     );
+}
+
+#[test]
+fn scan_imports_handles_division_inside_template_interpolation_parenthesized_calls() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        concat!(
+            "export const format = (count: number): string => {\n",
+            "  return `${(Math.floor((count / 1000) * 10) / 10).toLocaleString()}천`;\n",
+            "};\n",
+        ),
+    );
+
+    let files = collect_source_files(root).expect("collect template interpolation division files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis =
+        scan_imports(root, &files).expect("scan template interpolation division fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
+}
+
+#[test]
+fn scan_imports_handles_division_after_string_inside_template_interpolation_parentheses() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_file(
+        root,
+        "src/App.tsx",
+        "export const value = `${(\"x\".length) / 10}`;\n",
+    );
+
+    let files = collect_source_files(root).expect("collect template string division files");
+
+    assert_eq!(to_posix_paths(root, &files), vec!["src/App.tsx"]);
+
+    let analysis = scan_imports(root, &files).expect("scan template string division fixture");
+
+    assert!(analysis.by_package.is_empty());
+    assert_eq!(analysis.dynamic_import_count, 0);
+    assert!(analysis.tree_shaking_warnings.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## 배경

`connect-web`에서 `npx @jeremyfellaz/legolas scan .` 실행 시 Rust scanner가 stack overflow로 abort 되는 문제가 있었습니다.

원인은 템플릿 문자열 보간 안의 산술식에서 `/`를 정규식 리터럴 후보로 판별하는 과정이 괄호 매칭 로직과 재귀적으로 맞물리는 경로였습니다.

## 변경 사항

- 역방향 괄호 매칭 fast path가 `/`를 만나도 무조건 full lexer fallback으로 들어가지 않도록 보강했습니다.
- regex literal span과 comment span은 비재귀적으로 건너뛰어, regex/comment 내부 괄호를 실제 구문 괄호로 세지 않게 했습니다.
- 문자열과 backtick span도 비재귀적으로 건너뛰어, 템플릿 보간 내부 문자열 뒤 division에서도 fallback 재귀가 발생하지 않게 했습니다.
- 다음 회귀 케이스를 추가했습니다.
  - 템플릿 보간 내부 parenthesized call + division
  - regex 조건식 내부 escaped parenthesis
  - control head 내부 block comment parenthesis
  - 템플릿 보간 내부 문자열 포함 괄호식 + division

## 검증

- `cargo fmt --all --check`
- `cargo test -p legolas-core --test import_scanner_regressions`
- `cargo test -p legolas-core --test import_scanner`
- `cargo run -p legolas-cli -- scan /Users/pjw/workspace/io/connect-web --json > /private/tmp/legolas-connect-web-scan.json`
  - `sourceSummary`: `filesScanned=806`, `importedPackages=50`, `dynamicImports=24`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`

## 리뷰 게이트

- `$devils-advocate-review-loop` Round 1: `Critical 0 / High 0 / Medium 1 / Low 0`
  - regex literal 내부 escaped parenthesis 오탐 지적 수용 및 수정
- `$devils-advocate-review-loop` Round 2: `Critical 0 / High 0 / Medium 1 / Low 0`
  - block comment 내부 parenthesis 오탐 지적 수용 및 수정
- `$devils-advocate-review-loop` Round 3: `Critical 0 / High 0 / Medium 0 / Low 0`
- `$independent-pr-review-comment` Pass 1: `Critical 0 / High 1 / Medium 0 / Low 0`
  - 템플릿 보간 내부 문자열 포함 괄호식 뒤 division stack overflow 지적 수용 및 수정

## 브랜치 / 워크트리

- base: `master`
- head: `feature/fix-scan-template-division-stack-overflow`
- worktree: `/Users/pjw/workspace/legolas`
