### PR TITLE
fix(core): duplicate 확정 절감 산식 보정

### DIFF
--- a/crates/legolas-cli/tests/text_report_parity.rs
+++ b/crates/legolas-cli/tests/text_report_parity.rs
@@ -422,11 +422,11 @@ fn scan_report_confirms_production_likely_duplicate_savings_without_other_findin
     let ko_report = format_scan_report_for_language(&analysis, ReportLanguage::Ko);
     let en_report = format_scan_report_for_language(&analysis, ReportLanguage::En);
 
-    assert!(ko_report.contains("확정 초기 페이로드 절감: 약 48 KB"));
-    assert!(!ko_report.contains("확정 초기 페이로드 절감: 미확정"));
+    assert!(ko_report.contains("확정 초기 페이로드 절감: 미확정"));
+    assert!(!ko_report.contains("확정 초기 페이로드 절감: 약 48 KB"));
     assert!(ko_report.contains("초기 페이로드 절감 후보"));
-    assert!(en_report.contains("Confirmed initial payload savings: ~48 KB"));
-    assert!(!en_report.contains("Confirmed initial payload savings: not confirmed"));
+    assert!(en_report.contains("Confirmed initial payload savings: not confirmed"));
+    assert!(!en_report.contains("Confirmed initial payload savings: ~48 KB"));
     assert!(en_report.contains("initial payload candidate"));
 }
 

--- a/crates/legolas-core/src/report_summary.rs
+++ b/crates/legolas-core/src/report_summary.rs
@@ -1,5 +1,6 @@
 use crate::{
     action_plan::rank_actions,
+    findings::FindingAnalysisSource,
     models::{
         Analysis, DuplicateImpactScope, ReportSummary, ReportSummaryAction,
         ReportSummaryGroupSummary, ReportSummaryTextSource,
@@ -53,7 +54,10 @@ fn build_group_summaries(analysis: &Analysis) -> Vec<ReportSummaryGroupSummary> 
     let production_duplicate_kb = analysis
         .duplicate_packages
         .iter()
-        .filter(|item| item.impact_scope == DuplicateImpactScope::ProductionLikely)
+        .filter(|item| {
+            item.impact_scope == DuplicateImpactScope::ProductionLikely
+                && confirms_initial_payload_savings(item.finding.analysis_source)
+        })
         .map(|item| item.estimated_extra_kb)
         .sum();
     let all_duplicate_kb = analysis
@@ -98,6 +102,17 @@ fn build_group_summaries(analysis: &Analysis) -> Vec<ReportSummaryGroupSummary> 
             tree_shaking_kb,
         ),
     ]
+}
+
+fn confirms_initial_payload_savings(analysis_source: Option<FindingAnalysisSource>) -> bool {
+    matches!(
+        analysis_source,
+        Some(
+            FindingAnalysisSource::SourceImport
+                | FindingAnalysisSource::Artifact
+                | FindingAnalysisSource::ArtifactSource
+        )
+    )
 }
 
 fn group_summary(

--- a/crates/legolas-core/tests/intelligence_impact.rs
+++ b/crates/legolas-core/tests/intelligence_impact.rs
@@ -167,7 +167,7 @@ fn estimate_impact_excludes_non_production_duplicate_savings_from_initial_payloa
 }
 
 #[test]
-fn report_summary_separates_confirmed_initial_payload_from_directional_duplicate_opportunity() {
+fn report_summary_excludes_lockfile_duplicates_from_confirmed_initial_payload() {
     let mut production_duplicate =
         duplicate_package_with_scope(50, DuplicateImpactScope::ProductionLikely);
     production_duplicate.finding = FindingMetadata::new(
@@ -197,18 +197,27 @@ fn report_summary_separates_confirmed_initial_payload_from_directional_duplicate
 
     let summary = build_report_summary(&analysis);
 
-    assert_eq!(summary.verdict_key, "targeted-impact");
+    assert_eq!(summary.verdict_key, "low-impact");
     assert_eq!(
         summary.text_source.title_key,
-        "report.summary.targeted-impact.title"
+        "report.summary.low-impact.title"
     );
-    assert_eq!(summary.confirmed_initial_payload_kb_saved, 50);
+    assert_eq!(summary.confirmed_initial_payload_kb_saved, 0);
     assert_eq!(summary.directional_opportunity_kb, 80);
-    assert_eq!(summary.estimated_lcp_improvement_ms, 105);
+    assert_eq!(summary.estimated_lcp_improvement_ms, 0);
     assert_eq!(summary.top_actions.len(), 2);
     assert_eq!(
         summary.top_actions[0].finding_id,
         "duplicate-package:prod-shared"
+    );
+    assert_eq!(
+        summary
+            .group_summaries
+            .iter()
+            .find(|group| group.key == "duplicate-packages")
+            .expect("duplicate group summary")
+            .confirmed_initial_payload_kb_saved,
+        0
     );
     assert_eq!(
         summary


### PR DESCRIPTION
## 배경

lockfile-only duplicate가 `confirmedInitialPayloadKbSaved`와 LCP 개선 추정에 포함되면 README가 설명하는 confirmed payload 계약과 실제 summary가 어긋납니다.

## 변경 사항

- `duplicate-packages` summary의 confirmed payload 합산을 source import 또는 artifact evidence가 있는 finding으로 제한했습니다.
- duplicate 전체 추정치는 `directionalOpportunityKb`에 계속 남도록 유지했습니다.
- core regression test와 CLI text parity 기대값을 새 summary 의미에 맞춰 갱신했습니다.

## 검증

- `cargo test -p legolas-core --test intelligence_impact`
- `cargo test -p legolas-cli --test json_schema_contract`
- `cargo test -p legolas-cli --test text_report_parity`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `$devils-advocate-review-loop`: Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- base: `master`
- branch: `fix/93-confirmed-payload-summary`
- worktree: `/private/tmp/legolas-wave1-20260505/issue-93-confirmed-payload-summary`

## 이슈 연결

Closes #93
