### PR TITLE
docs: 보안 지원 정책 명확화

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,13 @@
 
 ## Supported Versions
 
-Legolas is in early development. Security fixes are applied to the latest
-version on the default branch.
+Until v1.0.0 is released, security fixes are applied to the latest npm release
+on npm's `latest` dist-tag and the default branch.
+
+After the v1.0.0 release, the supported line is the latest supported `1.x` npm
+release on npm's `latest` dist-tag and the default branch. Older pre-1.0
+releases are not backported unless a maintainer announces a specific exception
+in the release notes.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## 배경

v1.0.0 정식 출시 이후의 보안 지원 범위를 `SECURITY.md`에서 명확히 합니다.

## 변경 사항

- early-development 표현을 제거했습니다.
- v1.0.0 이후 지원 라인을 최신 지원 `1.x` npm release로 명시했습니다.
- pre-1.0 backport는 별도 release note 예외가 없는 한 지원하지 않는다고 명시했습니다.
- private vulnerability reporting flow는 유지했습니다.

## 검증

- `git diff --check`
- `$devils-advocate-review-loop` Round 1: Critical 0 / High 0 / Medium 0 / Low 1
- `$devils-advocate-review-loop` Round 2: Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- branch: `feature/v1-security-policy`
- worktree: `/Users/pjw/workspace/legolas/.worktrees/feature-v1-security-policy`

## 이슈 연결

Closes #105
Refs #102
