### PR TITLE
build: Rust crate publish 비활성화

### DIFF
--- a/crates/legolas-cli/Cargo.toml
+++ b/crates/legolas-cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "legolas-cli"
 version = "0.1.7"
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/legolas-core/Cargo.toml
+++ b/crates/legolas-core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "legolas-core"
 version = "0.1.0"
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## 배경

v1.0.0 npm 정식 출시에서 Rust workspace crate가 별도 crates.io 공개 API처럼 보이지 않도록 공개 정책을 manifest에 고정합니다.

## 변경 사항

- `legolas-cli` crate에 `publish = false`를 추가했습니다.
- `legolas-core` crate에 `publish = false`를 추가했습니다.
- version bump는 하지 않았습니다.

## 검증

- `cargo metadata --format-version 1`
- `cargo test --workspace`
- `git diff --check`
- `$devils-advocate-review-loop` Round 1: Critical 0 / High 0 / Medium 0 / Low 0

## 브랜치 / 워크트리

- branch: `feature/v1-rust-crate-publish-policy`
- worktree: `/Users/pjw/workspace/legolas/.worktrees/feature-v1-rust-crate-publish-policy`

## 이슈 연결

Closes #103
Refs #102
