### PR TITLE
docs(readme): duplicate hygiene 설명 정렬

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -171,7 +171,7 @@ Heaviest known dependencies:
 - chart.js (160 KB) [high confidence]: Charting code is often only needed on a subset of screens. imported in 1 file(s).
 ```
 
-`Confirmed initial payload savings` sums only findings with source-import or artifact evidence for initial payload impact. `Directional cleanup opportunity` also includes dependency hygiene signals such as lockfile duplication. Development/test-only duplicates are presented as cleanup work, not as LCP improvement.
+`Confirmed initial payload savings` sums only findings with source-import or bundle-artifact evidence for initial payload impact. Lockfile-only duplication is not counted in that confirmed/LCP number; it is treated as a `Directional cleanup opportunity` dependency-hygiene signal. Development/test-only duplicates are also presented as dependency-hygiene cleanup work, not as LCP improvement.
 
 `optimize` turns findings into ranked actions:
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Top next actions:
 - chart.js (160 KB) [높음 신뢰도]: Charting code is often only needed on a subset of screens. 1개 파일에서 import됨.
 ```
 
-`확정 초기 페이로드 절감`은 소스 import나 산출물 증거로 초기 번들 영향이 확인된 항목만 합산합니다. `방향성 정리 여지`는 lockfile 중복 같은 dependency hygiene 신호까지 포함합니다. 개발/테스트 전용 중복은 LCP 개선치가 아니라 정리 후보로 표시됩니다.
+`확정 초기 페이로드 절감`은 소스 import 또는 번들 산출물 증거로 초기 페이로드 영향이 확인된 항목만 합산합니다. Lockfile-only 중복은 이 confirmed/LCP 수치에 포함하지 않고 `방향성 정리 여지`의 dependency hygiene 신호로만 다룹니다. 개발/테스트 전용 중복도 LCP 개선치가 아니라 dependency hygiene 정리 작업으로 표시됩니다.
 
 `optimize`는 발견 항목을 우선순위 작업으로 바꿉니다.
 


### PR DESCRIPTION
## 배경

#95 이후 duplicate 리포트 문구가 directional/hygiene 기준으로 보정되었으므로, README의 confirmed payload 설명도 같은 의미로 정렬합니다.

## 변경 사항

- `README.md`에서 확정 초기 페이로드 절감이 source import 또는 bundle artifact evidence 기반임을 명확히 했습니다.
- `README.en.md`에서 lockfile-only duplicate와 development/test-only duplicate를 confirmed/LCP savings가 아닌 directional cleanup / dependency hygiene로 설명했습니다.

## 검증

- `rg -n "Confirmed initial payload|확정 초기|avoidable|정리 가능" README.md README.en.md`
- `cargo test -p legolas-cli --test text_report_parity`
- `git diff --check`
- fresh-session Devil's Advocate review: Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- base: `master`
- head: `feature/96-readme-duplicate-hygiene`
- worktree: `/private/tmp/legolas-wave3-20260505/issue-96-readme-duplicate-hygiene`

## 이슈 연결

Closes #96
